### PR TITLE
Add support for username only login (TEMP)

### DIFF
--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -1,6 +1,7 @@
 import { Level } from 'pino';
 
 import { Locale } from '../enums/locale';
+import { AuthProvider } from '../enums/auth-providers';
 
 import { AppEnv } from './env.enum';
 import { SessionStore } from './session-store.enum';
@@ -37,6 +38,7 @@ export interface AppConfig {
         maxRequests: number;
     };
     auth: {
+        providers: AuthProvider[];
         jwt: {
             secret: string;
             cookieDomain: string;

--- a/src/config/envs/ci.ts
+++ b/src/config/envs/ci.ts
@@ -1,3 +1,4 @@
+import { AuthProvider } from '../../enums/auth-providers';
 import { AppConfig } from '../app-config.interface';
 import { defineConfig } from '../define-config';
 import { AppEnv } from '../env.enum';
@@ -29,6 +30,7 @@ export function getCIConfig(): AppConfig {
             secure: false
         },
         auth: {
+            providers: [AuthProvider.EntraId, AuthProvider.Google],
             jwt: {
                 secret: 'mysecret',
                 cookieDomain: 'http://localhost'

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -40,6 +40,7 @@ export const getDefaultConfig = (): AppConfig => {
             maxRequests: 100
         },
         auth: {
+            providers: [],
             jwt: {
                 secret: process.env.JWT_SECRET!,
                 cookieDomain: process.env.JWT_COOKIE_DOMAIN!

--- a/src/config/envs/local.ts
+++ b/src/config/envs/local.ts
@@ -1,3 +1,4 @@
+import { AuthProvider } from '../../enums/auth-providers';
 import { AppConfig } from '../app-config.interface';
 import { defineConfig } from '../define-config';
 import { AppEnv } from '../env.enum';
@@ -29,6 +30,7 @@ export function getLocalConfig(): AppConfig {
             windowMs: -1 // disable rate limiting in local
         },
         auth: {
+            providers: [AuthProvider.EntraId, AuthProvider.Google, AuthProvider.Local],
             jwt: {
                 secret: process.env.JWT_SECRET || 'jwtsecret',
                 cookieDomain: 'http://localhost'

--- a/src/config/envs/staging.ts
+++ b/src/config/envs/staging.ts
@@ -1,3 +1,4 @@
+import { AuthProvider } from '../../enums/auth-providers';
 import { AppConfig } from '../app-config.interface';
 import { defineConfig } from '../define-config';
 import { AppEnv } from '../env.enum';
@@ -12,6 +13,7 @@ export function getStagingConfig(): AppConfig {
             store: SessionStore.Redis
         },
         auth: {
+            providers: [AuthProvider.EntraId, AuthProvider.Google, AuthProvider.Local],
             jwt: {
                 cookieDomain: process.env.BACKEND_URL!.replace('statswales-develop-backend.', '')
             }

--- a/src/enums/auth-providers.ts
+++ b/src/enums/auth-providers.ts
@@ -1,0 +1,6 @@
+export enum AuthProvider {
+    Jwt = 'jwt',
+    Google = 'google',
+    EntraId = 'entraid',
+    Local = 'local'
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,12 +46,21 @@
         "heading": "Login",
         "buttons": {
             "entraid": "Microsoft",
-            "google": "Google"
+            "google": "Google",
+            "local": "Form"
         },
         "error": {
             "summary_title": "There is a problem",
             "generic": "You could not be logged in. Please try again later.",
             "expired": "Your session has expired. Please log in again."
+        },
+        "form": {
+            "notice": "This temporary login form is for demo purposes only, and will not be part of the final service.",
+            "username": {
+                "label": "Username",
+                "error": "Please enter your username"
+            },
+            "submit": "Login"
         }
     },
     "homepage": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,7 +55,8 @@
             "expired": "Your session has expired. Please log in again."
         },
         "form": {
-            "notice": "This temporary login form is for demo purposes only, and will not be part of the final service.",
+            "notice_1": "The username we've given you is temporary. You'll only be able to log in with it whilst we run this round of testing.",
+            "notice_2": "Do not upload any sensitive data or data that other StatsWales users should not have access to.",
             "username": {
                 "label": "Username",
                 "error": "Please enter your username"

--- a/src/views/auth/local.ejs
+++ b/src/views/auth/local.ejs
@@ -1,0 +1,37 @@
+<%- include("../partials/header"); %>
+
+<div class="govuk-width-container app-width-container">
+	<main class="govuk-main-wrapper" id="main-content" role="main">
+
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+
+				<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+					<div class="govuk-notification-banner__header">
+						<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+					</div>
+					<div class="govuk-notification-banner__content">
+						<p class="govuk-notification-banner__heading">
+							<%= t('login.form.notice') %>
+						</p>
+					</div>
+				</div>
+
+				<form method="post">
+					<div class="govuk-form-group">
+							<label class="govuk-label govuk-label--m" for="username"><%= t('login.form.username.label') %></label>
+							<% if(locals.errors?.find(e => e.field === 'username')) { %>
+									<p id="quality-error" class="govuk-error-message"><%= t('login.form.username.error') %></p>
+							<% } %>
+							<input class="govuk-input <%= locals.errors?.find(e => e.field === 'username') ? 'govuk-input--error' : '' %>" id="username" name="username" type="text" value="<%= locals.username %>">
+					</div>
+					<button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+				</form>
+
+			</div>
+		</div>
+
+	</main>
+</div>
+
+<%- include("../partials/footer"); %>

--- a/src/views/auth/local.ejs
+++ b/src/views/auth/local.ejs
@@ -11,9 +11,8 @@
 						<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
 					</div>
 					<div class="govuk-notification-banner__content">
-						<p class="govuk-notification-banner__heading">
-							<%= t('login.form.notice') %>
-						</p>
+						<p class="govuk-notification-banner__heading"><%= t('login.form.notice_1') %></p>
+						<p class="govuk-notification-banner__heading"><%= t('login.form.notice_2') %></p>
 					</div>
 				</div>
 

--- a/src/views/auth/login.ejs
+++ b/src/views/auth/login.ejs
@@ -22,8 +22,9 @@
 		<% } %>
 
 		<div class="govuk-button-group">
-			<a href="/<%= i18n.language %>/auth/entraid" class="govuk-button"><%= t('login.buttons.entraid') %></a>
-			<a href="/<%= i18n.language %>/auth/google" class="govuk-button"><%= t('login.buttons.google') %></a>
+			<% for (const provider of providers) { %>
+				<a href="<%= `/${i18n.language}/auth/${provider}` %>" class="govuk-button"><%= t(`login.buttons.${provider}`) %></a>
+			<% } %>
 		</div>
 	</main>
 </div>


### PR DESCRIPTION
This adds an incredibly basic login form that takes just a username and redirects the user to the backend for the user check. 

**IT IS NOT SECURE and is not intended to be**

This is purely a temporary workaround for testing purposes until we can authenticate WG users via their own EntraID.

To be removed once the testing session is complete.

![Screenshot 2025-01-31 at 14 37 27](https://github.com/user-attachments/assets/ae0765e2-f5c6-4e09-896f-81e220c3adce)


