### PR TITLE
Improved tasklist performance

### DIFF
--- a/src/dtos/lookup-table.ts
+++ b/src/dtos/lookup-table.ts
@@ -1,7 +1,5 @@
 export class LookupTableDTO {
     id: string;
-    dimension_id?: string;
-    measure_id?: string;
     mime_type: string;
     filename: string;
     file_type: string;

--- a/src/dtos/task-list-state.ts
+++ b/src/dtos/task-list-state.ts
@@ -1,11 +1,10 @@
 import { TaskStatus } from '../enums/task-status';
-
-import { DimensionState } from './dimension-state';
+import { DimensionStatus } from '../interfaces/dimension-status';
 
 export interface TaskListState {
     datatable: TaskStatus;
-    measure?: DimensionState;
-    dimensions: DimensionState[];
+    measure?: DimensionStatus;
+    dimensions?: DimensionStatus[];
 
     metadata: {
         title: TaskStatus;

--- a/src/interfaces/dimension-status.ts
+++ b/src/interfaces/dimension-status.ts
@@ -1,6 +1,7 @@
 import { TaskStatus } from '../enums/task-status';
 
-export interface DimensionState {
+export interface DimensionStatus {
+    id: string;
     name: string;
     status: TaskStatus;
     type: string;

--- a/src/middleware/fetch-dataset.ts
+++ b/src/middleware/fetch-dataset.ts
@@ -5,7 +5,7 @@ import { getLatestRevision, getDataTable } from '../utils/latest';
 import { logger } from '../utils/logger';
 import { hasError, datasetIdValidator } from '../validators';
 
-export const fetchDataset = async (req: Request, res: Response, next: NextFunction) => {
+export const fetchFullDataset = async (req: Request, res: Response, next: NextFunction) => {
     const datasetIdError = await hasError(datasetIdValidator(), req);
 
     if (datasetIdError) {
@@ -15,11 +15,37 @@ export const fetchDataset = async (req: Request, res: Response, next: NextFuncti
     }
 
     try {
-        const dataset = await req.pubapi.getDataset(req.params.datasetId);
+        const dataset = await req.pubapi.getFullDataset(req.params.datasetId);
         res.locals.datasetId = dataset.id;
         res.locals.dataset = dataset;
         res.locals.revision = getLatestRevision(dataset);
         res.locals.dataTable = getDataTable(res.locals.revision);
+    } catch (err: any) {
+        if (err.status === 401) {
+            next(err);
+            return;
+        }
+        next(new NotFoundException('errors.dataset_missing'));
+        return;
+    }
+
+    next();
+};
+
+export const fetchLimitedDataset = async (req: Request, res: Response, next: NextFunction) => {
+    const datasetIdError = await hasError(datasetIdValidator(), req);
+
+    if (datasetIdError) {
+        logger.error('Invalid or missing datasetId');
+        next(new NotFoundException('errors.dataset_missing'));
+        return;
+    }
+
+    try {
+        const dataset = await req.pubapi.getLimitedDataset(req.params.datasetId);
+        res.locals.datasetId = dataset.id;
+        res.locals.dataset = dataset;
+        res.locals.revision = getLatestRevision(dataset);
     } catch (err: any) {
         if (err.status === 401) {
             next(err);

--- a/src/routes/developer.ts
+++ b/src/routes/developer.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream';
 import { Router, Request, Response, NextFunction } from 'express';
 
 import { ViewDTO } from '../dtos/view-dto';
-import { fetchDataset } from '../middleware/fetch-dataset';
+import { fetchFullDataset } from '../middleware/fetch-dataset';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { logger } from '../utils/logger';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item';
@@ -24,7 +24,7 @@ developer.get('/', async (req: Request, res: Response, next: NextFunction) => {
     }
 });
 
-developer.get('/:datasetId', fetchDataset, async (req: Request, res: Response, next: NextFunction) => {
+developer.get('/:datasetId', fetchFullDataset, async (req: Request, res: Response, next: NextFunction) => {
     const datasetId = res.locals.datasetId;
     const page: number = Number.parseInt(req.query.page_number as string, 10) || 1;
     const pageSize: number = Number.parseInt(req.query.page_size as string, 10) || 100;
@@ -49,7 +49,7 @@ developer.get('/:datasetId', fetchDataset, async (req: Request, res: Response, n
 
 developer.get(
     '/:datasetId/import/:factTableId',
-    fetchDataset,
+    fetchFullDataset,
     async (req: Request, res: Response, next: NextFunction) => {
         const dataset = res.locals.dataset;
         const importIdError = await hasError(factTableIdValidator(), req);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import multer from 'multer';
 
-import { fetchDataset } from '../middleware/fetch-dataset';
+import { fetchFullDataset, fetchLimitedDataset } from '../middleware/fetch-dataset';
 import {
     start,
     provideTitle,
@@ -56,110 +56,110 @@ publish.post('/title', upload.none(), provideTitle);
 
 publish.get('/:datasetId', redirectToTasklist);
 
-publish.get('/:datasetId/title', fetchDataset, provideTitle);
-publish.post('/:datasetId/title', fetchDataset, upload.none(), provideTitle);
+publish.get('/:datasetId/title', fetchFullDataset, provideTitle);
+publish.post('/:datasetId/title', fetchFullDataset, upload.none(), provideTitle);
 
-publish.get('/:datasetId/upload', fetchDataset, uploadFile);
-publish.post('/:datasetId/upload', fetchDataset, upload.single('csv'), uploadFile);
+publish.get('/:datasetId/upload', fetchFullDataset, uploadFile);
+publish.post('/:datasetId/upload', fetchFullDataset, upload.single('csv'), uploadFile);
 
-publish.get('/:datasetId/preview', fetchDataset, factTablePreview);
-publish.post('/:datasetId/preview', fetchDataset, upload.none(), factTablePreview);
+publish.get('/:datasetId/preview', fetchFullDataset, factTablePreview);
+publish.post('/:datasetId/preview', fetchFullDataset, upload.none(), factTablePreview);
 
-publish.get('/:datasetId/sources', fetchDataset, sources);
-publish.post('/:datasetId/sources', fetchDataset, upload.none(), sources);
+publish.get('/:datasetId/sources', fetchFullDataset, sources);
+publish.post('/:datasetId/sources', fetchFullDataset, upload.none(), sources);
 
 /* Tasklist */
-publish.get('/:datasetId/tasklist', fetchDataset, taskList);
-publish.post('/:datasetId/tasklist', fetchDataset, upload.none(), taskList);
+publish.get('/:datasetId/tasklist', fetchLimitedDataset, taskList);
+publish.post('/:datasetId/tasklist', fetchLimitedDataset, upload.none(), taskList);
 
 /* Cube Preview */
-publish.get('/:datasetId/cube-preview', fetchDataset, cubePreview);
-publish.get('/:datasetId/cube-preview/download', fetchDataset, downloadDataset);
+publish.get('/:datasetId/cube-preview', fetchFullDataset, cubePreview);
+publish.get('/:datasetId/cube-preview/download', fetchFullDataset, downloadDataset);
 
 /* Measure creation */
-publish.get('/:datasetId/measure', fetchDataset, measurePreview);
-publish.post('/:datasetId/measure', fetchDataset, upload.single('csv'), measurePreview);
-publish.get('/:datasetId/measure/review', fetchDataset, measureReview);
-publish.post('/:datasetId/measure/review', fetchDataset, measureReview);
+publish.get('/:datasetId/measure', fetchFullDataset, measurePreview);
+publish.post('/:datasetId/measure', fetchFullDataset, upload.single('csv'), measurePreview);
+publish.get('/:datasetId/measure/review', fetchFullDataset, measureReview);
+publish.post('/:datasetId/measure/review', fetchFullDataset, measureReview);
 
 /* Dimension creation */
-publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset, fetchDimensionPreview);
-publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset, fetchDimensionPreview);
+publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchFullDataset, fetchDimensionPreview);
+publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchFullDataset, fetchDimensionPreview);
 
 /* lookup table handlers */
-publish.get('/:datasetId/lookup/:dimensionId', fetchDataset, uploadLookupTable);
-publish.post('/:datasetId/lookup/:dimensionId', fetchDataset, upload.single('csv'), uploadLookupTable);
-publish.get('/:datasetId/lookup/:dimensionId/review', fetchDataset, lookupReview);
-publish.post('/:datasetId/lookup/:dimensionId/review', fetchDataset, lookupReview);
+publish.get('/:datasetId/lookup/:dimensionId', fetchFullDataset, uploadLookupTable);
+publish.post('/:datasetId/lookup/:dimensionId', fetchFullDataset, upload.single('csv'), uploadLookupTable);
+publish.get('/:datasetId/lookup/:dimensionId/review', fetchFullDataset, lookupReview);
+publish.post('/:datasetId/lookup/:dimensionId/review', fetchFullDataset, lookupReview);
 
-publish.get('/:datasetId/time-period/:dimensionId', fetchDataset, fetchTimeDimensionPreview);
-publish.post('/:datasetId/time-period/:dimensionId', fetchDataset, fetchTimeDimensionPreview);
-publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset, pointInTimeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset, pointInTimeChooser);
+publish.get('/:datasetId/time-period/:dimensionId', fetchFullDataset, fetchTimeDimensionPreview);
+publish.post('/:datasetId/time-period/:dimensionId', fetchFullDataset, fetchTimeDimensionPreview);
+publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchFullDataset, pointInTimeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchFullDataset, pointInTimeChooser);
 
 /* Period of time flow */
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset, yearTypeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset, yearTypeChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset, yearFormat);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset, yearFormat);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset, periodType);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset, periodType);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset, quarterChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset, quarterChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset, monthChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset, monthChooser);
-publish.get('/:datasetId/time-period/:dimensionId/review', fetchDataset, periodReview);
-publish.post('/:datasetId/time-period/:dimensionId/review', fetchDataset, periodReview);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchFullDataset, yearTypeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchFullDataset, yearTypeChooser);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchFullDataset, yearFormat);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchFullDataset, yearFormat);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchFullDataset, periodType);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchFullDataset, periodType);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchFullDataset, quarterChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchFullDataset, quarterChooser);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchFullDataset, monthChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchFullDataset, monthChooser);
+publish.get('/:datasetId/time-period/:dimensionId/review', fetchFullDataset, periodReview);
+publish.post('/:datasetId/time-period/:dimensionId/review', fetchFullDataset, periodReview);
 
 /* Applies to all dimensions */
-publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset, dimensionName);
-publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset, dimensionName);
+publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchFullDataset, dimensionName);
+publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchFullDataset, dimensionName);
 
 /* Metadata */
-publish.get('/:datasetId/change', fetchDataset, changeData);
-publish.post('/:datasetId/change', fetchDataset, upload.none(), changeData);
+publish.get('/:datasetId/change', fetchFullDataset, changeData);
+publish.post('/:datasetId/change', fetchFullDataset, upload.none(), changeData);
 
-publish.get('/:datasetId/summary', fetchDataset, provideSummary);
-publish.post('/:datasetId/summary', fetchDataset, upload.none(), provideSummary);
+publish.get('/:datasetId/summary', fetchFullDataset, provideSummary);
+publish.post('/:datasetId/summary', fetchFullDataset, upload.none(), provideSummary);
 
-publish.get('/:datasetId/collection', fetchDataset, provideCollection);
-publish.post('/:datasetId/collection', fetchDataset, upload.none(), provideCollection);
+publish.get('/:datasetId/collection', fetchFullDataset, provideCollection);
+publish.post('/:datasetId/collection', fetchFullDataset, upload.none(), provideCollection);
 
-publish.get('/:datasetId/quality', fetchDataset, provideQuality);
-publish.post('/:datasetId/quality', fetchDataset, upload.none(), provideQuality);
+publish.get('/:datasetId/quality', fetchFullDataset, provideQuality);
+publish.post('/:datasetId/quality', fetchFullDataset, upload.none(), provideQuality);
 
-publish.get('/:datasetId/providers', fetchDataset, provideDataProviders);
-publish.post('/:datasetId/providers', fetchDataset, upload.none(), provideDataProviders);
+publish.get('/:datasetId/providers', fetchFullDataset, provideDataProviders);
+publish.post('/:datasetId/providers', fetchFullDataset, upload.none(), provideDataProviders);
 
-publish.get('/:datasetId/related', fetchDataset, provideRelatedLinks);
-publish.post('/:datasetId/related', fetchDataset, upload.none(), provideRelatedLinks);
+publish.get('/:datasetId/related', fetchFullDataset, provideRelatedLinks);
+publish.post('/:datasetId/related', fetchFullDataset, upload.none(), provideRelatedLinks);
 
-publish.get('/:datasetId/update-frequency', fetchDataset, provideUpdateFrequency);
-publish.post('/:datasetId/update-frequency', fetchDataset, upload.none(), provideUpdateFrequency);
+publish.get('/:datasetId/update-frequency', fetchFullDataset, provideUpdateFrequency);
+publish.post('/:datasetId/update-frequency', fetchFullDataset, upload.none(), provideUpdateFrequency);
 
-publish.get('/:datasetId/designation', fetchDataset, provideDesignation);
-publish.post('/:datasetId/designation', fetchDataset, upload.none(), provideDesignation);
+publish.get('/:datasetId/designation', fetchFullDataset, provideDesignation);
+publish.post('/:datasetId/designation', fetchFullDataset, upload.none(), provideDesignation);
 
-publish.get('/:datasetId/topics', fetchDataset, provideTopics);
-publish.post('/:datasetId/topics', fetchDataset, upload.none(), provideTopics);
+publish.get('/:datasetId/topics', fetchFullDataset, provideTopics);
+publish.post('/:datasetId/topics', fetchFullDataset, upload.none(), provideTopics);
 
 /* Publishing */
-publish.get('/:datasetId/schedule', fetchDataset, providePublishDate);
-publish.post('/:datasetId/schedule', fetchDataset, upload.none(), providePublishDate);
+publish.get('/:datasetId/schedule', fetchFullDataset, providePublishDate);
+publish.post('/:datasetId/schedule', fetchFullDataset, upload.none(), providePublishDate);
 
-publish.get('/:datasetId/organisation', fetchDataset, provideOrganisation);
-publish.post('/:datasetId/organisation', fetchDataset, upload.none(), provideOrganisation);
+publish.get('/:datasetId/organisation', fetchFullDataset, provideOrganisation);
+publish.post('/:datasetId/organisation', fetchFullDataset, upload.none(), provideOrganisation);
 
 /* Translations */
-publish.get('/:datasetId/translation/export', fetchDataset, exportTranslations);
-publish.get('/:datasetId/translation/import', fetchDataset, importTranslations);
-publish.post('/:datasetId/translation/import', fetchDataset, upload.single('csv'), importTranslations);
+publish.get('/:datasetId/translation/export', fetchFullDataset, exportTranslations);
+publish.get('/:datasetId/translation/import', fetchFullDataset, importTranslations);
+publish.post('/:datasetId/translation/import', fetchFullDataset, upload.single('csv'), importTranslations);
 
 /* Dataset Overview */
-publish.get('/:datasetId/overview', fetchDataset, overview);
-publish.post('/:datasetId/overview', fetchDataset, upload.none(), overview);
+publish.get('/:datasetId/overview', fetchFullDataset, overview);
+publish.post('/:datasetId/overview', fetchFullDataset, upload.none(), overview);
 
 /* Update Dataset */
-publish.get('/:datasetId/update', fetchDataset, createNewUpdate);
-publish.get('/:datasetId/update-type', fetchDataset, updateDatatable);
-publish.post('/:datasetId/update-type', fetchDataset, updateDatatable);
+publish.get('/:datasetId/update', fetchFullDataset, createNewUpdate);
+publish.get('/:datasetId/update-type', fetchFullDataset, updateDatatable);
+publish.post('/:datasetId/update-type', fetchFullDataset, updateDatatable);

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -99,9 +99,16 @@ export class PublisherApi {
         );
     }
 
-    public async getDataset(datasetId: string): Promise<DatasetDTO> {
-        logger.debug(`Fetching dataset: ${datasetId}`);
+    public async getFullDataset(datasetId: string): Promise<DatasetDTO> {
+        logger.debug(`Fetching full dataset: ${datasetId}`);
         return this.fetch({ url: `dataset/${datasetId}` }).then((response) => response.json() as unknown as DatasetDTO);
+    }
+
+    public async getLimitedDataset(datasetId: string): Promise<DatasetDTO> {
+        logger.debug(`Fetching limited dataset: ${datasetId}`);
+        return this.fetch({ url: `dataset/${datasetId}/limited` }).then(
+            (response) => response.json() as unknown as DatasetDTO
+        );
     }
 
     public uploadCSVToDataset(datasetId: string, file: Blob, filename: string): Promise<DatasetDTO> {

--- a/src/views/publish/tasklist.ejs
+++ b/src/views/publish/tasklist.ejs
@@ -23,7 +23,7 @@
         <ul class="govuk-task-list">
           <li class="govuk-task-list__item govuk-task-list__item--with-link">
             <div class="govuk-task-list__name-and-hint">
-              <% if (locals.revision.revision_index === 0 && !locals.revision.data_table) { %>
+              <% if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
                 <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/update-type`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>
@@ -51,14 +51,13 @@
               </div>
             </li>
           <% } %>
-          <% taskList.dimensions.forEach(function(dimension) { %>
-            <% const dim = locals.dimensions.find((d) => d.dimensionInfo.name === dimension.name) %>
+          <% taskList.dimensions?.forEach(function(dimension) { %>
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
                 <div class="govuk-task-list__name-and-hint">
                     <% if (dimension.type === 'time_period') { %>
-                      <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/time-period/${dim.id}`, i18n.language) %>"><%= dimension.name %></a>
+                      <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/time-period/${dimension.id}`, i18n.language) %>"><%= dimension.name %></a>
                     <% } else { %>
-                      <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/dimension-data-chooser/${dim.id}`, i18n.language) %>"><%= dimension.name %></a>
+                      <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/dimension-data-chooser/${dimension.id}`, i18n.language) %>"><%= dimension.name %></a>
                     <% } %>
                 </div>
                 <div class="govuk-task-list__status">

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -169,7 +169,7 @@ describe('PublisherApi', () => {
 
       mockResponse = Promise.resolve(new Response(JSON.stringify(dataset)));
 
-      const datasetDTO = await statsWalesApi.getDataset(datasetId);
+      const datasetDTO = await statsWalesApi.getFullDataset(datasetId);
 
       expect(fetchSpy).toHaveBeenCalledWith(`${baseUrl}/dataset/${datasetId}`, {
         method: HttpMethod.Get,


### PR DESCRIPTION
Paired with https://github.com/Marvell-Consulting/statswales-backend/pull/108.

Previously the tasklist was taking quite a while to load, and as it's the core of the publisher workflow, it results in a frustrating experience.

We do not need to load the full dataset with all relations just for the tasklist, so we have a new route with a minimal set of dataset relations loaded (currently metadata & revisions only). We could further improve this by only fetching the latest revision.