### PR TITLE
SW-383: Add cancel button to all pages (return to tasklist)

### DIFF
--- a/src/views/publish/collection.ejs
+++ b/src/views/publish/collection.ejs
@@ -34,6 +34,7 @@
                             <textarea class="govuk-textarea <%= locals.errors?.find(e => e.field === 'collection') ? 'govuk-textarea--error' : '' %>" id="collection" name="collection" rows="4"><%= locals.collection %></textarea>
                         </div>
                         <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                        <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                     </form>
                 </div>
             </div>

--- a/src/views/publish/designation.ejs
+++ b/src/views/publish/designation.ejs
@@ -32,6 +32,7 @@
                         </div>
 
                         <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                        <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                     </form>
                 </div>
             </div>

--- a/src/views/publish/providers.ejs
+++ b/src/views/publish/providers.ejs
@@ -105,6 +105,7 @@
                                 </fieldset>
                             </div>
                             <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                            <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                         </form>
                     </div>
                 </div>
@@ -168,6 +169,7 @@
                                 </fieldset>
                             </div>
                             <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                            <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                         </form>
                     </div>
                 </div>

--- a/src/views/publish/quality.ejs
+++ b/src/views/publish/quality.ejs
@@ -71,6 +71,7 @@
                         </div>
 
                         <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                        <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                     </form>
                 </div>
             </div>

--- a/src/views/publish/related-links.ejs
+++ b/src/views/publish/related-links.ejs
@@ -66,7 +66,7 @@
                                 </fieldset>
                             </div>
                             <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
-                            <a class="govuk-button govuk-button--secondary" href="javascript:history.back()"><%= t('buttons.cancel')%></a>
+                            <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                         </form>
                     </div>
 

--- a/src/views/publish/topics.ejs
+++ b/src/views/publish/topics.ejs
@@ -40,6 +40,7 @@
             </fieldset>
           </div>
           <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+          <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
         </form>
       </div>
     </div>

--- a/src/views/publish/update-frequency.ejs
+++ b/src/views/publish/update-frequency.ejs
@@ -50,7 +50,7 @@
                         </div>
 
                         <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
-                        <a class="govuk-button govuk-button--secondary" href="javascript:history.back()"><%= t('buttons.cancel')%></a>
+                        <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
All metadata sections now have a cancel button that returns the user to the tasklist.