### PR TITLE
Simplify the consumer list route

### DIFF
--- a/src/routes/consumer.ts
+++ b/src/routes/consumer.ts
@@ -5,7 +5,7 @@ import { fetchPublishedDataset } from '../middleware/fetch-dataset';
 
 export const consumer = Router();
 
-consumer.get('/list', listPublishedDatasets);
+consumer.get('/', listPublishedDatasets);
 
 consumer.get('/:datasetId', fetchPublishedDataset, viewPublishedDataset);
 


### PR DESCRIPTION
Consumer dataset list route changed from

`/en-GB/published/list` to just `/en-GB/published`