### PR TITLE
Fix not being able to select `-X` option in Quarter formats

### DIFF
--- a/src/views/publish/quarter-format.ejs
+++ b/src/views/publish/quarter-format.ejs
@@ -70,10 +70,10 @@
                                 </div>
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="quarter-format-7" name="quarterType" type="radio" <% if (locals.quarterType === '-X') { %>checked <% } %>value="-X">
-                                    <label class="govuk-label govuk-radios__label" for="quarter-format-6">
+                                    <label class="govuk-label govuk-radios__label" for="quarter-format-7">
                                         -x
                                     </label>
-                                    <div id="quarter-format-6-hint" class="govuk-hint govuk-radios__hint">
+                                    <div id="quarter-format-7-hint" class="govuk-hint govuk-radios__hint">
                                         <%- t('publish.quarter_format.example', { example: '-1' })%>
                                     </div>
                                 </div>


### PR DESCRIPTION
Wrong ID on the hint means that clicking on the hint results in the wrong radio button being selected as a result.  This PR updates the for and ID values.