### PR TITLE
Moved dataset routes to /developer

### DIFF
--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -1,6 +1,12 @@
-import { AuthenticatedRequest } from '../../interfaces/authenticated-request';
-import { ServiceContainer } from '../../interfaces/service-container';
+import { User } from '../../interfaces/user.interface';
+import { StatsWalesApi } from '../../services/stats-wales-api';
+import { Locale } from '../../enums/locale';
 
 declare module 'express-serve-static-core' {
-    interface Request extends ServiceContainer, AuthenticatedRequest {}
+    interface Request {
+        user?: User;
+        jwt?: string;
+        swapi: StatsWalesApi;
+        buildUrl: (path: string, locale: Locale | string, query?: Record<string, string>) => string;
+    }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { checkConfig } from './config/check-config';
 import { httpLogger, logger } from './utils/logger';
 import session from './middleware/session';
 import { ensureAuthenticated } from './middleware/ensure-authenticated';
+import { ensureDeveloper } from './middleware/ensure-developer';
 import { rateLimiter } from './middleware/rate-limiter';
 import { i18next, i18nextMiddleware } from './middleware/translation';
 import { skipMap } from './middleware/skip-map';
@@ -15,7 +16,7 @@ import { languageSwitcher } from './middleware/language-switcher';
 import { auth } from './routes/auth';
 import { healthcheck } from './routes/healthcheck';
 import { publish } from './routes/publish';
-import { dataset } from './routes/dataset';
+import { developer } from './routes/developer';
 import { errorHandler } from './routes/error-handler';
 import { homepage } from './routes/homepage';
 import { notFound } from './routes/not-found';
@@ -53,7 +54,7 @@ app.use('/assets', express.static(`${__dirname}/assets`));
 app.use('/healthcheck', rateLimiter, healthcheck);
 app.use('/:lang/auth', rateLimiter, auth);
 app.use('/:lang/publish', rateLimiter, ensureAuthenticated, publish);
-app.use('/:lang/dataset', rateLimiter, ensureAuthenticated, dataset);
+app.use('/:lang/developer', rateLimiter, ensureAuthenticated, ensureDeveloper, developer);
 app.use('/:lang', rateLimiter, ensureAuthenticated, homepage);
 
 // handle 404s

--- a/src/exceptions/forbidden.exception.ts
+++ b/src/exceptions/forbidden.exception.ts
@@ -1,0 +1,10 @@
+export class ForbiddenException extends Error {
+    constructor(
+        public message = 'Permission Denied',
+        public status = 403
+    ) {
+        super(message);
+        this.name = 'ForbiddenException';
+        this.status = status;
+    }
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,7 +26,8 @@
             "skip_to_content": "Skip to main content",
             "publish_dataset": "Publish a Dataset",
             "list_datasets": "List Datasets",
-            "logout": "Logout"
+            "logout": "Logout",
+            "developer": "Developer"
         }
     },
     "footer": {
@@ -829,11 +830,15 @@
             }
         }
     },
-    "view": {
+    "developer": {
+        "heading": "Developer Tools",
         "list": {
             "heading": "List Datasets",
             "details": "Details",
-            "tasklist": "Task List"
+            "tasklist": "Task List",
+            "error": {
+                "no_datasets": "No datasets are currently listed in the database.  If you need help please reach out to a member of the development team."
+            }
         },
         "display": {
             "heading": "Display a Dataset",
@@ -856,7 +861,12 @@
             "location": "Location",
             "filename": "Filename",
             "mime_type": "Mime Type",
-            "fact_tables": "Fact Tables"
+            "fact_tables": "Fact Tables",
+            "error": {
+                "no_dimensions": "This dataset has not been completed with dimensions",
+                "no_revisions": "This dataset has not been completed with revisions",
+                "no_description": "No description available"
+            }
         }
     },
 	"errors": {
@@ -874,16 +884,6 @@
             "multiple_datavalues": "You can only specify one column as containing data values",
             "multiple_footnotes": "You can only specify one column as containing notes",
             "dimension_creation_failed": "Something went wrong trying to create the dimensions.  Please try again."
-        },
-        "view": {
-            "list": {
-                "no_datasets": "No datasets are currently listed in the database.  If you need help please reach out to a member of the development team."
-            },
-            "display": {
-                "no_dimensions": "This dataset has not been completed with dimensions",
-                "no_revisions": "This dataset has not been completed with revisions",
-                "no_description": "No description available"
-            }
         },
         "preview": {
             "failed_to_get_preview": "We were unable to generate a preview of the uploaded CSV.  Is this a valid CSV?",
@@ -909,6 +909,7 @@
         },
         "not_found": "Page not found",
         "server_error": "An unknown error occcured, please try again later",
+        "forbidden": "You do not have permission to access this page",
         "dimension_reset": "Something went wrong trying to reset the dimension"
 	},
     "routes": {

--- a/src/interfaces/authenticated-request.ts
+++ b/src/interfaces/authenticated-request.ts
@@ -1,6 +1,0 @@
-import { User } from './user.interface';
-
-export interface AuthenticatedRequest {
-    user?: User;
-    jwt?: string;
-}

--- a/src/interfaces/service-container.ts
+++ b/src/interfaces/service-container.ts
@@ -1,7 +1,0 @@
-import { Locale } from '../enums/locale';
-import { StatsWalesApi } from '../services/stats-wales-api';
-
-export interface ServiceContainer {
-    swapi: StatsWalesApi;
-    buildUrl: (path: string, locale: Locale | string, query?: Record<string, string>) => string;
-}

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -4,4 +4,5 @@ export interface User {
     name: string;
     givenName?: string;
     familyName?: string;
+    isDeveloper?: boolean;
 }

--- a/src/middleware/ensure-authenticated.ts
+++ b/src/middleware/ensure-authenticated.ts
@@ -31,8 +31,13 @@ export const ensureAuthenticated = (req: Request, res: Response, next: NextFunct
         // store the token string in the request as we need it for Authorization header in API requests
         req.jwt = token;
 
-        // store the user object in the request for use in the frontend
-        req.user = decoded.user;
+        if (decoded.user) {
+            req.user = decoded.user;
+            // TODO: replace with role-based permissions are available
+            req.user.isDeveloper = /@marvell-consulting.com$/.test(decoded.user.email);
+            res.locals.isDeveloper = req.user.isDeveloper;
+        }
+
         res.locals.isAuthenticated = true;
         logger.info('user is authenticated');
     } catch (err) {

--- a/src/middleware/ensure-developer.ts
+++ b/src/middleware/ensure-developer.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { logger } from '../utils/logger';
+import { appConfig } from '../config';
+import { User } from '../interfaces/user.interface';
+import { ForbiddenException } from '../exceptions/forbidden.exception';
+
+const config = appConfig();
+
+export const ensureDeveloper = (req: Request, res: Response, next: NextFunction) => {
+    logger.debug(`checking if user is a developer...`);
+
+    try {
+        const user = req.user as User;
+        // TODO: replace with role based perms once available
+        if (!user || !user.email.includes('@marvell-consulting.com')) {
+            throw new ForbiddenException('user is not a developer');
+        }
+        logger.info('user is a developer');
+    } catch (err) {
+        next(err);
+    }
+
+    return next();
+};

--- a/src/middleware/services.ts
+++ b/src/middleware/services.ts
@@ -7,11 +7,10 @@ import { StatsWalesApi } from '../services/stats-wales-api';
 import { localeUrl } from './language-switcher';
 
 // initialise any request-scoped services required by the app and store them on the request object for later use
-// see interfaces/service-container.ts and @types/express/index.d.ts for details
+// see @types/express/index.d.ts for details
 export const initServices = (req: Request, res: Response, next: NextFunction): void => {
     if (!/^\/(public|css|assets)/.test(req.originalUrl)) {
-        const statsWalesApi = new StatsWalesApi(req.language as Locale, req.cookies.jwt);
-        req.swapi = statsWalesApi;
+        req.swapi = new StatsWalesApi(req.language as Locale, req.cookies.jwt);
         req.buildUrl = localeUrl; // for controllers
         res.locals.buildUrl = localeUrl; // for templates
         res.locals.url = req.originalUrl; // Allows the passing through of the URL

--- a/src/routes/developer.ts
+++ b/src/routes/developer.ts
@@ -13,18 +13,18 @@ import { FactTableDTO } from '../dtos/fact-table';
 import { generateSequenceForNumber } from '../utils/pagination';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 
-export const dataset = Router();
+export const developer = Router();
 
-dataset.get('/', async (req: Request, res: Response, next: NextFunction) => {
+developer.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const results: ResultsetWithCount<DatasetListItemDTO> = await req.swapi.getActiveDatasetList();
-        res.render('dataset/list', { datasets: results.data });
+        res.render('developer/list', { datasets: results.data });
     } catch (err) {
         next(err);
     }
 });
 
-dataset.get('/:datasetId', fetchDataset, async (req: Request, res: Response, next: NextFunction) => {
+developer.get('/:datasetId', fetchDataset, async (req: Request, res: Response, next: NextFunction) => {
     const datasetId = res.locals.datasetId;
     const page: number = Number.parseInt(req.query.page_number as string, 10) || 1;
     const pageSize: number = Number.parseInt(req.query.page_size as string, 10) || 100;
@@ -44,10 +44,10 @@ dataset.get('/:datasetId', fetchDataset, async (req: Request, res: Response, nex
 
     // eslint-disable-next-line require-atomic-updates
     res.locals.pagination = generateSequenceForNumber(datasetView?.current_page, datasetView?.total_pages);
-    res.render('dataset/data', datasetView);
+    res.render('developer/data', datasetView);
 });
 
-dataset.get(
+developer.get(
     '/:datasetId/import/:factTableId',
     fetchDataset,
     async (req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/error-handler.ts
+++ b/src/routes/error-handler.ts
@@ -14,6 +14,11 @@ export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: R
             res.redirect(req.buildUrl(`/auth/login`, req.language));
             break;
 
+        case 403:
+            logger.error('403 error detected');
+            res.render('errors/forbidden');
+            break;
+
         case 404:
             logger.error(`404 error detected for ${req.originalUrl}, rendering not-found page`);
             res.status(404);

--- a/src/views/developer/data.ejs
+++ b/src/views/developer/data.ejs
@@ -4,33 +4,33 @@
         <!-- <a href="#" class="govuk-back-link">Back</a> -->
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <% if (locals?.data) { %>
-                <h1 class="govuk-heading-xl"><%- t('view.display.heading') %></h1>
+                <h1 class="govuk-heading-xl"><%- t('developer.display.heading') %></h1>
 
                 <%= include('../partials/error-handler') %>
 
                 <div class="govuk-tabs" data-module="govuk-tabs">
                     <h2 class="govuk-tabs__title">
-                        <%= t('view.display.contents') %>
+                        <%= t('developer.display.contents') %>
                     </h2>
                     <ul class="govuk-tabs__list">
                         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
                             <a class="govuk-tabs__tab" href="#summary">
-                                <%= t('view.display.summary') %>
+                                <%= t('developer.display.summary') %>
                             </a>
                         </li>
                         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
                             <a class="govuk-tabs__tab" href="#dimension">
-                                <%= t('view.display.dimension') %>
+                                <%= t('developer.display.dimension') %>
                             </a>
                         </li>
                         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
                             <a class="govuk-tabs__tab" href="#revision">
-                                <%= t('view.display.revision') %>
+                                <%= t('developer.display.revision') %>
                             </a>
                         </li>
                         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
                             <a class="govuk-tabs__tab" href="#fact_tables">
-                                <%= t('view.display.fact_tables') %>
+                                <%= t('developer.display.fact_tables') %>
                             </a>
                         </li>
                         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
@@ -40,68 +40,68 @@
                         </li>
                     </ul>
                     <div class="govuk-tabs__panel" id="summary">
-                        <h2 class="govuk-heading-m"><%= t('view.display.summary') %></h2>
-                        <p class="govuk-body-m"><strong><%- t('view.display.title') %></strong> <%= locals.dataset?.datasetInfo?.find((infos) => infos.language === i18n.language).title || `<${t('errors.name_missing')}>` %></p>
+                        <h2 class="govuk-heading-m"><%= t('developer.display.summary') %></h2>
+                        <p class="govuk-body-m"><strong><%- t('developer.display.title') %></strong> <%= locals.dataset?.datasetInfo?.find((infos) => infos.language === i18n.language).title || `<${t('errors.name_missing')}>` %></p>
 
-                        <p class="govuk-body-m"><strong><%- t('view.display.description') %></strong>
-                            <%= locals.dataset?.datasetInfo?.find((infos) => infos.language === i18n.language).description || `<${t('errors.view.display.no_description')}>` %>
+                        <p class="govuk-body-m"><strong><%- t('developer.display.description') %></strong>
+                            <%= locals.dataset?.datasetInfo?.find((infos) => infos.language === i18n.language).description || `<${t('developer.display.error.no_description')}>` %>
                         </p>
                     </div>
                     <div class="govuk-tabs__panel" id="dimension">
-                        <h2 class="govuk-heading-m"><%= t('view.display.dimension') %></h2>
+                        <h2 class="govuk-heading-m"><%= t('developer.display.dimension') %></h2>
                         <% if (locals.dataset?.dimensions?.length > 0) { %>
                             <% locals.dataset?.dimensions?.forEach((dim) => { %>
                                 <p class="govuk-body"><strong>ID:</strong> <%= dim.id %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.type') %>:</strong> <%= dim.type %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.start_revision') %>:</strong> <%= dim.start_revision_id %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.title') %>:</strong>
+                                <p class="govuk-body"><strong><%- t('developer.display.type') %>:</strong> <%= dim.type %></p>
+                                <p class="govuk-body"><strong><%- t('developer.display.start_revision') %>:</strong> <%= dim.start_revision_id %></p>
+                                <p class="govuk-body"><strong><%- t('developer.display.title') %>:</strong>
                                     <% const info = dim.dimensionInfo.find((info) => info.language === i18n.language) || dim.dimensionInfo.find((info) => info.language === i18n.language.split('-')[0]) %>
                                     <%= info.name %>
                                 </p>
-                                <p class="govuk-body-m"><strong><%- t('view.display.description') %></strong>
+                                <p class="govuk-body-m"><strong><%- t('developer.display.description') %></strong>
                                     <%= info.description %>
                                 </p>
-                                <p class="govuk-body-m"><strong><%- t('view.display.notes') %></strong>
+                                <p class="govuk-body-m"><strong><%- t('developer.display.notes') %></strong>
                                     <%= info.notes %>
                                 </p>
                                 <hr>
                             <% });%>
                         <% } else { %>
-                            <p class="govuk-body-l"><%= t('errors.view.display.no_dimensions') %></p>
+                            <p class="govuk-body-l"><%= t('developer.display.error.display.no_dimensions') %></p>
                         <% } %>
                     </div>
                     <div class="govuk-tabs__panel" id="revision">
-                        <h2 class="govuk-heading-m"><%= t('view.display.revision') %></h2>
+                        <h2 class="govuk-heading-m"><%= t('developer.display.revision') %></h2>
                         <% if (locals.dataset?.revisions?.length > 0) { %>
                             <% locals.dataset?.revisions?.forEach((rev) => { %>
                                 <p class="govuk-body"><strong>ID:</strong> <%= rev.id %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.index') %>:</strong> <%= rev.revision_index %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.created_at') %>:</strong> <%= rev.created_at %></p>
-                                <p class="govuk-body"><strong><%- t('view.display.created_by') %>:</strong> <%= rev.created_by %></p>
+                                <p class="govuk-body"><strong><%- t('developer.display.index') %>:</strong> <%= rev.revision_index %></p>
+                                <p class="govuk-body"><strong><%- t('developer.display.created_at') %>:</strong> <%= rev.created_at %></p>
+                                <p class="govuk-body"><strong><%- t('developer.display.created_by') %>:</strong> <%= rev.created_by %></p>
                             <% });%>
                         <% } else { %>
-                            <p class="govuk-body-l"><%= t('errors.view.display.no_revisions') %></p>
+                            <p class="govuk-body-l"><%= t('developer.display.error.no_revisions') %></p>
                         <% } %>
                     </div>
                     <div class="govuk-tabs__panel" id="fact_tables">
-                        <h2 class="govuk-heading-m"><%= t('view.display.fact_tables') %></h2>
+                        <h2 class="govuk-heading-m"><%= t('developer.display.fact_tables') %></h2>
                         <% if (locals.dataset?.revisions?.length > 0) { %>
                             <% locals.dataset?.revisions?.forEach((rev) => { %>
                                 <% rev.fact_tables?.forEach((factTable) => { %>
                                     <p class="govuk-body"><strong>ID:</strong> <%= factTable.id %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.filename') %>:</strong> <%= factTable.filename %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.original_filename') %>:</strong> <%= factTable.original_filename %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.mime_type') %>:</strong> <%= factTable.mime_type %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.filetype') %>:</strong> <%= factTable.file_type %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.upload_at') %>:</strong> <%= factTable.uploaded_at %></p>
-                                    <p class="govuk-body"><strong><%= t('view.display.download') %>:</strong>
+                                    <p class="govuk-body"><strong><%= t('developer.display.filename') %>:</strong> <%= factTable.filename %></p>
+                                    <p class="govuk-body"><strong><%= t('developer.display.original_filename') %>:</strong> <%= factTable.original_filename %></p>
+                                    <p class="govuk-body"><strong><%= t('developer.display.mime_type') %>:</strong> <%= factTable.mime_type %></p>
+                                    <p class="govuk-body"><strong><%= t('developer.display.filetype') %>:</strong> <%= factTable.file_type %></p>
+                                    <p class="govuk-body"><strong><%= t('developer.display.upload_at') %>:</strong> <%= factTable.uploaded_at %></p>
+                                    <p class="govuk-body"><strong><%= t('developer.display.download') %>:</strong>
                                         <a href="<%= buildUrl(`/dataset/${locals.datasetId}/import/${factTable.id}`, i18n.language) %>">
-                                            <i class="fa-solid fa-download"></i> <%= t('view.display.download_file') %>
+                                            <i class="fa-solid fa-download"></i> <%= t('developer.display.download_file') %>
                                         </a></p>
                                 <% }); %>
                             <% });%>
                         <% } else { %>
-                            <p class="govuk-body-l"><%= t('errors.view.display.no_revisions') %></p>
+                            <p class="govuk-body-l"><%= t('developer.display.error.no_revisions') %></p>
                         <% } %>
                     </div>
                     <div class="govuk-tabs__panel" id="json">

--- a/src/views/developer/list.ejs
+++ b/src/views/developer/list.ejs
@@ -3,14 +3,14 @@
 <div class="govuk-width-container app-width-container">
     <!-- <a href="#" class="govuk-back-link">Back</a> -->
     <main class="govuk-main-wrapper" id="main-content" role="main">
-        <h1 class="govuk-heading-xl"><%= t('view.list.heading') %></h1>
+        <h1 class="govuk-heading-xl"><%= t('developer.heading') %></h1>
         <% if (locals?.datasets && locals?.datasets.length > 0) {%>
             <ul class="govuk-list">
             <% locals?.datasets.forEach(function(dataset) { %>
                 <li>
                     <span><strong><%= dataset.title %>:</strong></span>
-                    <span><a href="/<%= i18n.language %>/publish/<%= dataset.id %>/tasklist" class="govuk-link"><%= t('view.list.tasklist') %></a></span>
-                    <span><a href="/<%= i18n.language %>/dataset/<%= dataset.id %>" class="govuk-link"><%= t('view.list.details') %> <i class="fa-solid fa-file-csv"></i></a></span>
+                    <span><a href="/<%= i18n.language %>/publish/<%= dataset.id %>/tasklist" class="govuk-link"><%= t('developer.list.tasklist') %></a></span>
+                    <span><a href="/<%= i18n.language %>/developer/<%= dataset.id %>" class="govuk-link"><%= t('developer.list.details') %> <i class="fa-solid fa-file-csv"></i></a></span>
                 </li>
             <% }); %>
             </ul>

--- a/src/views/errors/forbidden.ejs
+++ b/src/views/errors/forbidden.ejs
@@ -2,7 +2,7 @@
 
 <div class="govuk-width-container app-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
-      <h1 class="govuk-heading-xl"><%- t('errors.server_error') %></h1>
+      <h1 class="govuk-heading-xl"><%- t('errors.forbidden') %></h1>
   </main>
 </div>
 

--- a/src/views/errors/not-found.ejs
+++ b/src/views/errors/not-found.ejs
@@ -1,7 +1,6 @@
 <%- include("../partials/header"); %>
 
 <div class="govuk-width-container app-width-container">
-  <!-- <a href="#" class="govuk-back-link">Back</a> -->
   <main class="govuk-main-wrapper" id="main-content" role="main">
       <h1 class="govuk-heading-xl"><%- t('errors.not_found') %></h1>
   </main>

--- a/src/views/homepage.ejs
+++ b/src/views/homepage.ejs
@@ -56,8 +56,6 @@
                     <% if (locals.total_pages > 1) { %>
                         <%- include("partials/pagination"); %>
                     <% } %>
-                <% } else { %>
-                    nodata
                 <% } %>
             </div>
         </div>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -62,21 +62,9 @@
                         <%= t('header.navigation.menu') %>
                     </button>
                     <ul id="navigation" class="govuk-header__navigation-list">
-                        <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-                            <a class="govuk-header__link" href="/<%= i18n.language %>/publish">
-                                <%= t('header.navigation.publish_dataset') %>
-                            </a>
-                        </li>
-                        <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-                            <a class="govuk-header__link"
-                                href="/<%= i18n.language %>/dataset">
-                                <%= t('header.navigation.list_datasets') %>
-                            </a>
-                        </li>
                         <% if (locals?.isAuthenticated) { %>
                             <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-                                <a class="govuk-header__link"
-                                href="/<%= i18n.language %>/auth/logout">
+                                <a class="govuk-header__link" href="/<%= i18n.language %>/auth/logout">
                                     <%= t('header.navigation.logout') %>
                                 </a>
                             </li>
@@ -92,6 +80,13 @@
                                 </a>
                             <% } %>
                         </li>
+                        <% if (locals?.isDeveloper) { %>
+                            <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+                                <a class="govuk-header__link" href="/<%= i18n.language %>/developer">
+                                    <%= t('header.navigation.developer') %>
+                                </a>
+                            </li>
+                        <% } %>
                     </ul>
                 </nav>
             </div>

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -36,7 +36,7 @@ describe('Error handling', () => {
   test('should delete the jwt cookie and redirect to login page after logout', async () => {
     mockBackend.use(http.get('http://localhost:3001/dataset/active', () => new HttpResponse(null, { status: 401 })));
 
-    const res = await request(app).get('/en-GB/dataset');
+    const res = await request(app).get('/en-GB');
     const jwtCookie = parseCookies(res.headers['set-cookie']).find((cookie) => cookie.name === 'jwt');
 
     expect(res.status).toBe(302);
@@ -52,14 +52,14 @@ describe('Error handling', () => {
 
   test('should render the error page for 500s', async () => {
     mockBackend.use(http.get('http://localhost:3001/dataset/active', () => new HttpResponse(null, { status: 500 })));
-    const res = await request(app).get('/en-GB/dataset');
+    const res = await request(app).get('/en-GB');
     expect(res.status).toBe(500);
     expect(res.text).toContain(t('errors.server_error', { lng: Locale.English }));
   });
 
   test('should render the error page for everything else', async () => {
     mockBackend.use(http.get('http://localhost:3001/dataset/active', () => HttpResponse.error()));
-    const res = await request(app).get('/en-GB/dataset');
+    const res = await request(app).get('/en-GB');
     expect(res.status).toBe(500);
     expect(res.text).toContain(t('errors.server_error', { lng: Locale.English }));
   });


### PR DESCRIPTION
Moved the dev pages (dataset list and dataset details) under `/developer` and limited access to those with a Marvell email until we have user roles.