### PR TITLE
Fix: Updated beta banner content

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,7 +20,7 @@
     "header": {
         "product_name": "StatsWales V3.0",
         "beta": "Beta",
-        "feedback": "You’re viewing a new version of Stats Wales. <a href=\"mailto:{{support_email}}\">Get support</a>.",
+        "feedback": "You’re viewing a new version of StatsWales. Get support at <a href=\"mailto:{{support_email}}\">{{support_email}}</a>.",
         "navigation": {
             "menu": "Menu",
             "skip_to_content": "Skip to main content",
@@ -931,7 +931,7 @@
             "heading": "StatsWales",
             "phase_banner": {
                 "beta": "Beta",
-                "feedback": "You're viewing a new version of StatsWales. <a class=\"govuk-link\" href=\"{{feedback_url}}\" target=\"_blank\">Give feedback (opens in new tab)</a>."
+                "feedback": "You’re viewing a new version of StatsWales"
             }
         },
         "list": {


### PR DESCRIPTION
As per design review, support link text updated.

Consumer side:
> You’re viewing a new version of StatsWales

Publisher side:
> You’re viewing a new version of StatsWales. Get support at {{support_email}}.