### PR TITLE
Implement measures and preview

### DIFF
--- a/src/@types/express-session/index.d.ts
+++ b/src/@types/express-session/index.d.ts
@@ -1,10 +1,10 @@
 import 'express-session';
-import { DimensionPatchDto } from '../../dtos/dimension-patch-dto';
+import { DimensionPatchDTO } from '../../dtos/dimension-patch-dto';
 import { ViewError } from '../../dtos/view-error';
 
 declare module 'express-session' {
     interface SessionData {
         errors: ViewError[] | undefined;
-        dimensionPatch: DimensionPatchDto | undefined;
+        dimensionPatch: DimensionPatchDTO | undefined;
     }
 }

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -395,9 +395,9 @@ export const measurePreview = async (req: Request, res: Response, next: NextFunc
                 const error = err as ApiException;
                 logger.debug(`Error is: ${JSON.stringify(error, null, 2)}`);
                 if (error.status === 400) {
-                    res.status(400);
                     logger.error('Measure lookup table did not match data in the fact table.', err);
                     const failurePreview = JSON.parse(error.body as string) as ViewErrDTO;
+                    res.status(400);
                     res.render('publish/measure-match-failure', {
                         ...failurePreview,
                         measure

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -37,7 +37,7 @@ import { ViewError } from '../dtos/view-error';
 import { logger } from '../utils/logger';
 import { ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { SourceType } from '../enums/source-type';
-import { FactTableInfoDto } from '../dtos/fact-table-info';
+import { FactTableInfoDTO } from '../dtos/fact-table-info';
 import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
 import { UnknownException } from '../exceptions/unknown.exception';
 import { TaskListState } from '../dtos/task-list-state';
@@ -59,7 +59,7 @@ import { nestTopics } from '../utils/nested-topics';
 import { OrganisationDTO } from '../dtos/organisation';
 import { TeamDTO } from '../dtos/team';
 import { DimensionType } from '../enums/dimension-type';
-import { DimensionPatchDto } from '../dtos/dimension-patch-dto';
+import { DimensionPatchDTO } from '../dtos/dimension-patch-dto';
 import { ApiException } from '../exceptions/api.exception';
 import { DimensionInfoDTO } from '../dtos/dimension-info';
 import { YearType } from '../enums/year-type';
@@ -152,7 +152,7 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
 
     // if sources have previously been assigned a type, this is a revisit
     const revisit =
-        factTable.fact_table_info?.filter((factTableInfo: FactTableInfoDto) => Boolean(factTableInfo.column_type))
+        factTable.fact_table_info?.filter((factTableInfo: FactTableInfoDTO) => Boolean(factTableInfo.column_type))
             .length > 0;
 
     if (req.method === 'POST') {
@@ -193,7 +193,7 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
 export const sources = async (req: Request, res: Response, next: NextFunction) => {
     const { dataset, revision, factTable } = res.locals;
     const revisit =
-        factTable.fact_table_info?.filter((factTableInfo: FactTableInfoDto) => Boolean(factTableInfo.column_type))
+        factTable.fact_table_info?.filter((factTableInfo: FactTableInfoDTO) => Boolean(factTableInfo.column_type))
             .length > 0;
     let error: ViewError | undefined;
     let errors: ViewError[] | undefined;
@@ -208,7 +208,7 @@ export const sources = async (req: Request, res: Response, next: NextFunction) =
         if (req.method === 'POST') {
             const counts = { unknown: 0, dataValues: 0, footnotes: 0, measure: 0 };
             const sourceAssignment: SourceAssignmentDTO[] = factTable.fact_table_info.map(
-                (factTableInfo: FactTableInfoDto) => {
+                (factTableInfo: FactTableInfoDTO) => {
                     const sourceType = req.body[`column-${factTableInfo.column_index}`];
                     if (sourceType === SourceType.Unknown) counts.unknown++;
                     if (sourceType === SourceType.DataValues) counts.dataValues++;
@@ -453,10 +453,10 @@ export const measureReview = async (req: Request, res: Response, next: NextFunct
         if (req.method === 'POST') {
             logger.debug(`User has reviewed measure lookup table.`);
             switch (req.body.confirm) {
-                case 'true':
+                case 'continue':
                     res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
                     break;
-                case 'goback':
+                case 'cancel':
                     try {
                         await req.swapi.resetMeasure(dataset.id);
                         res.redirect(req.buildUrl(`/publish/${dataset.id}/measure`, req.language));
@@ -486,10 +486,8 @@ export const measureReview = async (req: Request, res: Response, next: NextFunct
         const dataPreview = await req.swapi.getMeasurePreview(res.locals.dataset.id);
         if (errors) {
             res.status(errors.status || 500);
-            res.render('publish/measure-review', { ...dataPreview, measure, review: true, errors });
-        } else {
-            res.render('publish/measure-review', { ...dataPreview, measure, review: true });
         }
+        res.render('publish/measure-review', { ...dataPreview, measure, review: true, errors });
     } catch (err) {
         logger.error('Failed to get dimension preview', err);
         next(new NotFoundException());
@@ -1181,7 +1179,7 @@ export const pointInTimeChooser = async (req: Request, res: Response, next: Next
     }
 
     if (req.method === 'POST') {
-        const patchRequest: DimensionPatchDto = {
+        const patchRequest: DimensionPatchDTO = {
             date_format: req.body.dateFormat,
             dimension_type: DimensionType.TimePoint,
             date_type: YearType.PointInTime

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -7,8 +7,6 @@ import { nanoid } from 'nanoid';
 import { v4 as uuid } from 'uuid';
 import { isBefore, isValid, parseISO } from 'date-fns';
 import { parse } from 'csv-parse';
-import detectCharacterEncoding from 'detect-character-encoding';
-import iconv from 'iconv-lite';
 
 import {
     collectionValidator,
@@ -68,20 +66,6 @@ import { YearType } from '../enums/year-type';
 import { addEditLinks } from '../utils/add-edit-links';
 import { TranslationDTO } from '../dtos/translations';
 
-function convertBufferToUTF8(buffer: Buffer): Buffer {
-    const fileEncoding = detectCharacterEncoding(buffer)?.encoding;
-    if (fileEncoding !== 'utf-8') {
-        logger.warn('File is not UTF-8 encoded... Going to try to recode it');
-        if (!fileEncoding) {
-            logger.warn('Could not detect file encoding for the file');
-            throw new Error('errors.csv.invalid');
-        }
-        const decodedString = iconv.decode(buffer, fileEncoding);
-        return iconv.encode(decodedString, 'utf-8');
-    }
-    return buffer;
-}
-
 export const start = (req: Request, res: Response, next: NextFunction) => {
     res.render('publish/start');
 };
@@ -139,7 +123,7 @@ export const uploadFile = async (req: Request, res: Response, next: NextFunction
             }
             const fileName = req.file.originalname;
             req.file.mimetype = fileMimeTypeHandler(req.file.mimetype, req.file.originalname);
-            const fileData = new Blob([convertBufferToUTF8(req.file.buffer)], { type: req.file.mimetype });
+            const fileData = new Blob([req.file.buffer], { type: req.file.mimetype });
             logger.debug('Sending file to backend.');
             await req.swapi.uploadCSVToDataset(dataset.id, fileData, fileName);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/preview`, req.language));
@@ -295,8 +279,221 @@ export const taskList = async (req: Request, res: Response, next: NextFunction) 
     }
 };
 
+export const cubePreview = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = res.locals.revision;
+    let errors: ViewError[] | undefined;
+    let previewData: ViewDTO | undefined;
+    let pagination: (string | number)[] = [];
+
+    if (!dataset || !revision) {
+        logger.error('Dataset or Revision not found');
+        next(new UnknownException('errors.preview.revision_not_found'));
+        return;
+    }
+
+    try {
+        const pageNumber = Number.parseInt(req.query.page_number as string, 10) || 1;
+        const pageSize = Number.parseInt(req.query.page_size as string, 10) || 10;
+        previewData = await req.swapi.getRevisionPreview(dataset.id, revision.id, pageNumber, pageSize);
+        if (!previewData) {
+            throw new Error('No preview data found.');
+        }
+        pagination = generateSequenceForNumber(previewData.current_page, previewData.total_pages);
+    } catch (err: any) {
+        res.status(400);
+        errors = [{ field: 'preview', message: { key: 'errors.preview.failed_to_get_preview' } }];
+    }
+    res.render('publish/cube-preview', { ...previewData, dataset, pagination, errors });
+};
+
+export const downloadAsCSV = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = res.locals.revision;
+    const fileStream = await req.swapi.getRevisionCubeCSV(dataset.id, revision.id);
+    res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'text/csv; charset=utf-8',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-disposition': `attachment;filename=${revision.id}.csv`
+    });
+    const readable: Readable = Readable.from(fileStream);
+    readable.pipe(res);
+};
+
+export const downloadAsParquet = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = res.locals.revision;
+    const fileStream = await req.swapi.getRevisionCubeParquet(dataset.id, revision.id);
+    res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/vnd.apache.parquet',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-disposition': `attachment;filename=${revision.id}.parquet`
+    });
+    const readable: Readable = Readable.from(fileStream);
+    readable.pipe(res);
+};
+
+export const downloadAsExcel = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = res.locals.revision;
+    const fileStream = await req.swapi.getRevisionCubeExcel(dataset.id, revision.id);
+    res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/vnd.ms-excel',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-disposition': `attachment;filename=${revision.id}.xlsx`
+    });
+    const readable: Readable = Readable.from(fileStream);
+    readable.pipe(res);
+};
+
+export const downloadAsDuckDb = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = res.locals.revision;
+    const fileStream = await req.swapi.getRevisionCube(dataset.id, revision.id);
+    res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/octet-stream',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-disposition': `attachment;filename=${revision.id}.duckdb`
+    });
+    const readable: Readable = Readable.from(fileStream);
+    readable.pipe(res);
+};
+
 export const redirectToTasklist = (req: Request, res: Response) => {
     res.redirect(req.buildUrl(`/publish/${req.params.datasetId}/tasklist`, req.language));
+};
+
+export const measurePreview = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dataset = singleLangDataset(res.locals.dataset, req.language);
+        const measure = singleLangDataset(res.locals.dataset, req.language).measure;
+        if (!measure) {
+            logger.error('Measure not defined for this dataset');
+            next(new UnknownException('errors.preview.measure_not_found'));
+            return;
+        }
+
+        if (req.method === 'POST') {
+            logger.debug('User is uploading a measure lookup table..');
+            try {
+                if (!req.file) {
+                    logger.error('No file is present in the request');
+                    throw new Error('errors.csv.invalid');
+                }
+                const fileName = req.file.originalname;
+                req.file.mimetype = fileMimeTypeHandler(req.file.mimetype, req.file.originalname);
+                const fileData = new Blob([req.file.buffer], { type: req.file.mimetype });
+                logger.debug('Sending file to backend.');
+                await req.swapi.uploadMeasureLookup(dataset.id, fileData, fileName);
+                res.redirect(req.buildUrl(`/publish/${dataset.id}/measure/review`, req.language));
+                return;
+            } catch (err) {
+                const error = err as ApiException;
+                logger.debug(`Error is: ${JSON.stringify(error, null, 2)}`);
+                if (error.status === 400) {
+                    res.status(400);
+                    logger.error('Measure lookup table did not match data in the fact table.', err);
+                    const failurePreview = JSON.parse(error.body as string) as ViewErrDTO;
+                    res.render('publish/measure-match-failure', {
+                        ...failurePreview,
+                        measure
+                    });
+                    return;
+                }
+                logger.error('Something went wrong other than not matching');
+                logger.debug(`Full error JSON: ${JSON.stringify(error, null, 2)}`);
+                req.session.errors = [
+                    {
+                        field: 'unknown',
+                        message: {
+                            key: 'errors.csv.unknown'
+                        }
+                    }
+                ];
+                res.redirect(req.buildUrl(`/publish/${dataset.id}/measure`, req.language));
+                return;
+            }
+        }
+
+        const dataPreview = await req.swapi.getMeasurePreview(res.locals.dataset.id);
+        if (req.session.errors) {
+            const errors = req.session.errors;
+            req.session.errors = undefined;
+            req.session.save();
+            res.status(500);
+            res.render('publish/measure-preview', {
+                ...dataPreview,
+                measure,
+                errors
+            });
+        } else {
+            res.render('publish/measure-preview', { ...dataPreview, measure });
+        }
+    } catch (err) {
+        logger.error('Failed to get dimension preview', err);
+        next(new NotFoundException());
+    }
+};
+
+export const measureReview = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dataset = singleLangDataset(res.locals.dataset, req.language);
+        const measure = dataset.measure;
+        if (!measure) {
+            logger.error('Failed to find measure in dataset');
+            next(new NotFoundException());
+            return;
+        }
+        let errors: ViewErrDTO | undefined;
+
+        if (req.method === 'POST') {
+            logger.debug(`User has reviewed measure lookup table.`);
+            switch (req.body.confirm) {
+                case 'true':
+                    res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
+                    break;
+                case 'goback':
+                    try {
+                        await req.swapi.resetMeasure(dataset.id);
+                        res.redirect(req.buildUrl(`/publish/${dataset.id}/measure`, req.language));
+                    } catch (err) {
+                        const error = err as ApiException;
+                        logger.error(
+                            `Something went wrong trying to reset the dimension with the following error: ${err}`
+                        );
+                        errors = {
+                            status: error.status || 500,
+                            errors: [
+                                {
+                                    field: '',
+                                    message: {
+                                        key: 'errors.dimension_reset'
+                                    }
+                                }
+                            ],
+                            dataset_id: req.params.datasetId
+                        } as ViewErrDTO;
+                    }
+                    break;
+            }
+            return;
+        }
+
+        const dataPreview = await req.swapi.getMeasurePreview(res.locals.dataset.id);
+        if (errors) {
+            res.status(errors.status || 500);
+            res.render('publish/measure-review', { ...dataPreview, measure, review: true, errors });
+        } else {
+            res.render('publish/measure-review', { ...dataPreview, measure, review: true });
+        }
+    } catch (err) {
+        logger.error('Failed to get dimension preview', err);
+        next(new NotFoundException());
+    }
 };
 
 export const uploadLookupTable = async (req: Request, res: Response, next: NextFunction) => {
@@ -321,7 +518,7 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
             }
             const fileName = req.file.originalname;
             req.file.mimetype = fileMimeTypeHandler(req.file.mimetype, req.file.originalname);
-            const fileData = new Blob([convertBufferToUTF8(req.file.buffer)], { type: req.file.mimetype });
+            const fileData = new Blob([req.file.buffer], { type: req.file.mimetype });
             try {
                 logger.debug('Sending lookup table to backend');
                 await req.swapi.uploadLookupTable(dataset.id, dimension.id, fileData, fileName);

--- a/src/dtos/dataset.ts
+++ b/src/dtos/dataset.ts
@@ -3,6 +3,8 @@ import { RevisionDTO } from './revision';
 import { DatasetInfoDTO } from './dataset-info';
 import { DatasetProviderDTO } from './dataset-provider';
 import { DatasetTopicDTO } from './dataset-topic';
+import { Measure } from './measure';
+import { TeamDTO } from './team';
 
 export interface DatasetDTO {
     id: string;
@@ -10,10 +12,13 @@ export interface DatasetDTO {
     created_by: string;
     live?: string;
     archive?: string;
+    measure?: Measure;
     dimensions?: DimensionDTO[];
     revisions: RevisionDTO[];
     datasetInfo?: DatasetInfoDTO[];
     providers?: DatasetProviderDTO[];
     topics?: DatasetTopicDTO[];
-    team_id?: string;
+    team?: TeamDTO[];
+    start_date?: string;
+    end_date?: string;
 }

--- a/src/dtos/dataset.ts
+++ b/src/dtos/dataset.ts
@@ -3,7 +3,7 @@ import { RevisionDTO } from './revision';
 import { DatasetInfoDTO } from './dataset-info';
 import { DatasetProviderDTO } from './dataset-provider';
 import { DatasetTopicDTO } from './dataset-topic';
-import { Measure } from './measure';
+import { MeasureDTO } from './measure';
 import { TeamDTO } from './team';
 
 export interface DatasetDTO {
@@ -12,7 +12,7 @@ export interface DatasetDTO {
     created_by: string;
     live?: string;
     archive?: string;
-    measure?: Measure;
+    measure?: MeasureDTO;
     dimensions?: DimensionDTO[];
     revisions: RevisionDTO[];
     datasetInfo?: DatasetInfoDTO[];

--- a/src/dtos/dimension-patch-dto.ts
+++ b/src/dtos/dimension-patch-dto.ts
@@ -1,7 +1,7 @@
 import { DimensionType } from '../enums/dimension-type';
 import { YearType } from '../enums/year-type';
 
-export interface DimensionPatchDto {
+export interface DimensionPatchDTO {
     dimension_type: DimensionType;
     dimension_title?: string;
     lookup_join_column?: string;

--- a/src/dtos/dimension.ts
+++ b/src/dtos/dimension.ts
@@ -1,5 +1,5 @@
 import { DimensionInfoDTO } from './dimension-info';
-import { LookupTable } from './lookup-table';
+import { LookupTableDTO } from './lookup-table';
 
 export interface DimensionDTO {
     id: string;
@@ -9,6 +9,6 @@ export interface DimensionDTO {
     joinColumn?: string; // <-- Tells you have to join the dimension to the fact_table
     factTableColumn: string; // <-- Tells you which column in the fact table you're joining to
     isSliceDimension: boolean;
-    lookupTable?: LookupTable;
+    lookupTable?: LookupTableDTO;
     dimensionInfo?: DimensionInfoDTO[];
 }

--- a/src/dtos/dimension.ts
+++ b/src/dtos/dimension.ts
@@ -1,5 +1,5 @@
 import { DimensionInfoDTO } from './dimension-info';
-import { LookupTableDTO } from './lookup-table';
+import { LookupTable } from './lookup-table';
 
 export interface DimensionDTO {
     id: string;
@@ -9,6 +9,6 @@ export interface DimensionDTO {
     joinColumn?: string; // <-- Tells you have to join the dimension to the fact_table
     factTableColumn: string; // <-- Tells you which column in the fact table you're joining to
     isSliceDimension: boolean;
-    lookupTable?: LookupTableDTO;
+    lookupTable?: LookupTable;
     dimensionInfo?: DimensionInfoDTO[];
 }

--- a/src/dtos/fact-table-info.ts
+++ b/src/dtos/fact-table-info.ts
@@ -1,4 +1,4 @@
-export interface FactTableInfoDto {
+export interface FactTableInfoDTO {
     column_name: string;
     column_index: number;
     column_type: string;

--- a/src/dtos/fact-table.ts
+++ b/src/dtos/fact-table.ts
@@ -1,6 +1,6 @@
-import { FactTableInfoDto } from './fact-table-info';
+import { FactTableInfoDTO } from './fact-table-info';
 
-export interface FactTableDto {
+export interface FactTableDTO {
     id: string;
     revision_id: string;
     mime_type: string;
@@ -12,5 +12,5 @@ export interface FactTableDto {
     delimiter?: string;
     quote?: string;
     linebreak?: string;
-    fact_table_info: FactTableInfoDto[];
+    fact_table_info: FactTableInfoDTO[];
 }

--- a/src/dtos/lookup-table.ts
+++ b/src/dtos/lookup-table.ts
@@ -1,4 +1,4 @@
-export class LookupTable {
+export class LookupTableDTO {
     id: string;
     dimension_id?: string;
     measure_id?: string;

--- a/src/dtos/lookup-table.ts
+++ b/src/dtos/lookup-table.ts
@@ -1,4 +1,4 @@
-export class LookupTableDTO {
+export class LookupTable {
     id: string;
     dimension_id?: string;
     measure_id?: string;

--- a/src/dtos/measure-info.ts
+++ b/src/dtos/measure-info.ts
@@ -1,4 +1,4 @@
-export class MeasureInfo {
+export class MeasureInfoDTO {
     measure_id: string;
     language: string;
     reference_id: string;

--- a/src/dtos/measure-info.ts
+++ b/src/dtos/measure-info.ts
@@ -1,0 +1,9 @@
+export class MeasureInfo {
+    measure_id: string;
+    language: string;
+    reference_id: string;
+    sort_order: number;
+    description: string;
+    notes: string;
+    display_type: string;
+}

--- a/src/dtos/measure.ts
+++ b/src/dtos/measure.ts
@@ -1,11 +1,11 @@
-import { LookupTable } from './lookup-table';
-import { MeasureInfo } from './measure-info';
+import { LookupTableDTO } from './lookup-table';
+import { MeasureInfoDTO } from './measure-info';
 
-export class Measure {
+export class MeasureDTO {
     id: string;
     dataset_id: string;
     fact_table_column: string;
     join_column: string | null;
-    lookup_table?: LookupTable;
-    measure_info: MeasureInfo[] | undefined;
+    lookup_table?: LookupTableDTO;
+    measure_info: MeasureInfoDTO[] | undefined;
 }

--- a/src/dtos/measure.ts
+++ b/src/dtos/measure.ts
@@ -1,0 +1,11 @@
+import { LookupTable } from './lookup-table';
+import { MeasureInfo } from './measure-info';
+
+export class Measure {
+    id: string;
+    dataset_id: string;
+    fact_table_column: string;
+    join_column: string | null;
+    lookup_table?: LookupTable;
+    measure_info: MeasureInfo[] | undefined;
+}

--- a/src/dtos/revision.ts
+++ b/src/dtos/revision.ts
@@ -1,4 +1,4 @@
-import { FactTableDto } from './fact-table';
+import { FactTableDTO } from './fact-table';
 
 export interface RevisionDTO {
     id: string;
@@ -10,6 +10,6 @@ export interface RevisionDTO {
     approved_at?: string;
     approved_by?: string;
     created_by: string;
-    fact_tables: FactTableDto[];
+    fact_tables: FactTableDTO[];
     dataset_id?: string;
 }

--- a/src/dtos/single-language/dataset.ts
+++ b/src/dtos/single-language/dataset.ts
@@ -2,6 +2,8 @@ import { RevisionDTO } from '../revision';
 import { DatasetInfoDTO } from '../dataset-info';
 import { DatasetProviderDTO } from '../dataset-provider';
 import { DatasetTopicDTO } from '../dataset-topic';
+import { Measure } from '../measure';
+import { TeamDTO } from '../team';
 
 import { SingleLanguageDimension } from './dimension';
 
@@ -11,9 +13,13 @@ export interface SingleLanguageDataset {
     created_by: string;
     live?: string;
     archive?: string;
+    measure?: Measure;
     dimensions?: SingleLanguageDimension[];
     revisions: RevisionDTO[];
     datasetInfo?: DatasetInfoDTO;
     providers?: DatasetProviderDTO[];
     topics?: DatasetTopicDTO[];
+    team?: TeamDTO;
+    start_date?: string;
+    end_date?: string;
 }

--- a/src/dtos/single-language/dataset.ts
+++ b/src/dtos/single-language/dataset.ts
@@ -2,7 +2,7 @@ import { RevisionDTO } from '../revision';
 import { DatasetInfoDTO } from '../dataset-info';
 import { DatasetProviderDTO } from '../dataset-provider';
 import { DatasetTopicDTO } from '../dataset-topic';
-import { Measure } from '../measure';
+import { MeasureDTO } from '../measure';
 import { TeamDTO } from '../team';
 
 import { SingleLanguageDimension } from './dimension';
@@ -13,7 +13,7 @@ export interface SingleLanguageDataset {
     created_by: string;
     live?: string;
     archive?: string;
-    measure?: Measure;
+    measure?: MeasureDTO;
     dimensions?: SingleLanguageDimension[];
     revisions: RevisionDTO[];
     datasetInfo?: DatasetInfoDTO;

--- a/src/dtos/single-language/dimension.ts
+++ b/src/dtos/single-language/dimension.ts
@@ -1,5 +1,5 @@
 import { DimensionInfoDTO } from '../dimension-info';
-import { LookupTable } from '../lookup-table';
+import { LookupTableDTO } from '../lookup-table';
 
 export interface SingleLanguageDimension {
     id: string;
@@ -9,6 +9,6 @@ export interface SingleLanguageDimension {
     joinColumn?: string; // <-- Tells you have to join the dimension to the fact_table
     factTableColumn: string; // <-- Tells you which column in the fact table you're joining to
     isSliceDimension: boolean;
-    lookupTable?: LookupTable;
+    lookupTable?: LookupTableDTO;
     dimensionInfo?: DimensionInfoDTO;
 }

--- a/src/dtos/single-language/dimension.ts
+++ b/src/dtos/single-language/dimension.ts
@@ -1,5 +1,5 @@
 import { DimensionInfoDTO } from '../dimension-info';
-import { LookupTableDTO } from '../lookup-table';
+import { LookupTable } from '../lookup-table';
 
 export interface SingleLanguageDimension {
     id: string;
@@ -9,6 +9,6 @@ export interface SingleLanguageDimension {
     joinColumn?: string; // <-- Tells you have to join the dimension to the fact_table
     factTableColumn: string; // <-- Tells you which column in the fact table you're joining to
     isSliceDimension: boolean;
-    lookupTable?: LookupTableDTO;
+    lookupTable?: LookupTable;
     dimensionInfo?: DimensionInfoDTO;
 }

--- a/src/dtos/team.ts
+++ b/src/dtos/team.ts
@@ -7,4 +7,5 @@ export class TeamDTO {
     email?: string;
     organisation_id?: string;
     organisation?: OrganisationDTO;
+    language?: string;
 }

--- a/src/dtos/view-dto.ts
+++ b/src/dtos/view-dto.ts
@@ -2,7 +2,7 @@ import { SourceType } from '../enums/source-type';
 
 import { ViewError } from './view-error';
 import { DatasetDTO } from './dataset';
-import { FactTableDto } from './fact-table';
+import { FactTableDTO } from './fact-table';
 
 export interface CSVHeader {
     index: number;
@@ -25,7 +25,7 @@ export interface ViewErrDTO {
 export interface ViewDTO {
     status: number;
     dataset: DatasetDTO;
-    fact_table: FactTableDto;
+    fact_table: FactTableDTO;
     current_page: number;
     page_info: PageInfo;
     pages: (string | number)[];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,7 +8,7 @@
         "continue": "Continue",
         "back": "Back",
         "cancel": "Cancel",
-        "upload_csv": "Upload CSV File",
+        "upload_csv": "Upload File",
         "preview": "Preview (opens in new tab)"
     },
     "pagination": {
@@ -59,10 +59,76 @@
         "dataset_creation": "Start a new dataset creation journey",
         "project_reports": "See our projects reports"
     },
+    "dataset_view": {
+        "key_information": "Key information",
+        "last_update": "Most recent update",
+        "next_update": "Next update expected (provisional)",
+        "data_provider": "Data providers",
+        "data_source": "Data source",
+        "designation": "Designation",
+        "data_categories": "Data categories",
+        "time_covered": "Time period covered",
+        "buttons": {
+            "csv": "Download as CSV",
+            "excel": "Download as Excel",
+            "json": "Download as JSON",
+            "duckdb": "Download as DuckDB"
+        },
+        "data_notes": {
+            "heading": "Data Notes",
+            "a": "Average",
+            "c": "Confidential information",
+            "e": "Estimated",
+            "f": "Forecast",
+            "k": "Low figure",
+            "p": "Provisional",
+            "r": "Revised",
+            "t": "Total",
+            "u": "Low reliability",
+            "x": "Missing data",
+            "z": "Not applicable"
+        },
+        "designations": {
+            "official": "Official statistics",
+            "accredited": "Accredited official statistics",
+            "in_development": "Official statistics in development",
+            "none": "No designation"
+        },
+        "contents": "Contents",
+        "download": "Download",
+        "download_as": {
+            "csv": "Download as CSV",
+            "parquet": "Download as Parquet",
+            "excel": "Download as Excel",
+            "duckdb": "Download as DuckDB"
+        },
+        "table_preview": "Table Preview",
+        "table_note": "This is not shown in the consumer view",
+        "about_heading": "About this dataset",
+        "summary": "Summary",
+        "data_collection": "Data collection and calculation",
+        "statistical_quality": "Statistical quality",
+        "related_reports": "Related reports",
+        "published_heading": "Published by",
+        "org": "Organisation",
+        "contact": "Contact email",
+        "not_entered": "Not entered yet",
+        "not_selected": "Not selected yet",
+        "not_available": "Not Available",
+        "update_missing": "Publish date not entered yet",
+        "next_update_missing": "Publish date and update frequency not entered yet",
+        "categories_missing": "Reference data not selected yet",
+        "period_cover_missing": "Date information not entered yet"
+    },
     "publish": {
         "header": {
             "overview": "Return to dataset overview",
             "back": "Back"
+        },
+        "cube_preview": {
+            "panel": "This is a preview of this dataset.",
+            "heading": "Key information"
+
         },
         "start": {
             "title": "Create a new dataset",
@@ -113,8 +179,32 @@
                 "description_en": "Description (English)",
                 "description_cy": "Description (Welsh)",
                 "sort_order": "Sort Order",
+                "hierarchy": "Hierarchy",
                 "notes_en": "Notes (English)",
                 "notes_cy": "Notes (Welsh)"
+            }
+        },
+        "measure_review": {
+            "heading": "Check the measure table",
+            "showing": "Showing rows {{rows}} of {{total}} rows.",
+            "confirm": "By continuing, you confirm the measure table is correct.",
+            "go_back": "Choose a different measure table",
+            "column_headers": {
+                "fact_table": "Fact Table:",
+                "lookup_table": "Lookup Table:",
+                "description_en": "Description (English)",
+                "description_cy": "Description (Welsh)",
+                "sort": "Sort Order",
+                "sort_order": "Sort Order",
+                "notes_en": "Notes (English)",
+                "notes_cy": "Notes (Welsh)",
+                "decimal": "Decimal Value",
+                "format": "Format",
+                "measure_type": "Value Type"
+            },
+            "column_values": {
+                "1": "Yes",
+                "0": "No"
             }
         },
         "time_dimension_review": {
@@ -146,6 +236,10 @@
                 "meteorological_quarter": "Meteorological Quarter",
                 "meteorological_month": "Meteorological Month"
             }
+        },
+        "measure_preview": {
+            "heading": "Setup Measures and Datatypes",
+            "question": "Upload a measure lookup table"
         },
         "period-type-chooser": {
             "heading": "What are the shortest periods of time in the dimension?",
@@ -458,7 +552,7 @@
             "title": "Upload the data table",
             "lookup_heading": "Upload a lookup table",
             "measure_heading": "Upload a measure table",
-            "note": "The file should be in a CSV format"
+            "note": "This file must be in CSV, JSON or Parquet formats"
         },
         "preview": {
             "heading": "Check the data table",
@@ -505,6 +599,7 @@
         "tasklist": {
             "heading": "Dataset Overview",
             "no_title": "No Title Available",
+            "preview": "Preview (opens in new tab)",
             "status": {
                 "cannot_start": "Cannot start yet",
                 "available": "Available",

--- a/src/middleware/language-switcher.ts
+++ b/src/middleware/language-switcher.ts
@@ -6,7 +6,12 @@ import { Locale } from '../enums/locale';
 
 import { ignoreRoutes, SUPPORTED_LOCALES, i18next } from './translation';
 
-export const localeUrl = (path: string, locale: Locale | string, query?: Record<string, string>): string => {
+export const localeUrl = (
+    path: string,
+    locale: Locale | string,
+    query?: Record<string, string>,
+    anchor?: string
+): string => {
     const locales = SUPPORTED_LOCALES as string[];
 
     const pathElements = path
@@ -22,8 +27,8 @@ export const localeUrl = (path: string, locale: Locale | string, query?: Record<
 
     const newPath = isEmpty(pathElements) ? '' : `/${pathElements.join('/')}`;
     const queryString = isEmpty(query) ? '' : `?${new URLSearchParams(query).toString()}`;
-
-    return `/${locale}${newPath}${queryString}`;
+    const anchorString = isEmpty(anchor) ? '' : `#${anchor}`;
+    return `/${locale}${newPath}${queryString}${anchorString}`;
 };
 
 export const languageSwitcher: RequestHandler = (req, res, next): void => {

--- a/src/middleware/services.ts
+++ b/src/middleware/services.ts
@@ -19,7 +19,6 @@ export const initServices = (req: Request, res: Response, next: NextFunction): v
         res.locals.parseISO = parseISO;
         res.locals.dateFormat = format;
         res.locals.dateAdd = add;
-        res.locals.languague = req.language;
     }
     next();
 };

--- a/src/middleware/services.ts
+++ b/src/middleware/services.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
-import { format, parseISO } from 'date-fns';
+import { add, format, parseISO } from 'date-fns';
 
 import { Locale } from '../enums/locale';
 import { StatsWalesApi } from '../services/stats-wales-api';
@@ -18,6 +18,8 @@ export const initServices = (req: Request, res: Response, next: NextFunction): v
         res.locals.referrer = req.get('Referrer');
         res.locals.parseISO = parseISO;
         res.locals.dateFormat = format;
+        res.locals.dateAdd = add;
+        res.locals.languague = req.language;
     }
     next();
 };

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -34,9 +34,11 @@ dataset.get('/:datasetId', fetchDataset, async (req: Request, res: Response, nex
     } catch (err) {
         logger.error(err);
         next(new NotFoundException());
+        return;
     }
     if (!datasetView) {
-        throw new NotFoundException();
+        next(new NotFoundException());
+        return;
     }
 
     // eslint-disable-next-line require-atomic-updates

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -9,7 +9,7 @@ import { logger } from '../utils/logger';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item';
 import { hasError, factTableIdValidator } from '../validators';
 import { RevisionDTO } from '../dtos/revision';
-import { FactTableDto } from '../dtos/fact-table';
+import { FactTableDTO } from '../dtos/fact-table';
 import { generateSequenceForNumber } from '../utils/pagination';
 
 export const dataset = Router();
@@ -61,10 +61,10 @@ dataset.get(
 
         try {
             const importId = req.params.factTableId;
-            let factTable: FactTableDto | undefined;
+            let factTable: FactTableDTO | undefined;
 
             const revision = dataset.revisions?.find((rev: RevisionDTO) => {
-                factTable = rev.fact_tables?.find((file: FactTableDto) => file.id === importId);
+                factTable = rev.fact_tables?.find((file: FactTableDTO) => file.id === importId);
                 return Boolean(factTable);
             });
 

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -34,7 +34,14 @@ import {
     uploadLookupTable,
     lookupReview,
     exportTranslations,
-    importTranslations
+    importTranslations,
+    cubePreview,
+    measurePreview,
+    measureReview,
+    downloadAsCSV,
+    downloadAsParquet,
+    downloadAsExcel,
+    downloadAsDuckDb
 } from '../controllers/publish';
 
 export const publish = Router();
@@ -63,6 +70,19 @@ publish.post('/:datasetId/sources', fetchDataset, upload.none(), sources);
 
 /* Tasklist */
 publish.get('/:datasetId/tasklist', fetchDataset, taskList);
+
+/* Cube Preview */
+publish.get('/:datasetId/cube-preview', fetchDataset, cubePreview);
+publish.get('/:datasetId/cube-preview/csv', fetchDataset, downloadAsCSV);
+publish.get('/:datasetId/cube-preview/parquet', fetchDataset, downloadAsParquet);
+publish.get('/:datasetId/cube-preview/excel', fetchDataset, downloadAsExcel);
+publish.get('/:datasetId/cube-preview/cube', fetchDataset, downloadAsDuckDb);
+
+/* Measure creation */
+publish.get('/:datasetId/measure', fetchDataset, measurePreview);
+publish.post('/:datasetId/measure', fetchDataset, upload.single('csv'), measurePreview);
+publish.get('/:datasetId/measure/review', fetchDataset, measureReview);
+publish.post('/:datasetId/measure/review', fetchDataset, measureReview);
 
 /* Dimension creation */
 publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset, fetchDimensionPreview);

--- a/src/services/stats-wales-api.ts
+++ b/src/services/stats-wales-api.ts
@@ -3,7 +3,7 @@ import { ReadableStream } from 'node:stream/web';
 import { ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { DatasetDTO } from '../dtos/dataset';
 import { DatasetInfoDTO } from '../dtos/dataset-info';
-import { FactTableDto } from '../dtos/fact-table';
+import { FactTableDTO } from '../dtos/fact-table';
 import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
 import { logger as parentLogger } from '../utils/logger';
 import { appConfig } from '../config';
@@ -19,7 +19,7 @@ import { ProviderSourceDTO } from '../dtos/provider-source';
 import { TopicDTO } from '../dtos/topic';
 import { OrganisationDTO } from '../dtos/organisation';
 import { TeamDTO } from '../dtos/team';
-import { DimensionPatchDto } from '../dtos/dimension-patch-dto';
+import { DimensionPatchDTO } from '../dtos/dimension-patch-dto';
 import { DimensionDTO } from '../dtos/dimension';
 import { DimensionInfoDTO } from '../dtos/dimension-info';
 import { TranslationDTO } from '../dtos/translations';
@@ -201,25 +201,25 @@ export class StatsWalesApi {
         }).then((response) => response.body as ReadableStream);
     }
 
-    public async confirmFileImport(datasetId: string, revisionId: string, factTableId: string): Promise<FactTableDto> {
+    public async confirmFileImport(datasetId: string, revisionId: string, factTableId: string): Promise<FactTableDTO> {
         logger.debug(`Confirming file import: ${factTableId}`);
 
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/fact-table/by-id/${factTableId}/confirm`,
             method: HttpMethod.Patch
-        }).then((response) => response.json() as unknown as FactTableDto);
+        }).then((response) => response.json() as unknown as FactTableDTO);
     }
 
     public async getSourcesForFileImport(
         datasetId: string,
         revisionId: string,
         factTableId: string
-    ): Promise<FactTableDto> {
+    ): Promise<FactTableDTO> {
         logger.debug(`Fetching sources for file import: ${factTableId}`);
 
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/fact-table/by-id/${factTableId}`
-        }).then((response) => response.json() as unknown as FactTableDto);
+        }).then((response) => response.json() as unknown as FactTableDTO);
     }
 
     public async removeFileImport(datasetId: string, revisionId: string, factTableId: string): Promise<DatasetDTO> {
@@ -298,7 +298,7 @@ export class StatsWalesApi {
     public async patchDimension(
         datasetId: string,
         dimensionId: string,
-        dimensionPatch: DimensionPatchDto
+        dimensionPatch: DimensionPatchDTO
     ): Promise<ViewDTO> {
         logger.debug(`sending patch request for dimension: ${dimensionId}`);
 

--- a/src/services/stats-wales-api.ts
+++ b/src/services/stats-wales-api.ts
@@ -122,7 +122,27 @@ export class StatsWalesApi {
         }).then((response) => response.json() as unknown as ViewDTO);
     }
 
+    public uploadMeasureLookup(datasetId: string, file: Blob, filename: string): Promise<ViewDTO> {
+        logger.debug(`Uploading file ${filename} to dataset: ${datasetId}`);
+        const body = new FormData();
+        body.set('csv', file, filename);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/measure`,
+            method: HttpMethod.Post,
+            body
+        }).then((response) => response.json() as unknown as ViewDTO);
+    }
+
     public async getDatasetView(datasetId: string, pageNumber: number, pageSize: number): Promise<ViewDTO> {
+        logger.debug(`Fetching view for dataset: ${datasetId}, page: ${pageNumber}, pageSize: ${pageSize}`);
+
+        return this.fetch({ url: `dataset/${datasetId}/view?page_number=${pageNumber}&page_size=${pageSize}` }).then(
+            (response) => response.json() as unknown as ViewDTO
+        );
+    }
+
+    public async getDatasetCubeView(datasetId: string, pageNumber: number, pageSize: number): Promise<ViewDTO> {
         logger.debug(`Fetching view for dataset: ${datasetId}, page: ${pageNumber}, pageSize: ${pageSize}`);
 
         return this.fetch({ url: `dataset/${datasetId}/view?page_number=${pageNumber}&page_size=${pageSize}` }).then(
@@ -146,6 +166,38 @@ export class StatsWalesApi {
 
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/fact-table/by-id/${factTableId}/raw`
+        }).then((response) => response.body as ReadableStream);
+    }
+
+    public async getRevisionCubeCSV(datasetId: string, revisionId: string): Promise<ReadableStream> {
+        logger.debug(`Fetching CSV for revision: ${revisionId}...`);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/revision/by-id/${revisionId}/cube/csv`
+        }).then((response) => response.body as ReadableStream);
+    }
+
+    public async getRevisionCubeParquet(datasetId: string, revisionId: string): Promise<ReadableStream> {
+        logger.debug(`Fetching CSV for revision: ${revisionId}...`);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/revision/by-id/${revisionId}/cube/parquet`
+        }).then((response) => response.body as ReadableStream);
+    }
+
+    public async getRevisionCubeExcel(datasetId: string, revisionId: string): Promise<ReadableStream> {
+        logger.debug(`Fetching CSV for revision: ${revisionId}...`);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/revision/by-id/${revisionId}/cube/excel`
+        }).then((response) => response.body as ReadableStream);
+    }
+
+    public async getRevisionCube(datasetId: string, revisionId: string): Promise<ReadableStream> {
+        logger.debug(`Fetching CSV for revision: ${revisionId}...`);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/revision/by-id/${revisionId}/cube`
         }).then((response) => response.body as ReadableStream);
     }
 
@@ -188,6 +240,15 @@ export class StatsWalesApi {
         }).then((response) => response.json() as unknown as DimensionDTO);
     }
 
+    public async resetMeasure(datasetId: string): Promise<DatasetDTO> {
+        logger.debug(`Resetting measure on dataset: ${datasetId}`);
+
+        return this.fetch({
+            url: `dataset/${datasetId}/measure/reset`,
+            method: HttpMethod.Delete
+        }).then((response) => response.json() as unknown as DatasetDTO);
+    }
+
     public async getImportPreview(
         datasetId: string,
         revisionId: string,
@@ -201,6 +262,21 @@ export class StatsWalesApi {
 
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/fact-table/by-id/${factTableId}/preview?page_number=${pageNumber}&page_size=${pageSize}`
+        }).then((response) => response.json() as unknown as ViewDTO);
+    }
+
+    public async getRevisionPreview(
+        datasetId: string,
+        revisionId: string,
+        pageNumber: number,
+        pageSize: number
+    ): Promise<ViewDTO> {
+        logger.debug(
+            `Fetching preview for dataset: ${datasetId}, revision: ${revisionId}, page: ${pageNumber}, pageSize: ${pageSize}`
+        );
+
+        return this.fetch({
+            url: `dataset/${datasetId}/revision/by-id/${revisionId}/preview?page_number=${pageNumber}&page_size=${pageSize}`
         }).then((response) => response.json() as unknown as ViewDTO);
     }
 
@@ -273,6 +349,13 @@ export class StatsWalesApi {
     public async getDimensionPreview(datasetId: string, dimensionId: string): Promise<ViewDTO> {
         logger.debug(`Fetching dimension preview for dimension: ${datasetId}`);
         return this.fetch({ url: `dataset/${datasetId}/dimension/by-id/${dimensionId}/preview` }).then(
+            (response) => response.json() as unknown as ViewDTO
+        );
+    }
+
+    public async getMeasurePreview(datasetId: string): Promise<ViewDTO> {
+        logger.debug(`Fetching measure preview for dataset: ${datasetId}`);
+        return this.fetch({ url: `dataset/${datasetId}/measure/preview` }).then(
             (response) => response.json() as unknown as ViewDTO
         );
     }

--- a/src/utils/latest.ts
+++ b/src/utils/latest.ts
@@ -2,14 +2,14 @@ import { sortBy, last } from 'lodash';
 
 import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
-import { FactTableDto } from '../dtos/fact-table';
+import { FactTableDTO } from '../dtos/fact-table';
 
 export const getLatestRevision = (dataset: DatasetDTO): RevisionDTO | undefined => {
     if (!dataset) return undefined;
     return last(sortBy(dataset?.revisions, 'revision_index'));
 };
 
-export const getLatestFactTable = (revision: RevisionDTO): FactTableDto | undefined => {
+export const getLatestFactTable = (revision: RevisionDTO): FactTableDTO | undefined => {
     if (!revision) return undefined;
     return last(sortBy(revision?.fact_tables, 'uploaded_at'));
 };

--- a/src/utils/single-lang-dataset.ts
+++ b/src/utils/single-lang-dataset.ts
@@ -4,6 +4,7 @@ import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 export const singleLangDataset = (dataset: DatasetDTO, lang: string): SingleLanguageDataset => {
     return {
         ...dataset,
+        team: dataset.team?.find((team) => team.language === lang),
         datasetInfo: dataset.datasetInfo?.find((info) => info.language === lang),
         dimensions: dataset.dimensions?.map((dimension) => {
             return {

--- a/src/utils/update-source-types.ts
+++ b/src/utils/update-source-types.ts
@@ -1,12 +1,12 @@
-import { FactTableDto } from '../dtos/fact-table';
+import { FactTableDTO } from '../dtos/fact-table';
 import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
 import { SourceType } from '../enums/source-type';
-import { FactTableInfoDto } from '../dtos/fact-table-info';
+import { FactTableInfoDTO } from '../dtos/fact-table-info';
 
-export const updateSourceTypes = (factTable: FactTableDto, sourceAssign: SourceAssignmentDTO[]) => {
+export const updateSourceTypes = (factTable: FactTableDTO, sourceAssign: SourceAssignmentDTO[]) => {
     return {
         ...factTable,
-        sources: factTable.fact_table_info.map((factTableInfo: FactTableInfoDto) => {
+        sources: factTable.fact_table_info.map((factTableInfo: FactTableInfoDTO) => {
             const type =
                 sourceAssign.find((sass) => sass.column_name === factTableInfo.column_name)?.column_type ||
                 SourceType.Unknown;

--- a/src/views/partials/pagination.ejs
+++ b/src/views/partials/pagination.ejs
@@ -13,7 +13,7 @@
                 <% if (locals.current_page > 1) { %>
                     <div class="govuk-pagination__prev">
                         <a class="govuk-link govuk-pagination__link"
-                           href="<%= buildUrl(url, i18n.language, { page_number: locals.current_page - 1, page_size: locals.page_size }) %>"
+                           href="<%= buildUrl(url.split('?')[0], i18n.language, { page_number: locals.current_page - 1, page_size: locals.page_size }, locals.anchor) %>"
                            rel="prev">
                             <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
                                  height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
@@ -42,7 +42,7 @@
                         <% } else { %>
                             <li class="govuk-pagination__item">
                                 <a class="govuk-link govuk-pagination__link"
-                                   href="<%= buildUrl(url, i18n.language, { page_number: item, page_size: locals.page_size }) %>"
+                                   href="<%= buildUrl(url.split('?')[0], i18n.language, { page_number: item, page_size: locals.page_size }, locals.anchor) %>"
                                    aria-label="Page <%= item %>">
                                     <%= item %>
                                 </a>
@@ -53,7 +53,7 @@
                 <% if (locals.current_page < locals.total_pages) { %>
                     <div class="govuk-pagination__next">
                         <a class="govuk-link govuk-pagination__link"
-                           href="<%= buildUrl(url, i18n.language, { page_number: locals.current_page + 1, page_size: locals.page_size }) %>"
+                           href="<%= buildUrl(url.split('?')[0], i18n.language, { page_number: locals.current_page + 1, page_size: locals.page_size }, locals.anchor) %>"
                            rel="next">
                                     <span class="govuk-pagination__link-title">
                                         <%= t('pagination.next') %>

--- a/src/views/publish/cube-preview.ejs
+++ b/src/views/publish/cube-preview.ejs
@@ -1,0 +1,291 @@
+<%- include("../partials/header", t); %>
+
+<div class="govuk-width-container app-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+
+        <%- include("../partials/error-handler"); %>
+
+        <div class="govuk-panel govuk-panel--confirmation">
+            <p class="govuk-panel__title-m">
+                <%= t('publish.cube_preview.panel') %>
+            </p>
+        </div>
+
+        <h2 class="govuk-heading-l">
+            <%= t('dataset_view.key_information') %>
+        </h2>
+
+        <%
+            const publishDate = new Date(Math.max.apply(null, dataset.revisions.map((rev) => new Date(Date.parse(rev.publish_at? rev.publish_at : rev.created_at)))));
+            let updateObj = { years: 0 };
+            if (dataset.datasetInfo.update_frequency) {
+                if (dataset.datasetInfo.update_frequency.frequency_unit === 'year')
+                    updateObj = { years: dataset.datasetInfo.update_frequency.frequency_value };
+                if (dataset.datasetInfo.update_frequency.frequency_unit === 'month')
+                    updateObj = { months: dataset.datasetInfo.update_frequency.frequency_value };
+                if (dataset.datasetInfo.update_frequency.frequency_unit === 'week')
+                    updateObj = { weeks: dataset.datasetInfo.update_frequency.frequency_value };
+                if (dataset.datasetInfo.update_frequency.frequency_unit === 'day')
+                    updateObj = { days: dataset.datasetInfo.update_frequency.frequency_value };
+            }
+            const nextUpdate = locals.dateAdd(publishDate, updateObj);
+        %>
+
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.last_update') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <%= locals.dateFormat(publishDate, 'd MMMM yyyy h:mm aaa') %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.next_update') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.datasetInfo?.update_frequency && dataset.datasetInfo?.update_frequency?.is_updated) { %>
+                        <%= locals.dateFormat(nextUpdate, 'd MMMM yyyy') %>
+                    <% } else { %>
+                        <%= t('dataset_view.next_update_missing') %>
+                    <% } %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.data_provider') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.providers?.length > 0) { %>
+                        <ul class="govuk-list">
+                        <% for (const provider of dataset.providers.filter((item, i, ar) => ar.indexOf(item) === i)) { %>
+                            <li><%= provider.provider_name %></li>
+                        <% } %>
+                        </ul>
+                    <% } else { %>
+                        <%= t('dataset_view.not_selected') %>
+                    <% } %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.data_source') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.providers?.length > 0) { %>
+                        <ul class="govuk-list">
+                            <% for (const provider of dataset.providers.filter((item, i, ar) => ar.indexOf(item) === i)) { %>
+                                <li><%= provider.provider_name %>: <%= provider.source_name %></li>
+                            <% } %>
+                        </ul>
+                    <% } else { %>
+                        <%= t('dataset_view.not_selected') %>
+                    <% } %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.designation') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.datasetInfo.designation) { %>
+                        <%= t(`dataset_view.designations.${dataset.datasetInfo.designation}`) %>
+                    <% } else { %>
+                        <%= t('dataset_view.not_selected') %>
+                    <% } %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.time_covered') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.start_date) { %>
+                        <%= locals.dateFormat(new Date(Date.parse(dataset.start_date)), 'd MMMM yyyy') %> -
+                        <%= locals.dateFormat(new Date(Date.parse(dataset.end_date)), 'd MMMM yyyy') %>
+                    <% } else { %>
+                        <%= t('dataset_view.period_cover_missing') %>
+                    <% } %>
+                </dd>
+            </div>
+        </dl>
+
+        <div class="govuk-tabs" data-module="govuk-tabs">
+            <h2 class="govuk-tabs__title">
+                <%= t('dataset_view.contents') %>
+            </h2>
+            <ul class="govuk-tabs__list">
+                <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                    <a class="govuk-tabs__tab" href="#download">
+                        <%= t('dataset_view.download') %>
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item">
+                    <a class="govuk-tabs__tab" href="#preview">
+                        <%= t('dataset_view.table_preview') %>
+                    </a>
+                </li>
+            </ul>
+            <div class="govuk-tabs__panel" id="download">
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview/csv`, i18n.language) %>" class="govuk-button">
+                    <i class="fa-solid fa-file-csv"></i> <%= t('dataset_view.download_as.csv') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview/parquet`, i18n.language) %>" class="govuk-button">
+                    <i class="fa-solid fa-table"></i> <%= t('dataset_view.download_as.parquet') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview/excel`, i18n.language) %>" class="govuk-button">
+                    <i class="fa-solid fa-file-excel"></i> <%= t('dataset_view.download_as.excel') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview/cube`, i18n.language) %>" class="govuk-button">
+                    <i class="fa-solid fa-database"></i> <%= t('dataset_view.download_as.duckdb') %></a>
+            </div>
+            <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="preview">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-half">
+                        &nbsp;
+                    </div>
+                    <div class="govuk-grid-column-one-half" style="text-align: right;">
+                        <form action="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language, undefined, 'preview') %>" method="get" role="page-size" class="govuk-!-margin-bottom-0">
+                            <label class="govuk-label govuk-!-display-inline" for="page_size">
+                                <%= t('pagination.page_size') %>
+                            </label>
+
+                            <select class="govuk-select govuk-!-display-inline" id="page_size" name="page_size">
+                                <option value="5" <% if (locals.page_size===5) { %>selected <% }; %>>5</option>
+                                <option value="10" <% if (locals.page_size===10) { %>selected <% }; %>>10</option>
+                                <option value="25" <% if (locals.page_size===25) { %>selected <% }; %>>25</option>
+                                <option value="50" <% if (locals.page_size===50) { %>selected <% }; %>>50</option>
+                                <option value="100" <% if (locals.page_size===100) { %>selected <% }; %>>100</option>
+                                <option value="250" <% if (locals.page_size===250) { %>selected <% }; %>>250</option>
+                                <option value="500" <% if (locals.page_size===500) { %>selected <% }; %>>500</option>
+                            </select>
+                            <input type="hidden" name="file" value="<%= locals.datafile_id %>">
+                            <input type="hidden" name="page_number" value="1">
+                            <button type="submit" class="govuk-button govuk-!-display-inline" data-module="govuk-button">
+                                <%= t('pagination.update') %>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+                <% if (locals?.data) { %>
+                    <div class="govuk-grid-row">
+                        <div class="table-display govuk-grid-column-full with-overflow">
+                            <table class="govuk-table" style="position: relative; border-collapse: collapse;">
+                                <colgroup>
+                                    <% locals.headers.forEach(function(cell, idx) { %>
+                                        <col class="<%= cell.type === 'ignore' ? 'ignore-column' : '' %>" />
+                                    <% }); %>
+                                </colgroup>
+                                <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <% locals.headers.forEach(function(cell, idx) { %>
+                                        <% if (cell.source_type === 'line_number') { %>
+                                            <th scope="col" class="govuk-table__header">
+                                                <span class="govuk-visually-hidden"><%= t('publish.preview.row_number') %></span>
+                                            </th>
+                                        <% } else { %>
+                                            <th scope="col" class="govuk-table__header">
+                                                <% if (cell.source_type && cell.source_type !== 'unknown' && cell.source_type !== 'line_number') { %>
+                                                    <span class="region-subhead"><%= t(`publish.preview.source_type.${cell.source_type}`) %></span><br />
+                                                <% } %>
+                                                <%= cell.name || t('publish.preview.unnamed_column', { colNum: idx + 1 }) %>
+                                            </th>
+                                        <% } %>
+                                    <% }); %>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <% locals.data.forEach(function(row) { %>
+                                    <tr>
+                                        <% row.forEach(function(cell, index) { %>
+                                            <td class="govuk-table__cell <%= locals.headers[index].source_type %>">
+                                                <%= cell %>
+                                            </td>
+                                        <% }); %>
+                                    </tr>
+                                <% }); %>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <% locals.anchor = 'preview' %>
+                    <%- include("../partials/pagination", locals.anchor, t, locals.current_page, locals.total_records, locals.pagaination); %>
+                <% } %>
+            </div>
+        </div>
+
+        <h2 class="govuk-heading-l">
+            <%= t('dataset_view.about_heading') %>
+        </h2>
+
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.summary') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <%= dataset.datasetInfo.description || t('dataset_view.not_entered') %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.data_collection') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <%= dataset.datasetInfo.collection || t('dataset_view.not_entered') %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.statistical_quality') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <%= dataset.datasetInfo.quality || t('dataset_view.not_entered') %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.related_reports') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.datasetInfo.related_links?.length > 0) {%>
+                        <ul class="govuk-list">
+                            <% for(const link of dataset.datasetInfo.related_links) {%>
+                                <li><a href="<%= link.url %>" target="_blank"><%= link.title %></a></li>
+                            <% } %>
+                        </ul>
+                    <% } else { %>
+                        <%= t('dataset_view.not_entered') %>
+                    <% } %>
+                </dd>
+            </div>
+        </dl>
+
+        <h2 class="govuk-heading-l">
+            <%= t('dataset_view.published_heading') %>
+        </h2>
+
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.org') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <%= dataset.team?.organisation?.name || t('dataset_view.not_entered') %>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    <%= t('dataset_view.contact') %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    <% if (dataset.team?.email) { %>
+                        <a href="mailto:<%= dataset.team.email %>"><%= dataset.team.email %></a>
+                    <% } else { %>
+                        <%= t('dataset_view.not_entered') %>
+                    <% } %>
+                </dd>
+            </div>
+        </dl>
+    </main>
+</div>
+
+<%- include("../partials/footer"); %>

--- a/src/views/publish/dimension-chooser.ejs
+++ b/src/views/publish/dimension-chooser.ejs
@@ -84,38 +84,38 @@
                                 </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeAge" name="dimensionType" type="radio" value="age">
+                                        <input class="govuk-radios__input" id="dimensionTypeAge" name="dimensionType" type="radio" disabled value="age">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeAge">
                                             <%= t('publish.dimension_type_chooser.chooser.age')%>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeEthnicity" name="dimensionType" type="radio" value="ethnicity">
+                                        <input class="govuk-radios__input" id="dimensionTypeEthnicity" name="dimensionType" type="radio" disabled value="ethnicity">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeEthnicity">
                                             <%= t('publish.dimension_type_chooser.chooser.ethnicity')%>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeGeography" name="dimensionType" type="radio" value="geography">
+                                        <input class="govuk-radios__input" id="dimensionTypeGeography" name="dimensionType" type="radio" disabled value="geography">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeGeography">
                                             <%= t('publish.dimension_type_chooser.chooser.geography')%>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeReligion" name="dimensionType" type="radio" value="religion">
+                                        <input class="govuk-radios__input" id="dimensionTypeReligion" name="dimensionType" type="radio" disabled value="religion">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeReligion">
                                             <%= t('publish.dimension_type_chooser.chooser.religion')%>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeSexGender" name="dimensionType" type="radio" value="sexGender">
+                                        <input class="govuk-radios__input" id="dimensionTypeSexGender" name="dimensionType" type="radio" disabled value="sexGender">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeSexGender">
                                             <%= t('publish.dimension_type_chooser.chooser.sex_gender')%>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__divider">or</div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="dimensionTypeTimeLookup" name="dimensionType" type="radio" value="lookup">
+                                        <input class="govuk-radios__input" id="dimensionTypeTimeLookup" name="dimensionType" type="radio" checked value="lookup">
                                         <label class="govuk-label govuk-radios__label" for="dimensionTypeTimeLookup">
                                             <%= t('publish.dimension_type_chooser.chooser.lookup')%>
                                         </label>
@@ -127,7 +127,7 @@
                             <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                                 <%= t('buttons.continue') %>
                             </button>
-                            <a href="#" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                            <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                                 <%= t('buttons.preview') %>
                             </a>
                         </div>
@@ -137,7 +137,7 @@
         <% } %> <!-- Do I have data? -->
     </main>
 </div>
-<pre><code><%= JSON.stringify(locals.dimensionPreview) %></code></pre>
+
 <style>
     table {
         position: relative;

--- a/src/views/publish/lookup-table-preview.ejs
+++ b/src/views/publish/lookup-table-preview.ejs
@@ -22,7 +22,11 @@
                         <tr class="govuk-table__row">
                             <% locals.headers.forEach(function(cell, idx) { %>
                                 <th scope="col" class="govuk-table__header">
-                                    <%= cell.name === dimension.joinColumn ? cell.name : t(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`) %>
+                                    <% if (i18n.exists(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`)) { %>
+                                        <%= t(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`) %>
+                                    <% } else { %>
+                                        <%= cell.name %>
+                                    <% } %>
                                 </th>
                             <% }); %>
                         </tr>

--- a/src/views/publish/measure-match-failure.ejs
+++ b/src/views/publish/measure-match-failure.ejs
@@ -1,0 +1,44 @@
+<%- include("../partials/header", t); %>
+
+<div class="govuk-width-container app-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="top-links">
+            <div class="govuk-width-container">
+                <a href="<%= locals.referrer %>" class="govuk-back-link"><%= t('buttons.back') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>" class="govuk-link return-link"><%= t('publish.header.overview') %></a>
+            </div>
+        </div>
+
+        <h1 class="govuk-heading-xl"><%= t('publish.dimension_match_failure.lookup_heading') %></h1>
+
+        <p class="govuk-body"><%= t('publish.dimension_match_failure.information', {failureCount: locals.extension.totalNonMatching}) %></p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li class="govuk-list--bullet"><%= t('publish.dimension_match_failure.formatting') %></li>
+            <li class="govuk-list--bullet"><%= t('publish.dimension_match_failure.choices') %></li>
+        </ul>
+
+        <h2 class="govuk-heading-l"><%= t('publish.dimension_match_failure.subheading') %></h2>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <% if (locals.extension.nonMatchingValues.length === 0) { %>
+                <li class="govuk-list--bullet"><%= t('publish.dimension_match_failure.no_matches') %></li>
+            <% } else { %>
+                <% locals.extension.nonMatchingValues.forEach((value) => { %>
+                    <li class="govuk-list--bullet"><%= value %></li>
+                <% });%>
+            <% } %>
+        </ul>
+
+        <h2 class="govuk-heading-l"><%= t('publish.dimension_match_failure.actions') %></h2>
+
+        <p class="govuk-body"><a href="<%= buildUrl(`/publish/${locals.dataset.id}/upload`, i18n.language) %>" class="govuk-link">
+                <%= t('publish.dimension_match_failure.upload_different_file')%>
+            </a><br>
+            <%= t('publish.dimension_match_failure.upload_different_file_warning')%></p>
+
+        <p class="govuk-body"><a href="<%= buildUrl(`/publish/${locals.datasetId}/measure/`, i18n.language) %>" class="govuk-link">
+                <%= t('publish.dimension_match_failure.try_different_format')%></a></p>
+    </main>
+</div>
+
+<%- include("../partials/footer"); %>

--- a/src/views/publish/measure-preview.ejs
+++ b/src/views/publish/measure-preview.ejs
@@ -1,0 +1,116 @@
+<%- include("../partials/header", t); %>
+
+
+<main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-width-container app-width-container">
+        <div class="top-links">
+            <div class="govuk-width-container">
+                <a href="<%= locals.referrer %>" class="govuk-back-link"><%= t('buttons.back') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>" class="govuk-link return-link"><%= t('publish.header.overview') %></a>
+            </div>
+        </div>
+
+        <h1 class="govuk-heading-xl"><%= t('publish.measure_preview.heading') %></h1>
+
+        <% if (locals?.errors) { %>
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title">
+                        <%= t('errors.problem') %>
+                    </h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <% locals.errors.errors.forEach(function(error) { %>
+                                <li>
+                                    <a href="#<%= error.field %>">
+                                        <%= t(error.tag.name) %>
+                                    </a>
+                                </li>
+                            <% }); %>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        <% } %>
+
+        <% if (locals?.data) { %>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full with-overflow">
+                    <table class="govuk-table" style="position: relative; border-collapse: collapse;">
+                        <colgroup>
+                            <% locals.headers.forEach(function(cell, idx) { %>
+                                <col class="<%= cell.type === 'ignore' ? 'ignore-column' : '' %>" />
+                            <% }); %>
+                        </colgroup>
+                        <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <% locals.headers.forEach(function(cell, idx) { %>
+                                <th scope="col" class="govuk-table__header">
+                                    <% if (i18n.exists(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`)) { %>
+                                        <%= t(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`) %>
+                                    <% } else { %>
+                                        <%= cell.name %>
+                                    <% } %>
+                                </th>
+                            <% }); %>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <% locals.data.forEach(function(row) { %>
+                            <tr>
+                                <% row.forEach(function(cell, index) { %>
+                                    <% if (locals.headers[index].source_type === 'line_number') { %>
+                                        <td class="govuk-table__cell line-number"><span class="linespan"><%= cell %></span></td>
+                                    <% } else { %>
+                                        <td class="govuk-table__cell"><%= cell %></td>
+                                    <% } %>
+                                <% }); %>
+                            </tr>
+                        <% }); %>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" role="continue" enctype="multipart/form-data">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                <h2 class="govuk-fieldset__heading">
+                                    <%= t('publish.measure_preview.question') %>
+                                </h2>
+                            </legend>
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-label--m" for="csv">
+                                    <%= t('publish.upload.note') %>
+                                </label>
+                                <input class="govuk-file-upload" id="csv" name="csv" type="file" placeholder="Upload Data Files!" accept=".csv,.parquet,.json,.xls,.xlsx,.gz,text/csv,application/vnd.apache.parquet,application/parquet,application/json,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/msexcel,application/gzip">
+                            </div>
+                            <div class="govuk-form-group">
+                                <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                                    <%= t('buttons.upload_csv') %>
+                                </button>
+                                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                                    <%= t('buttons.preview') %>
+                                </a>
+                            </div>
+                        </fieldset>
+                    </form>
+                </div>
+            </div>
+        <% } %> <!-- Do I have data? -->
+    </div>
+</main>
+
+<style>
+    table {
+        position: relative;
+        width: 30% !important;
+    }
+    .region-subhead {
+        display: none;
+    }
+</style>
+
+<%- include("../partials/footer"); %>

--- a/src/views/publish/measure-review.ejs
+++ b/src/views/publish/measure-review.ejs
@@ -71,10 +71,10 @@
                             </h2>
                         </legend>
                         <div class="govuk-button-group">
-                            <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                            <button type="submit" name="confirm" value="continue" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                                 <%= t('buttons.continue') %>
                             </button>
-                            <button type="submit" name="confirm" value="goback" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                            <button type="submit" name="confirm" value="cancel" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                                 <%= t('publish.measure_review.go_back') %>
                             </button>
                         </div>

--- a/src/views/publish/measure-review.ejs
+++ b/src/views/publish/measure-review.ejs
@@ -1,0 +1,105 @@
+<%- include("../partials/header", t); %>
+
+
+<main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-width-container app-width-container">
+        <div class="top-links">
+            <div class="govuk-width-container">
+                <a href="<%= locals.referrer %>" class="govuk-back-link"><%= t('buttons.back') %></a>
+                <a href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>" class="govuk-link return-link"><%= t('publish.header.overview') %></a>
+            </div>
+        </div>
+
+        <h1 class="govuk-heading-xl"><%= t('publish.measure_review.heading') %></h1>
+
+        <%- include("../partials/error-handler"); %>
+
+        <% if (locals?.data) { %>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full with-overflow">
+                    <table class="govuk-table" style="position: relative; border-collapse: collapse; width:100% !important;">
+                        <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <% locals.headers.forEach(function(cell, idx) { %>
+                                    <th scope="col" class="govuk-table__header">
+                                        <% if (t(`publish.measure_review.column_headers.${cell.name.toLowerCase()}`) === `publish.measure_review.column_headers.${cell.name.toLowerCase()}`) { %>
+                                            <%= cell.name %>
+                                        <% } else { %>
+                                            <%= t(`publish.measure_review.column_headers.${cell.name.toLowerCase()}`) %>
+                                        <% } %>
+                                    </th>
+                                <% }); %>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <% locals.data.forEach(function(row) { %>
+                            <tr>
+                                <% row.forEach(function(cell, index) { %>
+                                    <td class="govuk-table__cell">
+                                        <% switch (locals.headers[index].name.toLowerCase()) {
+                                            case 'start_date':
+                                        case 'end_date': %>
+                                        <%= locals.dateFormat(locals.parseISO(cell.split('T')[0]), 'do MMMM yyyy') %>
+                                        <% break;
+                                        case 'date_type': %>
+                                        <%= t(`publish.measure_review.year_type.${cell}`) %>
+                                        <% break;
+                                        case 'decimals': %>
+                                        <%= t(`publish.measure_review.column_values.${cell}`) %>
+                                        <% break;
+                                        default: %>
+                                        <%= cell %>
+                                        <% } %>
+                                    </td>
+                                <% }); %>
+                            </tr>
+                        <% }); %>
+                        </tbody>
+                    </table>
+                    <p class="govuk-body govuk-hint"><%= t('publish.measure_review.showing', {rows: locals.page_size, total: locals.page_info.total_records}) %></p>
+                </div>
+            </div>
+        <% } %>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <form method="post" role="continue">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h2 class="govuk-fieldset__heading">
+                                <%= t('publish.measure_review.confirm') %>
+                            </h2>
+                        </legend>
+                        <div class="govuk-button-group">
+                            <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                                <%= t('buttons.continue') %>
+                            </button>
+                            <button type="submit" name="confirm" value="goback" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                                <%= t('publish.measure_review.go_back') %>
+                            </button>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+</main>
+
+<style>
+    table {
+        position: relative;
+        width: 30% !important;
+    }
+    th {
+        vertical-align: bottom !important;
+    }
+    .column_label {
+        white-space: nowrap;
+        color: #aa1111;
+        font-size: 14px;
+        letter-spacing: 0.08em;
+        line-height: 20px;
+        text-transform: uppercase;
+    }
+</style>
+<%- include("../partials/footer"); %>

--- a/src/views/publish/month-format.ejs
+++ b/src/views/publish/month-format.ejs
@@ -72,7 +72,7 @@
                         <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.continue') %>
                         </button>
-                        <a href="#" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                        <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.preview') %>
                         </a>
                     </div>

--- a/src/views/publish/period-type.ejs
+++ b/src/views/publish/period-type.ejs
@@ -63,7 +63,7 @@
                         <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.continue') %>
                         </button>
-                        <a href="#" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                        <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.preview') %>
                         </a>
                     </div>

--- a/src/views/publish/point-in-time-chooser.ejs
+++ b/src/views/publish/point-in-time-chooser.ejs
@@ -63,7 +63,7 @@
                         <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.continue') %>
                         </button>
-                        <a href="#" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                        <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.preview') %>
                         </a>
                     </div>

--- a/src/views/publish/quarter-format.ejs
+++ b/src/views/publish/quarter-format.ejs
@@ -118,7 +118,7 @@
                         <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.continue') %>
                         </button>
-                        <a href="#" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                        <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                             <%= t('buttons.preview') %>
                         </a>
                     </div>

--- a/src/views/publish/tasklist.ejs
+++ b/src/views/publish/tasklist.ejs
@@ -233,6 +233,13 @@
           </li>
         </ul>
       </div>
+      <div class="govuk-grid-column-one-third">
+        <p class="govuk-heading-s">
+          <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank">
+            <%= t('publish.tasklist.preview') %>
+          </a>
+        </p>
+      </div>
     </div>
   </main>
 </div>

--- a/src/views/publish/time-chooser.ejs
+++ b/src/views/publish/time-chooser.ejs
@@ -120,8 +120,8 @@
                                 <button type="submit" name="confirm" value="true" class="govuk-button" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
                                     <%= t('buttons.continue') %>
                                 </button>
-                                <a href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>" class="govuk-button govuk-button--secondary" data-module="govuk-button govuk-button--secondary" style="vertical-align: unset;" data-prevent-double-click="true">
-                                    <%= t('buttons.cancel') %>
+                                <a href="<%= buildUrl(`/publish/${locals.datasetId}/cube-preview`, i18n.language) %>" target="_blank" class="govuk-button govuk-button--secondary" data-module="govuk-button" style="vertical-align: unset;" data-prevent-double-click="true">
+                                    <%= t('buttons.preview') %>
                                 </a>
                             </div>
                         </form>

--- a/test/mocks/fixtures.ts
+++ b/test/mocks/fixtures.ts
@@ -1,5 +1,5 @@
 import { DatasetDTO } from '../../src/dtos/dataset';
-import { FactTableDto } from '../../src/dtos/fact-table';
+import { FactTableDTO } from '../../src/dtos/fact-table';
 import { TaskListState } from '../../src/dtos/task-list-state';
 import { ViewDTO } from '../../src/dtos/view-dto';
 import { TaskStatus } from '../../src/enums/task-status';
@@ -199,7 +199,7 @@ export const datasetView: ViewDTO = {
     ]
 };
 
-export const importWithDraftSources: FactTableDto = {
+export const importWithDraftSources: FactTableDTO = {
     id: '6a8b56ea-2fc5-4413-9dc3-4d31cbe4c953',
     revision_id: '09d1c9ac-4cea-482e-89c1-86997f3b6da6',
     mime_type: 'text/csv',

--- a/test/stats-wales.api.test.ts
+++ b/test/stats-wales.api.test.ts
@@ -1,15 +1,14 @@
 import { randomUUID } from 'crypto';
 
-import { appConfig } from '../config';
-import { HttpMethod } from '../enums/http-method';
-import { Locale } from '../enums/locale';
-import { SourceType } from '../enums/source-type';
-import { ApiException } from '../exceptions/api.exception';
-import { ViewException } from '../exceptions/view.exception';
-import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
-import { DatasetListItemDTO } from '../dtos/dataset-list-item';
-
-import { StatsWalesApi } from './stats-wales-api';
+import { appConfig } from '../src/config';
+import { HttpMethod } from '../src/enums/http-method';
+import { Locale } from '../src/enums/locale';
+import { SourceType } from '../src/enums/source-type';
+import { ApiException } from '../src/exceptions/api.exception';
+import { ViewException } from '../src/exceptions/view.exception';
+import { SourceAssignmentDTO } from '../src/dtos/source-assignment-dto';
+import { DatasetListItemDTO } from '../src/dtos/dataset-list-item';
+import { StatsWalesApi } from '../src/services/stats-wales-api';
 
 describe('StatsWalesApi', () => {
     let statsWalesApi: StatsWalesApi;


### PR DESCRIPTION
This PR implements measures and data cube previews in the publisher journey.  It adds the ability to download the cube in multiple formats including CSV, Excel and Parquet as well as downloading the raw cube in duckdb format.

Measures are added as a look up table upload in the measures lookup table format.

The preview page currently lacks the topics associated with the cube due to a bug on the backend which doesn't currently pass the topics through in a user readable format.