### PR TITLE
FIX: SW-366 - move cleanup of old fact table to upload

### DIFF
--- a/src/views/publish/preview.ejs
+++ b/src/views/publish/preview.ejs
@@ -92,7 +92,7 @@
                 </div>
             </div>
 
-            <%- include("../partials/pagination", t, locals.current_page, locals.total_records, locals.pagaination); %>
+            <%- include("../partials/pagination"); %>
 
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">


### PR DESCRIPTION
The previous upload was being deleted before a new one was uploaded, meaning the user could be left in a state of having no uploaded fact table.

This PR moves the removal of the old fact table to happen once we upload a new one.