### PR TITLE
SW-430: fix broken team selection

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -1799,9 +1799,8 @@ export const provideOrganisation = async (req: Request, res: Response, next: Nex
         organisations = await req.pubapi.getAllOrganisations();
         teams = await req.pubapi.getAllTeams();
 
-        if (dataset.team_id) {
-            const datasetTeam = teams.find((team) => team.id === dataset.team_id)!;
-            values = { organisation: datasetTeam.organisation_id!, team: datasetTeam.id };
+        if (dataset.team.length > 0) {
+            values = { organisation: dataset.team[0].organisation_id, team: dataset.team[0].id };
         }
 
         if (req.method === 'POST') {


### PR DESCRIPTION
A change was made at some point to `DatasetDTO` that removed the `team_id` prop, which meant the code that pre-populated the selection on the form was not executing.

