### PR TITLE
Fix issue submitting update frequency form

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -338,8 +338,8 @@ export const provideUpdateFrequency = async (req: Request, res: Response, next: 
     if (req.method === 'POST') {
         update_frequency = {
             is_updated: req.body.is_updated ? req.body.is_updated === 'true' : undefined,
-            frequency_unit: req.body.is_updated ? req.body.frequency_unit : undefined,
-            frequency_value: req.body.is_updated ? req.body.frequency_value : undefined
+            frequency_unit: req.body.is_updated === 'true' ? req.body.frequency_unit : undefined,
+            frequency_value: req.body.is_updated === 'true' ? req.body.frequency_value : undefined
         };
 
         try {
@@ -351,6 +351,14 @@ export const provideUpdateFrequency = async (req: Request, res: Response, next: 
                     throw error;
                 }
             }
+
+            const { is_updated, frequency_unit, frequency_value } = matchedData(req);
+
+            update_frequency = {
+                is_updated,
+                frequency_unit: is_updated ? frequency_unit : undefined,
+                frequency_value: is_updated ? frequency_value : undefined
+            };
 
             await req.swapi.updateDatasetInfo(dataset.id, { update_frequency, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -21,9 +21,9 @@ export const roundingAppliedValidator = () => body('rounding_applied').notEmpty(
 export const roundingDescriptionValidator = () =>
     body('rounding_description').if(body('rounding_applied').equals('true')).trim().notEmpty();
 
-export const isUpdatedValidator = () => body('is_updated').notEmpty().isBoolean();
+export const isUpdatedValidator = () => body('is_updated').notEmpty().isBoolean().toBoolean();
 export const frequencyValueValidator = () =>
-    body('frequency_value').if(body('is_updated').equals('true')).notEmpty().isInt();
+    body('frequency_value').if(body('is_updated').equals('true')).notEmpty().isInt().toInt(10);
 export const frequencyUnitValidator = () =>
     body('frequency_unit').if(body('is_updated').equals('true')).isIn(Object.values(DurationUnit));
 


### PR DESCRIPTION
In a recent backend PR I made the validation of dataset info DTO stronger, which in turn broke the submission of the update frequency form - it was an number vs number string (`1` vs `'1'`) issue.

Fixed it by sending the validated and sanitized value rather than the form body.