### PR TITLE
Fix measure preview/review following backend changes

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -446,6 +446,10 @@ export const measurePreview = async (req: Request, res: Response, next: NextFunc
         }
 
         const dataPreview = await req.pubapi.getMeasurePreview(res.locals.dataset.id);
+        let langCol = -1;
+        if (dataPreview.headers.find((header) => header.name.toLowerCase().indexOf('lang') > -1)) {
+            langCol = dataPreview.headers.findIndex((header) => header.name.toLowerCase().indexOf('lang') > -1);
+        }
         if (req.session.errors) {
             const errors = req.session.errors;
             req.session.errors = undefined;
@@ -453,11 +457,12 @@ export const measurePreview = async (req: Request, res: Response, next: NextFunc
             res.status(500);
             res.render('publish/measure-preview', {
                 ...dataPreview,
+                langCol,
                 measure,
                 errors
             });
         } else {
-            res.render('publish/measure-preview', { ...dataPreview, measure });
+            res.render('publish/measure-preview', { ...dataPreview, langCol, measure });
         }
     } catch (err) {
         logger.error('Failed to get dimension preview', err);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -255,17 +255,33 @@
                 "lookup_table": "Lookup Table:",
                 "description_en": "Description (English)",
                 "description_cy": "Description (Welsh)",
+                "description": "Description",
+                "decimals": "Decimal Places",
+                "hierarchy": "Hierarchy",
+                "language": "Language",
+                "reference": "Reference Value",
                 "sort": "Sort Order",
                 "sort_order": "Sort Order",
+                "notes": "Notes",
                 "notes_en": "Notes (English)",
                 "notes_cy": "Notes (Welsh)",
-                "decimal": "Decimal Value",
                 "format": "Format",
                 "measure_type": "Value Type"
             },
             "column_values": {
-                "1": "Yes",
-                "0": "No"
+                "null": "No",
+                "cy-gb": "Welsh",
+                "en-gb": "English",
+                "float": "Floating Point Number",
+                "decimal": "Decimal Number",
+                "integer": "Whole Number",
+                "long": "Big Whole Number",
+                "percentage": "Percentage",
+                "string": "Plain Text",
+                "text": "Plain Text",
+                "date": "Date",
+                "datetime": "Date and Time",
+                "time": "Time"
             }
         },
         "time_dimension_review": {

--- a/src/views/publish/measure-preview.ejs
+++ b/src/views/publish/measure-preview.ejs
@@ -46,10 +46,10 @@
                         <tr class="govuk-table__row">
                             <% locals.headers.forEach(function(cell, idx) { %>
                                 <th scope="col" class="govuk-table__header">
-                                    <% if (i18n.exists(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`)) { %>
-                                        <%= t(`publish.lookup_table_review.column_headers.${cell.name.toLowerCase()}`) %>
-                                    <% } else { %>
+                                    <% if (t(`publish.measure_review.column_headers.${cell.name.toLowerCase()}`) === `publish.measure_review.column_headers.${cell.name.toLowerCase()}`) { %>
                                         <%= cell.name %>
+                                    <% } else { %>
+                                        <%= t(`publish.measure_review.column_headers.${cell.name.toLowerCase()}`) %>
                                     <% } %>
                                 </th>
                             <% }); %>
@@ -57,13 +57,28 @@
                         </thead>
                         <tbody>
                         <% locals.data.forEach(function(row) { %>
+                            <% if (locals.langCol > -1 && row[locals.langCol] !== i18n.language.toLowerCase() ) return; %>
                             <tr>
                                 <% row.forEach(function(cell, index) { %>
-                                    <% if (locals.headers[index].source_type === 'line_number') { %>
-                                        <td class="govuk-table__cell line-number"><span class="linespan"><%= cell %></span></td>
-                                    <% } else { %>
-                                        <td class="govuk-table__cell"><%= cell %></td>
-                                    <% } %>
+                                    <td class="govuk-table__cell">
+                                        <% switch (locals.headers[index].name.toLowerCase()) {
+                                            case 'start_date':
+                                        case 'end_date': %>
+                                        <%= locals.dateFormat(locals.parseISO(cell.split('T')[0]), 'do MMMM yyyy') %>
+                                        <% break;
+                                        case 'date_type': %>
+                                        <%= t(`publish.measure_review.year_type.${cell}`) %>
+                                        <% break;
+                                        default: %>
+                                        <% if (cell) { %>
+                                            <% if (t(`publish.measure_review.column_values.${cell.toString().toLowerCase()}`) === `publish.measure_review.column_values.${cell.toString().toLowerCase()}`) { %>
+                                                <%= cell %>
+                                            <% } else { %>
+                                                <%= t(`publish.measure_review.column_values.${cell.toString().toLowerCase()}`) %>
+                                            <% } %>
+                                        <% } %>
+                                        <% } %>
+                                    </td>
                                 <% }); %>
                             </tr>
                         <% }); %>

--- a/src/views/publish/measure-review.ejs
+++ b/src/views/publish/measure-review.ejs
@@ -33,6 +33,7 @@
                         </thead>
                         <tbody>
                         <% locals.data.forEach(function(row) { %>
+                            <% if (locals.langCol > -1 && row[locals.langCol] !== i18n.language.toLowerCase() ) return; %>
                             <tr>
                                 <% row.forEach(function(cell, index) { %>
                                     <td class="govuk-table__cell">
@@ -44,11 +45,14 @@
                                         case 'date_type': %>
                                         <%= t(`publish.measure_review.year_type.${cell}`) %>
                                         <% break;
-                                        case 'decimals': %>
-                                        <%= t(`publish.measure_review.column_values.${cell}`) %>
-                                        <% break;
                                         default: %>
-                                        <%= cell %>
+                                            <% if (cell) { %>
+                                                <% if (t(`publish.measure_review.column_values.${cell.toString().toLowerCase()}`) === `publish.measure_review.column_values.${cell.toString().toLowerCase()}`) { %>
+                                                    <%= cell %>
+                                                <% } else { %>
+                                                    <%= t(`publish.measure_review.column_values.${cell.toString().toLowerCase()}`) %>
+                                                <% } %>
+                                            <% } %>
                                         <% } %>
                                     </td>
                                 <% }); %>


### PR DESCRIPTION
The backend changes meant the measure preview was having issues especially around null value display.  This fixes many of these issues and makes the table more presentable.  It also filters the table to only show the values for the displayed language rather than both languages.

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/7b582681-1298-44a6-8b73-a9c290abc1c5" />
