### PR TITLE
Pass 401 exceptions through to the default error handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import { languageSwitcher } from './middleware/language-switcher';
 import { auth } from './routes/auth';
 import { healthcheck } from './routes/healthcheck';
 import { publish } from './routes/publish';
-import { view } from './routes/view';
+import { dataset } from './routes/dataset';
 import { errorHandler } from './routes/error-handler';
 import { homepage } from './routes/homepage';
 import { notFound } from './routes/not-found';
@@ -51,7 +51,7 @@ app.use('/assets', express.static(`${__dirname}/assets`));
 app.use('/healthcheck', rateLimiter, healthcheck);
 app.use('/:lang/auth', rateLimiter, auth);
 app.use('/:lang/publish', rateLimiter, ensureAuthenticated, publish);
-app.use('/:lang/dataset', rateLimiter, ensureAuthenticated, view);
+app.use('/:lang/dataset', rateLimiter, ensureAuthenticated, dataset);
 app.use('/:lang', rateLimiter, ensureAuthenticated, homepage);
 
 // handle 404s

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -11,7 +11,7 @@ import { AuthedRequest } from '../interfaces/authed-request';
 import { FileImportDTO } from '../dtos/dataset-dto';
 import { Locale } from '../enums/locale';
 
-export const view = Router();
+export const dataset = Router();
 
 const statsWalesApi = (req: AuthedRequest) => {
     const lang = req.language as Locale;
@@ -19,7 +19,7 @@ const statsWalesApi = (req: AuthedRequest) => {
     return new StatsWalesApi(lang, token);
 };
 
-view.get('/', async (req: AuthedRequest, res: Response, next: NextFunction) => {
+dataset.get('/', async (req: AuthedRequest, res: Response, next: NextFunction) => {
     try {
         const fileList: FileList = await statsWalesApi(req).getFileList();
         logger.debug(`FileList from server = ${JSON.stringify(fileList)}`);
@@ -29,7 +29,7 @@ view.get('/', async (req: AuthedRequest, res: Response, next: NextFunction) => {
     }
 });
 
-view.get('/:datasetId', async (req: AuthedRequest, res: Response) => {
+dataset.get('/:datasetId', async (req: AuthedRequest, res: Response) => {
     const datasetId = req.params.datasetId;
     const page: number = Number.parseInt(req.query.page_number as string, 10) || 1;
     const page_size: number = Number.parseInt(req.query.page_size as string, 10) || 100;
@@ -63,7 +63,7 @@ view.get('/:datasetId', async (req: AuthedRequest, res: Response) => {
     }
 });
 
-view.get('/:datasetId/import/:importId', async (req: AuthedRequest, res: Response) => {
+dataset.get('/:datasetId/import/:importId', async (req: AuthedRequest, res: Response) => {
     if (!validateUUID(req.params.datasetId)) {
         const err: ViewErrDTO = {
             success: false,

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -13,8 +13,8 @@ healthcheck.get('/', async (req: Request, res: Response, next: NextFunction) => 
 
     try {
         backend = await new StatsWalesApi(lang).ping();
-    } catch (error) {
-        logger.error('backend ping failed');
+    } catch (err: any) {
+        next(err);
     }
     res.json({ status: 200, lang: req.language, services: { backend } });
 });


### PR DESCRIPTION
There were a number of routes that do their own error handling so we need to check for 401 and then hand it off to the default error handler for the logout.