### PR TITLE
SW-308: Move metadata to revision, various fixes

### DIFF
--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -7,7 +7,6 @@ import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 import { getPaginationProps } from '../utils/pagination';
 import { singleLangDataset } from '../utils/single-lang-dataset';
 import { getDatasetPreview } from '../utils/dataset-preview';
-import { getLatestPublishedRevision } from '../utils/revision';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { FileFormat } from '../enums/file-format';
 import { getDownloadHeaders } from '../utils/download-headers';
@@ -45,7 +44,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
 export const downloadPublishedDataset = async (req: Request, res: Response, next: NextFunction) => {
     logger.debug('downloading published dataset');
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    const revision = getLatestPublishedRevision(dataset);
+    const revision = dataset.published_revision;
 
     try {
         if (!dataset.live || !revision) {
@@ -53,7 +52,7 @@ export const downloadPublishedDataset = async (req: Request, res: Response, next
         }
 
         const format = req.query.format as FileFormat;
-        const headers = getDownloadHeaders(format, revision);
+        const headers = getDownloadHeaders(format, revision.id);
 
         if (!headers) {
             throw new NotFoundException('invalid file format');

--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -30,7 +30,7 @@ export const listPublishedDatasets = async (req: Request, res: Response, next: N
 
 export const viewPublishedDataset = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    const revision = getLatestPublishedRevision(dataset);
+    const revision = dataset.published_revision;
 
     if (!dataset.live || !revision) {
         next(new NotFoundException('no published revision found'));

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -2203,8 +2203,14 @@ export const overview = async (req: Request, res: Response, next: NextFunction) 
 
 export const createNewUpdate = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = res.locals.dataset;
-    await req.pubapi.createRevision(dataset.id);
-    res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
+
+    try {
+        await req.pubapi.createRevision(dataset.id);
+        res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
+    } catch (err) {
+        logger.error(err, `Could not create dataset update`);
+        res.redirect(req.buildUrl(`/publish/${dataset.id}/overview`, req.language));
+    }
 };
 
 export const updateDatatable = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -11,7 +11,7 @@ import { parse } from 'csv-parse';
 import {
     collectionValidator,
     dayValidator,
-    descriptionValidator,
+    summaryValidator,
     designationValidator,
     frequencyUnitValidator,
     frequencyValueValidator,
@@ -45,7 +45,7 @@ import { singleLangDataset } from '../utils/single-lang-dataset';
 import { Designation } from '../enums/designation';
 import { DurationUnit } from '../enums/duration-unit';
 import { RelatedLinkDTO } from '../dtos/related-link';
-import { DatasetProviderDTO } from '../dtos/dataset-provider';
+import { RevisionProviderDTO } from '../dtos/revision-provider';
 import { ProviderSourceDTO } from '../dtos/provider-source';
 import { generateSequenceForNumber } from '../utils/pagination';
 import { fileMimeTypeHandler } from '../utils/file-mimetype-handler';
@@ -75,9 +75,11 @@ export const dimensionColumnNameRegex = /^[a-zA-ZÀ-ž()\-_ ]+$/;
 
 export const provideTitle = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] = [];
-    const existingDataset = res.locals.dataset; // dataset does not exist the first time through
-    let title = existingDataset ? singleLangDataset(existingDataset, req.language)?.datasetInfo?.title : undefined;
+
+    // dataset will not exist the first time through
+    const existingDataset = res.locals.dataset ? singleLangDataset(res.locals.dataset, req.language) : undefined;
     const revisit = Boolean(existingDataset);
+    let title = existingDataset?.draft_revision?.metadata?.title;
 
     if (req.method === 'POST') {
         try {
@@ -93,7 +95,7 @@ export const provideTitle = async (req: Request, res: Response, next: NextFuncti
             }
 
             if (existingDataset) {
-                await req.pubapi.updateDatasetInfo(existingDataset.id, { title, language: req.language });
+                await req.pubapi.updateMetadata(existingDataset.id, { title, language: req.language });
                 res.redirect(req.buildUrl(`/publish/${existingDataset.id}/tasklist`, req.language));
             } else {
                 const dataset = await req.pubapi.createDataset(title, req.language);
@@ -110,10 +112,10 @@ export const provideTitle = async (req: Request, res: Response, next: NextFuncti
     res.render('publish/title', { title, revisit, errors });
 };
 
-export const uploadFile = async (req: Request, res: Response, next: NextFunction) => {
-    const { dataset, revision, dataTable } = res.locals;
-    let errors: ViewError[] = [];
+export const uploadDataTable = async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
     const revisit = dataset.dimensions?.length > 0;
+    let errors: ViewError[] = [];
 
     if (req.method === 'POST') {
         logger.debug('User is uploading a fact table.');
@@ -124,30 +126,12 @@ export const uploadFile = async (req: Request, res: Response, next: NextFunction
                 throw new Error();
             }
 
-            if (revisit && revision && dataTable) {
-                // cleanup previous fact table
-                await req.pubapi.removeFileImport(dataset.id, revision.id);
-            }
-
             const fileName = req.file.originalname;
             req.file.mimetype = fileMimeTypeHandler(req.file.mimetype, req.file.originalname);
             const fileData = new Blob([req.file.buffer], { type: req.file.mimetype });
+
             logger.debug('Sending file to backend.');
-            if (req.session.updateType) {
-                logger.info('Performing an update to the dataset');
-                await req.pubapi.uploadCSVToUpdateDataset(
-                    dataset.id,
-                    revision.id,
-                    fileData,
-                    fileName,
-                    req.session.updateType
-                );
-            } else {
-                await req.pubapi.uploadCSVToDataset(dataset.id, fileData, fileName);
-            }
-            // eslint-disable-next-line require-atomic-updates
-            req.session.updateType = undefined;
-            req.session.save();
+            await req.pubapi.uploadCSVToDataset(dataset.id, fileData, fileName);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/preview`, req.language));
             return;
         } catch (err) {
@@ -162,7 +146,11 @@ export const uploadFile = async (req: Request, res: Response, next: NextFunction
 };
 
 export const factTablePreview = async (req: Request, res: Response, next: NextFunction) => {
-    const { dataset, revision, dataTable } = res.locals;
+    const dataset = res.locals.dataset;
+    const revision = dataset.draft_revision;
+    const dataTable = revision?.data_table;
+    const revisit = Boolean(!dataset.fact_table.find((col: FactTableColumnDto) => col.type === 'unknown'));
+
     let errors: ViewError[] | undefined;
     let previewData: ViewDTO | undefined;
     let ignoredCount = 0;
@@ -174,10 +162,9 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
         return;
     }
 
-    // if sources have previously been assigned a type, this is a revisit
-    const revisit = Boolean(!dataset.fact_table.find((col: FactTableColumnDto) => col.type === 'unknown'));
     logger.debug(`User is confirming the fact table upload and source_type = ${req.session.updateType}`);
     if (req.method === 'POST') {
+        logger.debug(`User is confirming the fact table upload and source_type = ${req.session.updateType}`);
         try {
             if (revisit) {
                 switch (req.body.actionChooser) {
@@ -196,7 +183,7 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
                     if (revision.revision_index === 0) {
                         res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
                     } else {
-                        await req.pubapi.confirmFileImport(dataset.id, revision.id);
+                        await req.pubapi.confirmDataTable(dataset.id, revision.id);
                         res.redirect(req.buildUrl(`/publish/${dataset.id}/sources`, req.language));
                     }
                 } else if (revision.revision_index === 0) {
@@ -229,26 +216,32 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
 };
 
 export const sources = async (req: Request, res: Response, next: NextFunction) => {
-    const { dataset, revision } = res.locals;
+    const dataset = res.locals.dataset;
+    const revision = dataset.draft_revision;
+
     const factTable = dataset.fact_table.sort(
         (colA: FactTableColumnDto, colB: FactTableColumnDto) => colA.index - colB.index
     ) as FactTableColumnDto[];
+
     const revisit = factTable.filter((column: FactTableColumnDto) => column.type === SourceType.Unknown).length > 0;
+
     let error: ViewError | undefined;
     let errors: ViewError[] | undefined;
 
-    try {
-        if (!dataset || !revision || !factTable) {
-            logger.error('Fact table not found');
-            throw new Error('errors.preview.import_missing');
-        }
+    if (!dataset || !revision || !factTable) {
+        logger.error('Fact table not found');
+        next(new UnknownException('errors.preview.import_missing'));
+        return;
+    }
 
+    try {
         if (req.method === 'POST') {
             logger.debug('Validating the source definition');
-            const counts = { unknown: 0, dataValues: 0, footnotes: 0, measure: 0 };
+            const counts = { unknown: 0, dataValues: 0, footnotes: 0, measure: 0, time: 0 };
             const sourceAssignment: SourceAssignmentDTO[] = factTable.map((column: FactTableColumnDto) => {
                 const sourceType = req.body[`column-${column.index}`];
                 if (sourceType === SourceType.Unknown) counts.unknown++;
+                if (sourceType === SourceType.Time) counts.time++;
                 if (sourceType === SourceType.DataValues) counts.dataValues++;
                 if (sourceType === SourceType.NoteCodes) counts.footnotes++;
                 if (sourceType === SourceType.Measure) counts.measure++;
@@ -312,9 +305,9 @@ export const sources = async (req: Request, res: Response, next: NextFunction) =
 
 export const taskList = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = singleLangDataset(res.locals.dataset, req.language);
+    const revision = dataset.draft_revision!;
     const datasetStatus = getDatasetStatus(dataset);
     const publishingStatus = getPublishingStatus(dataset);
-    const revision = res.locals.revision;
 
     try {
         if (req.method === 'POST') {
@@ -332,7 +325,7 @@ export const taskList = async (req: Request, res: Response, next: NextFunction) 
             }
         }
 
-        const datasetTitle = dataset.datasetInfo?.title;
+        const datasetTitle = revision.metadata?.title;
         const dimensions = dataset.dimensions;
         const taskList: TaskListState = await req.pubapi.getTaskList(dataset.id);
         res.render('publish/tasklist', {
@@ -351,7 +344,7 @@ export const taskList = async (req: Request, res: Response, next: NextFunction) 
 
 export const cubePreview = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    const revision = res.locals.revision;
+    const revision = dataset.draft_revision;
 
     let errors: ViewError[] | undefined;
     let previewData: ViewDTO | undefined;
@@ -1527,13 +1520,14 @@ export const changeData = async (req: Request, res: Response, next: NextFunction
 export const provideSummary = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] | undefined;
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let description = dataset?.datasetInfo?.description;
+    const revision = dataset.draft_revision;
+    let summary = revision?.metadata?.summary;
 
     if (req.method === 'POST') {
         try {
-            description = req.body.description;
+            summary = req.body.summary;
 
-            errors = (await getErrors(descriptionValidator(), req)).map((error: FieldValidationError) => {
+            errors = (await getErrors(summaryValidator(), req)).map((error: FieldValidationError) => {
                 return { field: error.path, message: { key: `publish.summary.form.description.error.missing` } };
             });
 
@@ -1542,7 +1536,7 @@ export const provideSummary = async (req: Request, res: Response, next: NextFunc
                 throw new Error();
             }
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { description, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { summary, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
             return;
         } catch (err) {
@@ -1552,13 +1546,14 @@ export const provideSummary = async (req: Request, res: Response, next: NextFunc
         }
     }
 
-    res.render('publish/summary', { description, errors });
+    res.render('publish/summary', { summary, errors });
 };
 
 export const provideCollection = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] | undefined;
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let collection = dataset?.datasetInfo?.collection;
+    const revision = dataset.draft_revision;
+    let collection = revision?.metadata?.collection;
 
     if (req.method === 'POST') {
         try {
@@ -1573,7 +1568,7 @@ export const provideCollection = async (req: Request, res: Response, next: NextF
                 throw new Error();
             }
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { collection, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { collection, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
             return;
         } catch (err) {
@@ -1589,11 +1584,18 @@ export const provideCollection = async (req: Request, res: Response, next: NextF
 export const provideQuality = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] | undefined;
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let datasetInfo = dataset?.datasetInfo!;
+    const revision = dataset.draft_revision;
+    let metadata = {
+        quality: revision?.metadata?.quality,
+        rounding_applied: revision?.rounding_applied,
+        rounding_description: revision?.metadata?.rounding_description
+    };
+
+    console.log(metadata);
 
     if (req.method === 'POST') {
         try {
-            datasetInfo = {
+            metadata = {
                 quality: req.body.quality,
                 rounding_applied: req.body.rounding_applied ? req.body.rounding_applied === 'true' : undefined,
                 rounding_description: req.body.rounding_applied === 'true' ? req.body.rounding_description : ''
@@ -1610,7 +1612,7 @@ export const provideQuality = async (req: Request, res: Response, next: NextFunc
                 throw new Error();
             }
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { ...datasetInfo, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { ...metadata, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
             return;
         } catch (err: any) {
@@ -1620,13 +1622,14 @@ export const provideQuality = async (req: Request, res: Response, next: NextFunc
         }
     }
 
-    res.render('publish/quality', { ...datasetInfo, errors });
+    res.render('publish/quality', { ...metadata, errors });
 };
 
 export const provideUpdateFrequency = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] | undefined;
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let update_frequency = dataset?.datasetInfo!.update_frequency;
+    const revision = dataset.draft_revision;
+    let update_frequency = revision?.update_frequency;
 
     if (req.method === 'POST') {
         update_frequency = {
@@ -1658,7 +1661,7 @@ export const provideUpdateFrequency = async (req: Request, res: Response, next: 
                 frequency_value: is_updated ? frequency_value : undefined
             };
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { update_frequency, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { update_frequency, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
             return;
         } catch (err) {
@@ -1675,7 +1678,7 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
     const deleteId = req.query.delete;
     const editId = req.query.edit;
     let availableProviders: ProviderDTO[] = [];
-    let dataProviders: DatasetProviderDTO[] = [];
+    let dataProviders: RevisionProviderDTO[] = [];
     let errors: ViewError[] | undefined;
 
     try {
@@ -1691,10 +1694,10 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
 
     let dataset = { ...res.locals.dataset, providers: sortBy(dataProviders || [], 'created_at') };
     dataset = singleLangDataset(dataset, req.language);
-    dataProviders = dataset.providers;
+    dataProviders = dataset.draft_revision.providers;
 
     let availableSources: ProviderSourceDTO[] = [];
-    let dataProvider: DatasetProviderDTO | undefined;
+    let dataProvider: RevisionProviderDTO | undefined;
 
     if (deleteId) {
         try {
@@ -1773,7 +1776,7 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
             logger.debug('Adding a new data provider');
 
             // create a new data provider - generate id on the frontend so we can redirect the user to add sources
-            dataProvider = { id: uuid(), dataset_id: dataset.id, provider_id, language: req.language };
+            dataProvider = { id: uuid(), revision_id: dataset.id, provider_id, language: req.language };
 
             await req.pubapi.addDatasetProvider(dataset.id, dataProvider);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/providers?edit=${dataProvider.id}`, req.language));
@@ -1796,17 +1799,19 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
 
 export const provideRelatedLinks = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let errors: ViewError[] | undefined;
-    let related_links = sortBy(dataset?.datasetInfo?.related_links || [], 'created_at');
+    const revision = dataset.draft_revision;
     const deleteId = req.query.delete;
     const editId = req.query.edit;
     const now = new Date().toISOString();
+
+    let errors: ViewError[] | undefined;
+    let related_links = sortBy(revision?.related_links || [], 'created_at');
     let link: RelatedLinkDTO = { id: nanoid(4), url: '', label: '', created_at: now };
 
     if (deleteId) {
         try {
             related_links = related_links.filter((rl) => rl.id !== deleteId);
-            await req.pubapi.updateDatasetInfo(dataset.id, { related_links, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { related_links, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/related`, req.language));
             return;
         } catch (err) {
@@ -1871,7 +1876,7 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
             // if the link already exists, replace it, otherwise add it, then sort
             related_links = sortBy([...related_links.filter((rl) => rl.id !== link.id), link], 'created_at');
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { related_links, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { related_links, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/related`, req.language));
             return;
         } catch (err) {
@@ -1887,7 +1892,8 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
 export const provideDesignation = async (req: Request, res: Response, next: NextFunction) => {
     let errors: ViewError[] | undefined;
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    let designation = dataset?.datasetInfo?.designation;
+    const revision = dataset.draft_revision;
+    let designation = revision?.designation;
 
     if (req.method === 'POST') {
         try {
@@ -1902,7 +1908,7 @@ export const provideDesignation = async (req: Request, res: Response, next: Next
                 throw new Error();
             }
 
-            await req.pubapi.updateDatasetInfo(dataset.id, { designation, language: req.language });
+            await req.pubapi.updateMetadata(dataset.id, { designation, language: req.language });
             res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
             return;
         } catch (err) {
@@ -2146,8 +2152,8 @@ export const importTranslations = async (req: Request, res: Response, next: Next
 
 export const overview = async (req: Request, res: Response, next: NextFunction) => {
     const dataset = singleLangDataset(res.locals.dataset, req.language);
-    const revision = res.locals.revision;
-    const title = dataset.datasetInfo?.title;
+    const revision = dataset.draft_revision!;
+    const title = revision.metadata?.title;
     const datasetStatus = getDatasetStatus(dataset);
     const publishingStatus = getPublishingStatus(dataset);
     const justScheduled = req.query?.scheduled === 'true';

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -66,6 +66,7 @@ import { FileFormat } from '../enums/file-format';
 import { getDownloadHeaders } from '../utils/download-headers';
 import { FactTableColumnDto } from '../dtos/fact-table-column-dto';
 import { ProviderDTO } from '../dtos/provider';
+import { Locale } from '../enums/locale';
 
 export const start = (req: Request, res: Response, next: NextFunction) => {
     res.render('publish/start');
@@ -1591,8 +1592,6 @@ export const provideQuality = async (req: Request, res: Response, next: NextFunc
         rounding_description: revision?.metadata?.rounding_description
     };
 
-    console.log(metadata);
-
     if (req.method === 'POST') {
         try {
             metadata = {
@@ -1806,7 +1805,7 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
 
     let errors: ViewError[] | undefined;
     let related_links = sortBy(revision?.related_links || [], 'created_at');
-    let link: RelatedLinkDTO = { id: nanoid(4), url: '', label: '', created_at: now };
+    let link: RelatedLinkDTO = { id: nanoid(4), url: '', label_en: '', label_cy: '', created_at: now };
 
     if (deleteId) {
         try {
@@ -1843,7 +1842,13 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
         }
 
         // redisplay the form with submitted values if there are errors
-        link = { id: link_id, url: link_url, label: link_label, created_at: link.created_at };
+        link = {
+            id: link_id,
+            url: link_url,
+            label_en: req.language.includes(Locale.English) ? link_label : link.label_en,
+            label_cy: req.language.includes(Locale.Welsh) ? link_label : link.label_cy,
+            created_at: link.created_at
+        };
 
         try {
             if (add_another === 'true' && !add_link) {
@@ -1871,7 +1876,13 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
             }
 
             const { link_id, link_url, link_label } = matchedData(req);
-            link = { id: link_id, url: link_url, label: link_label, created_at: link.created_at };
+            link = {
+                id: link_id,
+                url: link_url,
+                label_en: req.language.includes(Locale.English) ? link_label : link.label_en,
+                label_cy: req.language.includes(Locale.Welsh) ? link_label : link.label_cy,
+                created_at: link.created_at
+            };
 
             // if the link already exists, replace it, otherwise add it, then sort
             related_links = sortBy([...related_links.filter((rl) => rl.id !== link.id), link], 'created_at');

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -1684,14 +1684,21 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
         // eslint-disable-next-line prefer-const
         [availableProviders, dataProviders] = await Promise.all([
             req.pubapi.getAllProviders(),
-            req.pubapi.getDatasetProviders(res.locals.datasetId)
+            req.pubapi.getAssignedProviders(res.locals.datasetId)
         ]);
     } catch (err) {
         next(err);
         return;
     }
 
-    let dataset = { ...res.locals.dataset, providers: sortBy(dataProviders || [], 'created_at') };
+    let dataset = {
+        ...res.locals.dataset,
+        draft_revision: {
+            ...res.locals.dataset.draft_revision,
+            providers: sortBy(dataProviders || [], 'created_at')
+        }
+    };
+
     dataset = singleLangDataset(dataset, req.language);
     dataProviders = dataset.draft_revision.providers;
 
@@ -1701,11 +1708,11 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
     if (deleteId) {
         try {
             dataProviders = dataProviders.filter((dp) => dp.id !== deleteId);
-            await req.pubapi.updateDatasetProviders(dataset.id, dataProviders);
+            await req.pubapi.updateAssignedProviders(dataset.id, dataProviders);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/providers`, req.language));
             return;
         } catch (err) {
-            next(new UnknownException());
+            next(err);
             return;
         }
     }
@@ -1715,7 +1722,7 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
             dataProvider = dataProviders.find((dp) => dp.id === editId)!;
             availableSources = await req.pubapi.getSourcesByProvider(dataProvider.provider_id);
         } catch (err) {
-            next(new UnknownException());
+            next(err);
             return;
         }
     }
@@ -1767,7 +1774,7 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
 
                 const providerIdx = dataProviders.findIndex((dp) => dp.id === editId);
                 dataProviders[providerIdx].source_id = source_id;
-                await req.pubapi.updateDatasetProviders(dataset.id, dataProviders);
+                await req.pubapi.updateAssignedProviders(dataset.id, dataProviders);
                 res.redirect(req.buildUrl(`/publish/${dataset.id}/providers`, req.language));
                 return;
             }
@@ -1775,7 +1782,7 @@ export const provideDataProviders = async (req: Request, res: Response, next: Ne
             logger.debug('Adding a new data provider');
 
             // create a new data provider - generate id on the frontend so we can redirect the user to add sources
-            dataProvider = { id: uuid(), revision_id: dataset.id, provider_id, language: req.language };
+            dataProvider = { id: uuid(), revision_id: dataset.draft_revision.id, provider_id, language: req.language };
 
             await req.pubapi.addDatasetProvider(dataset.id, dataProvider);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/providers?edit=${dataProvider.id}`, req.language));

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -334,6 +334,7 @@ export const taskList = async (req: Request, res: Response, next: NextFunction) 
         res.render('publish/tasklist', {
             datasetTitle,
             taskList,
+            revision,
             dimensions,
             statusToColour,
             datasetStatus,

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -134,7 +134,7 @@ export const uploadDataTable = async (req: Request, res: Response, next: NextFun
             const fileData = new Blob([req.file.buffer], { type: req.file.mimetype });
 
             logger.debug('Sending file to backend.');
-            await req.pubapi.uploadCSVToDataset(dataset.id, fileData, fileName);
+            await req.pubapi.uploadDataToDataset(dataset.id, fileData, fileName);
             res.redirect(req.buildUrl(`/publish/${dataset.id}/preview`, req.language));
             return;
         } catch (err) {
@@ -317,7 +317,6 @@ export const taskList = async (req: Request, res: Response, next: NextFunction) 
             // TODO: for MVP there is no approval process, so we are jumping straight to approve
             // once we have approval process, there will be an interstitial status while the dataset is waiting to
             // be approved by a suitable member of the team
-            logger.debug('submitting dataset for publication');
             const scheduledDataset = await req.pubapi.approveForPublication(dataset.id, revision.id);
 
             if (scheduledDataset) {

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -1978,7 +1978,8 @@ export const provideTopics = async (req: Request, res: Response, next: NextFunct
 };
 
 export const providePublishDate = async (req: Request, res: Response, next: NextFunction) => {
-    const { dataset, revision } = res.locals;
+    const dataset = res.locals.dataset;
+    const revision = dataset.draft_revision;
     let errors: ViewError[] = [];
     let dateError;
     let timeError;

--- a/src/dtos/dataset-topic.ts
+++ b/src/dtos/dataset-topic.ts
@@ -1,5 +1,0 @@
-export class DatasetTopicDTO {
-    id: string;
-    dataset_id: string;
-    topic_id: number;
-}

--- a/src/dtos/dataset.ts
+++ b/src/dtos/dataset.ts
@@ -1,8 +1,5 @@
 import { DimensionDTO } from './dimension';
 import { RevisionDTO } from './revision';
-import { DatasetInfoDTO } from './dataset-info';
-import { DatasetProviderDTO } from './dataset-provider';
-import { TopicDTO } from './topic';
 import { MeasureDTO } from './measure';
 import { TeamDTO } from './team';
 import { FactTableColumnDto } from './fact-table-column-dto';
@@ -17,9 +14,10 @@ export interface DatasetDTO {
     measure?: MeasureDTO;
     dimensions?: DimensionDTO[];
     revisions: RevisionDTO[];
-    datasetInfo?: DatasetInfoDTO[];
-    providers?: DatasetProviderDTO[];
-    topics?: TopicDTO[];
+    start_revision?: RevisionDTO;
+    end_revision?: RevisionDTO;
+    draft_revision?: RevisionDTO;
+    published_revision?: RevisionDTO;
     team_id?: string;
     team?: TeamDTO[];
     start_date?: string;

--- a/src/dtos/related-link.ts
+++ b/src/dtos/related-link.ts
@@ -1,6 +1,7 @@
 export interface RelatedLinkDTO {
     id: string;
     url: string;
-    label: string;
+    label_en?: string;
+    label_cy?: string;
     created_at: string;
 }

--- a/src/dtos/revision-metadata.ts
+++ b/src/dtos/revision-metadata.ts
@@ -3,10 +3,10 @@ import { Designation } from '../enums/designation';
 import { UpdateFrequencyDTO } from './update-frequency';
 import { RelatedLinkDTO } from './related-link';
 
-export interface DatasetInfoDTO {
+export interface RevisionMetadataDTO {
     language?: string;
     title?: string;
-    description?: string;
+    summary?: string;
     collection?: string;
     quality?: string;
     rounding_applied?: boolean;

--- a/src/dtos/revision-provider.ts
+++ b/src/dtos/revision-provider.ts
@@ -1,6 +1,6 @@
-export class DatasetProviderDTO {
+export class RevisionProviderDTO {
     id?: string;
-    dataset_id: string;
+    revision_id: string;
     language: string;
     provider_id: string;
     provider_name?: string;

--- a/src/dtos/revision-topic.ts
+++ b/src/dtos/revision-topic.ts
@@ -1,0 +1,5 @@
+export class RevisionTopicDTO {
+    id: string;
+    revision_id: string;
+    topic_id: number;
+}

--- a/src/dtos/revision.ts
+++ b/src/dtos/revision.ts
@@ -19,6 +19,7 @@ export interface RevisionDTO {
     approved_at?: string;
     approved_by?: string;
     created_by: string;
+    data_table_id?: string;
     data_table?: DataTableDto;
     metadata?: RevisionMetadataDTO[];
     rounding_applied?: boolean;

--- a/src/dtos/revision.ts
+++ b/src/dtos/revision.ts
@@ -25,6 +25,6 @@ export interface RevisionDTO {
     update_frequency?: UpdateFrequencyDTO;
     designation?: Designation;
     related_links?: RelatedLinkDTO[];
-    providers: RevisionProviderDTO[];
-    topics: TopicDTO[];
+    providers?: RevisionProviderDTO[];
+    topics?: TopicDTO[];
 }

--- a/src/dtos/single-language/dataset.ts
+++ b/src/dtos/single-language/dataset.ts
@@ -1,4 +1,3 @@
-import { RevisionDTO } from '../revision';
 import { MeasureDTO } from '../measure';
 import { TeamDTO } from '../team';
 
@@ -13,7 +12,7 @@ export interface SingleLanguageDataset {
     archive?: string;
     measure?: MeasureDTO;
     dimensions?: SingleLanguageDimension[];
-    revisions: RevisionDTO[];
+    revisions?: SingleLanguageRevision[];
     start_revision?: SingleLanguageRevision;
     end_revision?: SingleLanguageRevision;
     draft_revision?: SingleLanguageRevision;

--- a/src/dtos/single-language/dataset.ts
+++ b/src/dtos/single-language/dataset.ts
@@ -1,11 +1,9 @@
 import { RevisionDTO } from '../revision';
-import { DatasetInfoDTO } from '../dataset-info';
-import { DatasetProviderDTO } from '../dataset-provider';
-import { TopicDTO } from '../topic';
 import { MeasureDTO } from '../measure';
 import { TeamDTO } from '../team';
 
 import { SingleLanguageDimension } from './dimension';
+import { SingleLanguageRevision } from './revision';
 
 export interface SingleLanguageDataset {
     id: string;
@@ -16,9 +14,10 @@ export interface SingleLanguageDataset {
     measure?: MeasureDTO;
     dimensions?: SingleLanguageDimension[];
     revisions: RevisionDTO[];
-    datasetInfo?: DatasetInfoDTO;
-    providers?: DatasetProviderDTO[];
-    topics?: TopicDTO[];
+    start_revision?: SingleLanguageRevision;
+    end_revision?: SingleLanguageRevision;
+    draft_revision?: SingleLanguageRevision;
+    published_revision?: SingleLanguageRevision;
     team?: TeamDTO;
     start_date?: string;
     end_date?: string;

--- a/src/dtos/single-language/revision.ts
+++ b/src/dtos/single-language/revision.ts
@@ -1,13 +1,12 @@
-import { Designation } from '../enums/designation';
+import { Designation } from '../../enums/designation';
+import { DataTableDto } from '../data-table';
+import { RelatedLinkDTO } from '../related-link';
+import { RevisionMetadataDTO } from '../revision-metadata';
+import { RevisionProviderDTO } from '../revision-provider';
+import { TopicDTO } from '../topic';
+import { UpdateFrequencyDTO } from '../update-frequency';
 
-import { DataTableDto } from './data-table';
-import { RelatedLinkDTO } from './related-link';
-import { RevisionMetadataDTO } from './revision-metadata';
-import { RevisionProviderDTO } from './revision-provider';
-import { TopicDTO } from './topic';
-import { UpdateFrequencyDTO } from './update-frequency';
-
-export interface RevisionDTO {
+export interface SingleLanguageRevision {
     id: string;
     dataset_id?: string;
     revision_index: number;
@@ -20,7 +19,7 @@ export interface RevisionDTO {
     approved_by?: string;
     created_by: string;
     data_table?: DataTableDto;
-    metadata?: RevisionMetadataDTO[];
+    metadata?: RevisionMetadataDTO;
     rounding_applied?: boolean;
     update_frequency?: UpdateFrequencyDTO;
     designation?: Designation;

--- a/src/dtos/single-language/revision.ts
+++ b/src/dtos/single-language/revision.ts
@@ -24,6 +24,6 @@ export interface SingleLanguageRevision {
     update_frequency?: UpdateFrequencyDTO;
     designation?: Designation;
     related_links?: RelatedLinkDTO[];
-    providers: RevisionProviderDTO[];
-    topics: TopicDTO[];
+    providers?: RevisionProviderDTO[];
+    topics?: TopicDTO[];
 }

--- a/src/enums/dataset-include.ts
+++ b/src/enums/dataset-include.ts
@@ -1,0 +1,5 @@
+export enum DatasetInclude {
+    All = 'all',
+    Metadata = 'meta',
+    DataTable = 'data'
+}

--- a/src/enums/dataset-include.ts
+++ b/src/enums/dataset-include.ts
@@ -1,5 +1,5 @@
 export enum DatasetInclude {
     All = 'all',
-    Metadata = 'meta',
-    DataTable = 'data'
+    Meta = 'meta',
+    Data = 'data'
 }

--- a/src/enums/dataset-include.ts
+++ b/src/enums/dataset-include.ts
@@ -1,5 +1,5 @@
 export enum DatasetInclude {
     All = 'all',
-    Meta = 'meta',
+    Meta = 'metadata',
     Data = 'data'
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -880,7 +880,8 @@
                     "withdraw_first_revision": "Change dataset before publication",
                     "withdraw_update_revision": "Change update before publication",
                     "continue_update": "Continue update",
-                    "continue": "Continue dataset"
+                    "continue": "Continue dataset",
+                    "preview": "View dataset preview"
                 }
             },
             "error": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -908,12 +908,13 @@
             },
             "field": {
                 "title": "Title",
-                "description": "Summary",
+                "summary": "Summary",
                 "collection": "Data collection",
                 "quality": "Statistical quality",
                 "roundingDescription": "Rounding applied"
             },
             "dimension": "{{key}} dimension name",
+            "link": "Related report",
             "buttons": {
                 "export": "Export CSV",
                 "change": "Change"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -562,6 +562,7 @@
                     "action_edit": "Change",
                     "action_delete": "Remove"
                 },
+                "not_translated": "Not yet translated",
                 "form": {
                     "add_another": {
                         "heading": "Do you need to add a link to another report?",

--- a/src/middleware/ensure-authenticated.ts
+++ b/src/middleware/ensure-authenticated.ts
@@ -8,7 +8,7 @@ import { appConfig } from '../config';
 const config = appConfig();
 
 export const ensureAuthenticated = (req: Request, res: Response, next: NextFunction) => {
-    logger.debug(`checking if user is authenticated for route ${req.originalUrl}...`);
+    logger.debug(`Checking if user is authenticated for route ${req.originalUrl}...`);
 
     try {
         if (!req.cookies.jwt) {

--- a/src/middleware/fetch-dataset.ts
+++ b/src/middleware/fetch-dataset.ts
@@ -1,61 +1,35 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { NotFoundException } from '../exceptions/not-found.exception';
-import { getLatestRevision, getDataTable } from '../utils/revision';
 import { logger } from '../utils/logger';
 import { hasError, datasetIdValidator } from '../validators';
+import { DatasetInclude } from '../enums/dataset-include';
 
-export const fetchFullDataset = async (req: Request, res: Response, next: NextFunction) => {
-    const datasetIdError = await hasError(datasetIdValidator(), req);
+export const fetchDataset = (include?: DatasetInclude) => {
+    return async (req: Request, res: Response, next: NextFunction) => {
+        const datasetIdError = await hasError(datasetIdValidator(), req);
 
-    if (datasetIdError) {
-        logger.error('Invalid or missing datasetId');
-        next(new NotFoundException('errors.dataset_missing'));
-        return;
-    }
-
-    try {
-        const dataset = await req.pubapi.getFullDataset(req.params.datasetId);
-        res.locals.datasetId = dataset.id;
-        res.locals.dataset = dataset;
-        res.locals.revision = getLatestRevision(dataset);
-        res.locals.dataTable = getDataTable(res.locals.revision);
-    } catch (err: any) {
-        if (err.status === 401) {
-            next(err);
+        if (datasetIdError) {
+            logger.error('Invalid or missing datasetId');
+            next(new NotFoundException('errors.dataset_missing'));
             return;
         }
-        next(new NotFoundException('errors.dataset_missing'));
-        return;
-    }
 
-    next();
-};
-
-export const fetchLimitedDataset = async (req: Request, res: Response, next: NextFunction) => {
-    const datasetIdError = await hasError(datasetIdValidator(), req);
-
-    if (datasetIdError) {
-        logger.error('Invalid or missing datasetId');
-        next(new NotFoundException('errors.dataset_missing'));
-        return;
-    }
-
-    try {
-        const dataset = await req.pubapi.getLimitedDataset(req.params.datasetId);
-        res.locals.datasetId = dataset.id;
-        res.locals.dataset = dataset;
-        res.locals.revision = getLatestRevision(dataset);
-    } catch (err: any) {
-        if (err.status === 401) {
-            next(err);
+        try {
+            const dataset = await req.pubapi.getDataset(req.params.datasetId, include);
+            res.locals.datasetId = dataset.id;
+            res.locals.dataset = dataset;
+        } catch (err: any) {
+            if (err.status === 401) {
+                next(err);
+                return;
+            }
+            next(new NotFoundException('errors.dataset_missing'));
             return;
         }
-        next(new NotFoundException('errors.dataset_missing'));
-        return;
-    }
 
-    next();
+        next();
+    };
 };
 
 export const fetchPublishedDataset = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/developer.ts
+++ b/src/routes/developer.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream';
 import { Router, Request, Response, NextFunction } from 'express';
 
 import { ViewDTO } from '../dtos/view-dto';
-import { fetchFullDataset } from '../middleware/fetch-dataset';
+import { fetchDataset } from '../middleware/fetch-dataset';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { logger } from '../utils/logger';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item';
@@ -17,14 +17,14 @@ export const developer = Router();
 
 developer.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getActiveDatasetList();
+        const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getDatasetList();
         res.render('developer/list', { datasets: results.data });
     } catch (err) {
         next(err);
     }
 });
 
-developer.get('/:datasetId', fetchFullDataset, async (req: Request, res: Response, next: NextFunction) => {
+developer.get('/:datasetId', fetchDataset, async (req: Request, res: Response, next: NextFunction) => {
     const datasetId = res.locals.datasetId;
     const page: number = Number.parseInt(req.query.page_number as string, 10) || 1;
     const pageSize: number = Number.parseInt(req.query.page_size as string, 10) || 100;
@@ -49,7 +49,7 @@ developer.get('/:datasetId', fetchFullDataset, async (req: Request, res: Respons
 
 developer.get(
     '/:datasetId/import/:factTableId',
-    fetchFullDataset,
+    fetchDataset,
     async (req: Request, res: Response, next: NextFunction) => {
         const dataset = res.locals.dataset;
         const importIdError = await hasError(factTableIdValidator(), req);

--- a/src/routes/homepage.ts
+++ b/src/routes/homepage.ts
@@ -11,7 +11,7 @@ homepage.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const page = parseInt(req.query.page_number as string, 10) || 1;
         const limit = parseInt(req.query.page_size as string, 10) || 20;
-        const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getActiveDatasetList(page, limit);
+        const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getDatasetList(page, limit);
         const { data, count } = results;
         const pagination = getPaginationProps(page, limit, count);
 

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -188,8 +188,8 @@ publish.get('/:datasetId/translation/import', fetchDataset(), importTranslations
 publish.post('/:datasetId/translation/import', fetchDataset(), upload.single('csv'), importTranslations);
 
 /* Dataset Overview */
-publish.get('/:datasetId/overview', fetchDataset(Include.All), overview);
-publish.post('/:datasetId/overview', fetchDataset(Include.All), upload.none(), overview);
+publish.get('/:datasetId/overview', fetchDataset(), overview);
+publish.post('/:datasetId/overview', fetchDataset(), upload.none(), overview);
 
 /* Update Dataset */
 publish.get('/:datasetId/update', fetchDataset(), createNewUpdate);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express';
 import multer from 'multer';
 
-import { fetchFullDataset, fetchLimitedDataset } from '../middleware/fetch-dataset';
+import { fetchDataset } from '../middleware/fetch-dataset';
 import {
     start,
     provideTitle,
-    uploadFile,
+    uploadDataTable,
     factTablePreview,
     sources,
     taskList,
@@ -43,6 +43,7 @@ import {
     createNewUpdate,
     updateDatatable
 } from '../controllers/publish';
+import { DatasetInclude as Include } from '../enums/dataset-include';
 
 export const publish = Router();
 
@@ -56,116 +57,116 @@ publish.post('/title', upload.none(), provideTitle);
 
 publish.get('/:datasetId', redirectToTasklist);
 
-publish.get('/:datasetId/title', fetchLimitedDataset, provideTitle);
-publish.post('/:datasetId/title', fetchLimitedDataset, upload.none(), provideTitle);
+publish.get('/:datasetId/title', fetchDataset(Include.Metadata), provideTitle);
+publish.post('/:datasetId/title', fetchDataset(Include.Metadata), upload.none(), provideTitle);
 
-publish.get('/:datasetId/upload', fetchFullDataset, uploadFile);
-publish.post('/:datasetId/upload', fetchFullDataset, upload.single('csv'), uploadFile);
+publish.get('/:datasetId/upload', fetchDataset(Include.DataTable), uploadDataTable);
+publish.post('/:datasetId/upload', fetchDataset(Include.DataTable), upload.single('csv'), uploadDataTable);
 
-publish.get('/:datasetId/preview', fetchFullDataset, factTablePreview);
-publish.post('/:datasetId/preview', fetchFullDataset, upload.none(), factTablePreview);
+publish.get('/:datasetId/preview', fetchDataset(Include.DataTable), factTablePreview);
+publish.post('/:datasetId/preview', fetchDataset(Include.DataTable), upload.none(), factTablePreview);
 
-publish.get('/:datasetId/sources', fetchFullDataset, sources);
-publish.post('/:datasetId/sources', fetchFullDataset, upload.none(), sources);
+publish.get('/:datasetId/sources', fetchDataset(Include.DataTable), sources);
+publish.post('/:datasetId/sources', fetchDataset(Include.DataTable), upload.none(), sources);
 
 /* Tasklist */
-publish.get('/:datasetId/tasklist', fetchLimitedDataset, taskList);
-publish.post('/:datasetId/tasklist', fetchLimitedDataset, upload.none(), taskList);
+publish.get('/:datasetId/tasklist', fetchDataset(Include.Metadata), taskList);
+publish.post('/:datasetId/tasklist', fetchDataset(Include.Metadata), upload.none(), taskList);
 
 /* Cube Preview */
-publish.get('/:datasetId/cube-preview', fetchFullDataset, cubePreview);
-publish.get('/:datasetId/cube-preview/download', fetchFullDataset, downloadDataset);
+publish.get('/:datasetId/cube-preview', fetchDataset(), cubePreview);
+publish.get('/:datasetId/cube-preview/download', fetchDataset(), downloadDataset);
 
 /* Measure creation */
-publish.get('/:datasetId/measure', fetchFullDataset, measurePreview);
-publish.post('/:datasetId/measure', fetchFullDataset, upload.single('csv'), measurePreview);
-publish.get('/:datasetId/measure/review', fetchFullDataset, measureReview);
-publish.post('/:datasetId/measure/review', fetchFullDataset, measureReview);
+publish.get('/:datasetId/measure', fetchDataset(), measurePreview);
+publish.post('/:datasetId/measure', fetchDataset(), upload.single('csv'), measurePreview);
+publish.get('/:datasetId/measure/review', fetchDataset(), measureReview);
+publish.post('/:datasetId/measure/review', fetchDataset(), measureReview);
 
 /* Dimension creation */
-publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchFullDataset, fetchDimensionPreview);
-publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchFullDataset, fetchDimensionPreview);
-publish.get('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchFullDataset, fetchDimensionPreview);
-publish.post('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchFullDataset, fetchDimensionPreview);
+publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(), fetchDimensionPreview);
+publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(), fetchDimensionPreview);
+publish.get('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchDataset(), fetchDimensionPreview);
+publish.post('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchDataset(), fetchDimensionPreview);
 
 /* lookup table handlers */
-publish.get('/:datasetId/lookup/:dimensionId', fetchFullDataset, uploadLookupTable);
-publish.post('/:datasetId/lookup/:dimensionId', fetchFullDataset, upload.single('csv'), uploadLookupTable);
-publish.get('/:datasetId/lookup/:dimensionId/review', fetchFullDataset, lookupReview);
-publish.post('/:datasetId/lookup/:dimensionId/review', fetchFullDataset, lookupReview);
+publish.get('/:datasetId/lookup/:dimensionId', fetchDataset(), uploadLookupTable);
+publish.post('/:datasetId/lookup/:dimensionId', fetchDataset(), upload.single('csv'), uploadLookupTable);
+publish.get('/:datasetId/lookup/:dimensionId/review', fetchDataset(), lookupReview);
+publish.post('/:datasetId/lookup/:dimensionId/review', fetchDataset(), lookupReview);
 
-publish.get('/:datasetId/time-period/:dimensionId', fetchLimitedDataset, fetchTimeDimensionPreview);
-publish.post('/:datasetId/time-period/:dimensionId', fetchFullDataset, fetchTimeDimensionPreview);
-publish.get('/:datasetId/time-period/:dimensionId/change-format', fetchLimitedDataset, fetchTimeDimensionPreview);
-publish.post('/:datasetId/time-period/:dimensionId/change-format', fetchFullDataset, fetchTimeDimensionPreview);
-publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchFullDataset, pointInTimeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchFullDataset, pointInTimeChooser);
+publish.get('/:datasetId/time-period/:dimensionId', fetchDataset(), fetchTimeDimensionPreview);
+publish.post('/:datasetId/time-period/:dimensionId', fetchDataset(), fetchTimeDimensionPreview);
+publish.get('/:datasetId/time-period/:dimensionId/change-format', fetchDataset(), fetchTimeDimensionPreview);
+publish.post('/:datasetId/time-period/:dimensionId/change-format', fetchDataset(), fetchTimeDimensionPreview);
+publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(), pointInTimeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(), pointInTimeChooser);
 
 /* Period of time flow */
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchFullDataset, yearTypeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchFullDataset, yearTypeChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchFullDataset, yearFormat);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchFullDataset, yearFormat);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchFullDataset, periodType);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchFullDataset, periodType);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchFullDataset, quarterChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchFullDataset, quarterChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchFullDataset, monthChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchFullDataset, monthChooser);
-publish.get('/:datasetId/time-period/:dimensionId/review', fetchFullDataset, periodReview);
-publish.post('/:datasetId/time-period/:dimensionId/review', fetchFullDataset, periodReview);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(), yearTypeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(), yearTypeChooser);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(), yearFormat);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(), yearFormat);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(), periodType);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(), periodType);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset(), quarterChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset(), quarterChooser);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(), monthChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(), monthChooser);
+publish.get('/:datasetId/time-period/:dimensionId/review', fetchDataset(), periodReview);
+publish.post('/:datasetId/time-period/:dimensionId/review', fetchDataset(), periodReview);
 
 /* Applies to all dimensions */
-publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchFullDataset, dimensionName);
-publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchFullDataset, dimensionName);
-publish.get('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchFullDataset, dimensionName);
-publish.post('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchFullDataset, dimensionName);
+publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(), dimensionName);
+publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(), dimensionName);
+publish.get('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchDataset(), dimensionName);
+publish.post('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchDataset(), dimensionName);
 
 /* Metadata */
-publish.get('/:datasetId/change', fetchLimitedDataset, changeData);
-publish.post('/:datasetId/change', fetchLimitedDataset, upload.none(), changeData);
+publish.get('/:datasetId/change', fetchDataset(), changeData);
+publish.post('/:datasetId/change', fetchDataset(), upload.none(), changeData);
 
-publish.get('/:datasetId/summary', fetchLimitedDataset, provideSummary);
-publish.post('/:datasetId/summary', fetchLimitedDataset, upload.none(), provideSummary);
+publish.get('/:datasetId/summary', fetchDataset(Include.Metadata), provideSummary);
+publish.post('/:datasetId/summary', fetchDataset(Include.Metadata), upload.none(), provideSummary);
 
-publish.get('/:datasetId/collection', fetchLimitedDataset, provideCollection);
-publish.post('/:datasetId/collection', fetchLimitedDataset, upload.none(), provideCollection);
+publish.get('/:datasetId/collection', fetchDataset(Include.Metadata), provideCollection);
+publish.post('/:datasetId/collection', fetchDataset(Include.Metadata), upload.none(), provideCollection);
 
-publish.get('/:datasetId/quality', fetchLimitedDataset, provideQuality);
-publish.post('/:datasetId/quality', fetchLimitedDataset, upload.none(), provideQuality);
+publish.get('/:datasetId/quality', fetchDataset(Include.Metadata), provideQuality);
+publish.post('/:datasetId/quality', fetchDataset(Include.Metadata), upload.none(), provideQuality);
 
-publish.get('/:datasetId/providers', fetchLimitedDataset, provideDataProviders);
-publish.post('/:datasetId/providers', fetchLimitedDataset, upload.none(), provideDataProviders);
+publish.get('/:datasetId/providers', fetchDataset(Include.Metadata), provideDataProviders);
+publish.post('/:datasetId/providers', fetchDataset(Include.Metadata), upload.none(), provideDataProviders);
 
-publish.get('/:datasetId/related', fetchLimitedDataset, provideRelatedLinks);
-publish.post('/:datasetId/related', fetchLimitedDataset, upload.none(), provideRelatedLinks);
+publish.get('/:datasetId/related', fetchDataset(Include.Metadata), provideRelatedLinks);
+publish.post('/:datasetId/related', fetchDataset(Include.Metadata), upload.none(), provideRelatedLinks);
 
-publish.get('/:datasetId/update-frequency', fetchLimitedDataset, provideUpdateFrequency);
-publish.post('/:datasetId/update-frequency', fetchLimitedDataset, upload.none(), provideUpdateFrequency);
+publish.get('/:datasetId/update-frequency', fetchDataset(Include.Metadata), provideUpdateFrequency);
+publish.post('/:datasetId/update-frequency', fetchDataset(Include.Metadata), upload.none(), provideUpdateFrequency);
 
-publish.get('/:datasetId/designation', fetchLimitedDataset, provideDesignation);
-publish.post('/:datasetId/designation', fetchLimitedDataset, upload.none(), provideDesignation);
+publish.get('/:datasetId/designation', fetchDataset(Include.Metadata), provideDesignation);
+publish.post('/:datasetId/designation', fetchDataset(Include.Metadata), upload.none(), provideDesignation);
 
-publish.get('/:datasetId/topics', fetchLimitedDataset, provideTopics);
-publish.post('/:datasetId/topics', fetchLimitedDataset, upload.none(), provideTopics);
+publish.get('/:datasetId/topics', fetchDataset(Include.Metadata), provideTopics);
+publish.post('/:datasetId/topics', fetchDataset(Include.Metadata), upload.none(), provideTopics);
 
 /* Publishing */
-publish.get('/:datasetId/schedule', fetchLimitedDataset, providePublishDate);
-publish.post('/:datasetId/schedule', fetchLimitedDataset, upload.none(), providePublishDate);
+publish.get('/:datasetId/schedule', fetchDataset(), providePublishDate);
+publish.post('/:datasetId/schedule', fetchDataset(), upload.none(), providePublishDate);
 
-publish.get('/:datasetId/organisation', fetchLimitedDataset, provideOrganisation);
-publish.post('/:datasetId/organisation', fetchLimitedDataset, upload.none(), provideOrganisation);
+publish.get('/:datasetId/organisation', fetchDataset(), provideOrganisation);
+publish.post('/:datasetId/organisation', fetchDataset(), upload.none(), provideOrganisation);
 
 /* Translations */
-publish.get('/:datasetId/translation/export', fetchLimitedDataset, exportTranslations);
-publish.get('/:datasetId/translation/import', fetchLimitedDataset, importTranslations);
-publish.post('/:datasetId/translation/import', fetchLimitedDataset, upload.single('csv'), importTranslations);
+publish.get('/:datasetId/translation/export', fetchDataset(), exportTranslations);
+publish.get('/:datasetId/translation/import', fetchDataset(), importTranslations);
+publish.post('/:datasetId/translation/import', fetchDataset(), upload.single('csv'), importTranslations);
 
 /* Dataset Overview */
-publish.get('/:datasetId/overview', fetchLimitedDataset, overview);
-publish.post('/:datasetId/overview', fetchLimitedDataset, upload.none(), overview);
+publish.get('/:datasetId/overview', fetchDataset(), overview);
+publish.post('/:datasetId/overview', fetchDataset(), upload.none(), overview);
 
 /* Update Dataset */
-publish.get('/:datasetId/update', fetchLimitedDataset, createNewUpdate);
-publish.get('/:datasetId/update-type', fetchLimitedDataset, updateDatatable);
-publish.post('/:datasetId/update-type', fetchLimitedDataset, updateDatatable);
+publish.get('/:datasetId/update', fetchDataset(), createNewUpdate);
+publish.get('/:datasetId/update-type', fetchDataset(), updateDatatable);
+publish.post('/:datasetId/update-type', fetchDataset(), updateDatatable);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -57,98 +57,123 @@ publish.post('/title', upload.none(), provideTitle);
 
 publish.get('/:datasetId', redirectToTasklist);
 
-publish.get('/:datasetId/title', fetchDataset(Include.Metadata), provideTitle);
-publish.post('/:datasetId/title', fetchDataset(Include.Metadata), upload.none(), provideTitle);
+publish.get('/:datasetId/title', fetchDataset(Include.Meta), provideTitle);
+publish.post('/:datasetId/title', fetchDataset(Include.Meta), upload.none(), provideTitle);
 
-publish.get('/:datasetId/upload', fetchDataset(Include.DataTable), uploadDataTable);
-publish.post('/:datasetId/upload', fetchDataset(Include.DataTable), upload.single('csv'), uploadDataTable);
+publish.get('/:datasetId/upload', fetchDataset(Include.Data), uploadDataTable);
+publish.post('/:datasetId/upload', fetchDataset(Include.Data), upload.single('csv'), uploadDataTable);
 
-publish.get('/:datasetId/preview', fetchDataset(Include.DataTable), factTablePreview);
-publish.post('/:datasetId/preview', fetchDataset(Include.DataTable), upload.none(), factTablePreview);
+publish.get('/:datasetId/preview', fetchDataset(Include.Data), factTablePreview);
+publish.post('/:datasetId/preview', fetchDataset(Include.Data), upload.none(), factTablePreview);
 
-publish.get('/:datasetId/sources', fetchDataset(Include.DataTable), sources);
-publish.post('/:datasetId/sources', fetchDataset(Include.DataTable), upload.none(), sources);
+publish.get('/:datasetId/sources', fetchDataset(Include.Data), sources);
+publish.post('/:datasetId/sources', fetchDataset(Include.Data), upload.none(), sources);
 
 /* Tasklist */
-publish.get('/:datasetId/tasklist', fetchDataset(Include.Metadata), taskList);
-publish.post('/:datasetId/tasklist', fetchDataset(Include.Metadata), upload.none(), taskList);
+publish.get('/:datasetId/tasklist', fetchDataset(Include.Meta), taskList);
+publish.post('/:datasetId/tasklist', fetchDataset(Include.Meta), upload.none(), taskList);
 
 /* Cube Preview */
-publish.get('/:datasetId/cube-preview', fetchDataset(), cubePreview);
-publish.get('/:datasetId/cube-preview/download', fetchDataset(), downloadDataset);
+publish.get('/:datasetId/cube-preview', fetchDataset(Include.All), cubePreview);
+publish.get('/:datasetId/cube-preview/download', fetchDataset(Include.All), downloadDataset);
 
 /* Measure creation */
-publish.get('/:datasetId/measure', fetchDataset(Include.DataTable), measurePreview);
-publish.post('/:datasetId/measure', fetchDataset(Include.DataTable), upload.single('csv'), measurePreview);
-publish.get('/:datasetId/measure/review', fetchDataset(Include.DataTable), measureReview);
-publish.post('/:datasetId/measure/review', fetchDataset(Include.DataTable), measureReview);
+publish.get('/:datasetId/measure', fetchDataset(Include.Data), measurePreview);
+publish.post('/:datasetId/measure', fetchDataset(Include.Data), upload.single('csv'), measurePreview);
+publish.get('/:datasetId/measure/review', fetchDataset(Include.Data), measureReview);
+publish.post('/:datasetId/measure/review', fetchDataset(Include.Data), measureReview);
 
 /* Dimension creation */
-publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(), fetchDimensionPreview);
-publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(), fetchDimensionPreview);
-publish.get('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchDataset(), fetchDimensionPreview);
-publish.post('/:datasetId/dimension-data-chooser/:dimensionId/change-type', fetchDataset(), fetchDimensionPreview);
+publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(Include.Data), fetchDimensionPreview);
+publish.post('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(Include.Data), fetchDimensionPreview);
+publish.get(
+    '/:datasetId/dimension-data-chooser/:dimensionId/change-type',
+    fetchDataset(Include.Data),
+    fetchDimensionPreview
+);
+publish.post(
+    '/:datasetId/dimension-data-chooser/:dimensionId/change-type',
+    fetchDataset(Include.Data),
+    fetchDimensionPreview
+);
 
 /* lookup table handlers */
-publish.get('/:datasetId/lookup/:dimensionId', fetchDataset(), uploadLookupTable);
-publish.post('/:datasetId/lookup/:dimensionId', fetchDataset(), upload.single('csv'), uploadLookupTable);
-publish.get('/:datasetId/lookup/:dimensionId/review', fetchDataset(), lookupReview);
-publish.post('/:datasetId/lookup/:dimensionId/review', fetchDataset(), lookupReview);
+publish.get('/:datasetId/lookup/:dimensionId', fetchDataset(Include.Data), uploadLookupTable);
+publish.post('/:datasetId/lookup/:dimensionId', fetchDataset(Include.Data), upload.single('csv'), uploadLookupTable);
+publish.get('/:datasetId/lookup/:dimensionId/review', fetchDataset(Include.Data), lookupReview);
+publish.post('/:datasetId/lookup/:dimensionId/review', fetchDataset(Include.Data), lookupReview);
 
-publish.get('/:datasetId/time-period/:dimensionId', fetchDataset(), fetchTimeDimensionPreview);
-publish.post('/:datasetId/time-period/:dimensionId', fetchDataset(), fetchTimeDimensionPreview);
-publish.get('/:datasetId/time-period/:dimensionId/change-format', fetchDataset(), fetchTimeDimensionPreview);
-publish.post('/:datasetId/time-period/:dimensionId/change-format', fetchDataset(), fetchTimeDimensionPreview);
-publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(), pointInTimeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(), pointInTimeChooser);
+publish.get('/:datasetId/time-period/:dimensionId', fetchDataset(Include.Data), fetchTimeDimensionPreview);
+publish.post('/:datasetId/time-period/:dimensionId', fetchDataset(Include.Data), fetchTimeDimensionPreview);
+publish.get(
+    '/:datasetId/time-period/:dimensionId/change-format',
+    fetchDataset(Include.Data),
+    fetchTimeDimensionPreview
+);
+publish.post(
+    '/:datasetId/time-period/:dimensionId/change-format',
+    fetchDataset(Include.Data),
+    fetchTimeDimensionPreview
+);
+publish.get('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(Include.Data), pointInTimeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/point-in-time', fetchDataset(Include.Data), pointInTimeChooser);
 
 /* Period of time flow */
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(), yearTypeChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(), yearTypeChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(), yearFormat);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(), yearFormat);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(), periodType);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(), periodType);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset(), quarterChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset(), quarterChooser);
-publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(), monthChooser);
-publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(), monthChooser);
-publish.get('/:datasetId/time-period/:dimensionId/review', fetchDataset(), periodReview);
-publish.post('/:datasetId/time-period/:dimensionId/review', fetchDataset(), periodReview);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(Include.Data), yearTypeChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time', fetchDataset(Include.Data), yearTypeChooser);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(Include.Data), yearFormat);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/year-format', fetchDataset(Include.Data), yearFormat);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(Include.Data), periodType);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/period-type', fetchDataset(Include.Data), periodType);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/quarters', fetchDataset(Include.Data), quarterChooser);
+publish.post(
+    '/:datasetId/time-period/:dimensionId/period-of-time/quarters',
+    fetchDataset(Include.Data),
+    quarterChooser
+);
+publish.get('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(Include.Data), monthChooser);
+publish.post('/:datasetId/time-period/:dimensionId/period-of-time/months', fetchDataset(Include.Data), monthChooser);
+publish.get('/:datasetId/time-period/:dimensionId/review', fetchDataset(Include.Data), periodReview);
+publish.post('/:datasetId/time-period/:dimensionId/review', fetchDataset(Include.Data), periodReview);
 
 /* Applies to all dimensions */
-publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(), dimensionName);
-publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(), dimensionName);
-publish.get('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchDataset(), dimensionName);
-publish.post('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchDataset(), dimensionName);
+publish.get('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(Include.Data), dimensionName);
+publish.post('/:datasetId/dimension/:dimensionId/name', upload.none(), fetchDataset(Include.Data), dimensionName);
+publish.get('/:datasetId/dimension/:dimensionId/change-name', upload.none(), fetchDataset(Include.Data), dimensionName);
+publish.post(
+    '/:datasetId/dimension/:dimensionId/change-name',
+    upload.none(),
+    fetchDataset(Include.Data),
+    dimensionName
+);
 
 /* Metadata */
 publish.get('/:datasetId/change', fetchDataset(), changeData);
 publish.post('/:datasetId/change', fetchDataset(), upload.none(), changeData);
 
-publish.get('/:datasetId/summary', fetchDataset(Include.Metadata), provideSummary);
-publish.post('/:datasetId/summary', fetchDataset(Include.Metadata), upload.none(), provideSummary);
+publish.get('/:datasetId/summary', fetchDataset(Include.Meta), provideSummary);
+publish.post('/:datasetId/summary', fetchDataset(Include.Meta), upload.none(), provideSummary);
 
-publish.get('/:datasetId/collection', fetchDataset(Include.Metadata), provideCollection);
-publish.post('/:datasetId/collection', fetchDataset(Include.Metadata), upload.none(), provideCollection);
+publish.get('/:datasetId/collection', fetchDataset(Include.Meta), provideCollection);
+publish.post('/:datasetId/collection', fetchDataset(Include.Meta), upload.none(), provideCollection);
 
-publish.get('/:datasetId/quality', fetchDataset(Include.Metadata), provideQuality);
-publish.post('/:datasetId/quality', fetchDataset(Include.Metadata), upload.none(), provideQuality);
+publish.get('/:datasetId/quality', fetchDataset(Include.Meta), provideQuality);
+publish.post('/:datasetId/quality', fetchDataset(Include.Meta), upload.none(), provideQuality);
 
-publish.get('/:datasetId/providers', fetchDataset(Include.Metadata), provideDataProviders);
-publish.post('/:datasetId/providers', fetchDataset(Include.Metadata), upload.none(), provideDataProviders);
+publish.get('/:datasetId/providers', fetchDataset(Include.Meta), provideDataProviders);
+publish.post('/:datasetId/providers', fetchDataset(Include.Meta), upload.none(), provideDataProviders);
 
-publish.get('/:datasetId/related', fetchDataset(Include.Metadata), provideRelatedLinks);
-publish.post('/:datasetId/related', fetchDataset(Include.Metadata), upload.none(), provideRelatedLinks);
+publish.get('/:datasetId/related', fetchDataset(Include.Meta), provideRelatedLinks);
+publish.post('/:datasetId/related', fetchDataset(Include.Meta), upload.none(), provideRelatedLinks);
 
-publish.get('/:datasetId/update-frequency', fetchDataset(Include.Metadata), provideUpdateFrequency);
-publish.post('/:datasetId/update-frequency', fetchDataset(Include.Metadata), upload.none(), provideUpdateFrequency);
+publish.get('/:datasetId/update-frequency', fetchDataset(Include.Meta), provideUpdateFrequency);
+publish.post('/:datasetId/update-frequency', fetchDataset(Include.Meta), upload.none(), provideUpdateFrequency);
 
-publish.get('/:datasetId/designation', fetchDataset(Include.Metadata), provideDesignation);
-publish.post('/:datasetId/designation', fetchDataset(Include.Metadata), upload.none(), provideDesignation);
+publish.get('/:datasetId/designation', fetchDataset(Include.Meta), provideDesignation);
+publish.post('/:datasetId/designation', fetchDataset(Include.Meta), upload.none(), provideDesignation);
 
-publish.get('/:datasetId/topics', fetchDataset(Include.Metadata), provideTopics);
-publish.post('/:datasetId/topics', fetchDataset(Include.Metadata), upload.none(), provideTopics);
+publish.get('/:datasetId/topics', fetchDataset(Include.Meta), provideTopics);
+publish.post('/:datasetId/topics', fetchDataset(Include.Meta), upload.none(), provideTopics);
 
 /* Publishing */
 publish.get('/:datasetId/schedule', fetchDataset(), providePublishDate);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -188,8 +188,8 @@ publish.get('/:datasetId/translation/import', fetchDataset(), importTranslations
 publish.post('/:datasetId/translation/import', fetchDataset(), upload.single('csv'), importTranslations);
 
 /* Dataset Overview */
-publish.get('/:datasetId/overview', fetchDataset(), overview);
-publish.post('/:datasetId/overview', fetchDataset(), upload.none(), overview);
+publish.get('/:datasetId/overview', fetchDataset(Include.All), overview);
+publish.post('/:datasetId/overview', fetchDataset(Include.All), upload.none(), overview);
 
 /* Update Dataset */
 publish.get('/:datasetId/update', fetchDataset(), createNewUpdate);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -176,8 +176,8 @@ publish.get('/:datasetId/topics', fetchDataset(Include.Meta), provideTopics);
 publish.post('/:datasetId/topics', fetchDataset(Include.Meta), upload.none(), provideTopics);
 
 /* Publishing */
-publish.get('/:datasetId/schedule', fetchDataset(), providePublishDate);
-publish.post('/:datasetId/schedule', fetchDataset(), upload.none(), providePublishDate);
+publish.get('/:datasetId/schedule', fetchDataset(Include.Meta), providePublishDate);
+publish.post('/:datasetId/schedule', fetchDataset(Include.Meta), upload.none(), providePublishDate);
 
 publish.get('/:datasetId/organisation', fetchDataset(), provideOrganisation);
 publish.post('/:datasetId/organisation', fetchDataset(), upload.none(), provideOrganisation);

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -78,10 +78,10 @@ publish.get('/:datasetId/cube-preview', fetchDataset(), cubePreview);
 publish.get('/:datasetId/cube-preview/download', fetchDataset(), downloadDataset);
 
 /* Measure creation */
-publish.get('/:datasetId/measure', fetchDataset(), measurePreview);
-publish.post('/:datasetId/measure', fetchDataset(), upload.single('csv'), measurePreview);
-publish.get('/:datasetId/measure/review', fetchDataset(), measureReview);
-publish.post('/:datasetId/measure/review', fetchDataset(), measureReview);
+publish.get('/:datasetId/measure', fetchDataset(Include.DataTable), measurePreview);
+publish.post('/:datasetId/measure', fetchDataset(Include.DataTable), upload.single('csv'), measurePreview);
+publish.get('/:datasetId/measure/review', fetchDataset(Include.DataTable), measureReview);
+publish.post('/:datasetId/measure/review', fetchDataset(Include.DataTable), measureReview);
 
 /* Dimension creation */
 publish.get('/:datasetId/dimension-data-chooser/:dimensionId', fetchDataset(), fetchDimensionPreview);

--- a/src/services/consumer-api.ts
+++ b/src/services/consumer-api.ts
@@ -12,7 +12,7 @@ import { FileFormat } from '../enums/file-format';
 
 const config = appConfig();
 
-const logger = parentLogger.child({ service: 'sw-api' });
+const logger = parentLogger.child({ service: 'consumer-api' });
 
 interface fetchParams {
     url: string;

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -246,6 +246,14 @@ export class PublisherApi {
         }).then((response) => response.json() as unknown as ViewDTO);
     }
 
+    public async getRevision(datasetId: string, revisionId: string): Promise<RevisionDTO> {
+        logger.debug(`Fetching revision: ${revisionId}`);
+
+        return this.fetch({ url: `dataset/${datasetId}/revision/by-id/${revisionId}` }).then(
+            (response) => response.json() as unknown as RevisionDTO
+        );
+    }
+
     public async getRevisionPreview(
         datasetId: string,
         revisionId: string,

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -107,7 +107,7 @@ export class PublisherApi {
         return this.fetch({ url }).then((response) => response.json() as unknown as DatasetDTO);
     }
 
-    public uploadCSVToDataset(datasetId: string, file: Blob, filename: string): Promise<DatasetDTO> {
+    public uploadDataToDataset(datasetId: string, file: Blob, filename: string): Promise<DatasetDTO> {
         logger.debug(`Uploading file ${filename} to dataset: ${datasetId}`);
         const body = new FormData();
         body.set('csv', file, filename);
@@ -168,14 +168,6 @@ export class PublisherApi {
         );
     }
 
-    public async getDatasetCubeView(datasetId: string, pageNumber: number, pageSize: number): Promise<ViewDTO> {
-        logger.debug(`Fetching view for dataset: ${datasetId}, page: ${pageNumber}, pageSize: ${pageSize}`);
-
-        return this.fetch({ url: `dataset/${datasetId}/view?page_number=${pageNumber}&page_size=${pageSize}` }).then(
-            (response) => response.json() as unknown as ViewDTO
-        );
-    }
-
     public async getDatasetList(page = 1, limit = 20): Promise<ResultsetWithCount<DatasetListItemDTO>> {
         logger.debug(`Fetching active dataset list...`);
         const qs = `${new URLSearchParams({ page: page.toString(), limit: limit.toString() }).toString()}`;
@@ -220,15 +212,6 @@ export class PublisherApi {
             url: `dataset/${datasetId}/sources`
         }).then((response) => response.json() as unknown as FactTableColumnDto[]);
     }
-
-    // public async removeFileImport(datasetId: string, revisionId: string): Promise<DatasetDTO> {
-    //     logger.debug(`Removing data table from revision: ${revisionId}`);
-
-    //     return this.fetch({
-    //         url: `dataset/${datasetId}/revision/by-id/${revisionId}/data-table`,
-    //         method: HttpMethod.Delete
-    //     }).then((response) => response.json() as unknown as DatasetDTO);
-    // }
 
     public async resetDimension(datasetId: string, dimensionId: string): Promise<DimensionDTO> {
         logger.debug(`Resetting dimension: ${dimensionId}`);
@@ -513,7 +496,7 @@ export class PublisherApi {
     }
 
     public async approveForPublication(datasetId: string, revisionId: string): Promise<DatasetDTO> {
-        logger.debug(`Attempting to approve dataset for publication: ${datasetId}`);
+        logger.debug(`Attempting to approve draft revision for publication`);
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/approve`,
             method: HttpMethod.Post
@@ -521,7 +504,7 @@ export class PublisherApi {
     }
 
     public async withdrawFromPublication(datasetId: string, revisionId: string): Promise<DatasetDTO> {
-        logger.debug(`Attempting to withdraw latest revision publication: ${datasetId}`);
+        logger.debug(`Attempting to withdraw scheduled revision from publication`);
         return this.fetch({
             url: `dataset/${datasetId}/revision/by-id/${revisionId}/withdraw`,
             method: HttpMethod.Post

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -31,7 +31,7 @@ import { DatasetInclude } from '../enums/dataset-include';
 
 const config = appConfig();
 
-const logger = parentLogger.child({ service: 'sw-api' });
+const logger = parentLogger.child({ service: 'publisher-api' });
 
 interface fetchParams {
     url: string;
@@ -65,7 +65,7 @@ export class PublisherApi {
         // if json is passed, then body will be ignored
         const data = json ? JSON.stringify(json) : body;
 
-        logger.debug(`Fetching /${url}`);
+        logger.debug(`API: ${method} /${url}`);
 
         return fetch(`${this.backendUrl}/${url}`, { method, headers: head, body: data })
             .then(async (response: Response) => {

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -221,14 +221,14 @@ export class PublisherApi {
         }).then((response) => response.json() as unknown as FactTableColumnDto[]);
     }
 
-    public async removeFileImport(datasetId: string, revisionId: string): Promise<DatasetDTO> {
-        logger.debug(`Removing data table from revision: ${revisionId}`);
+    // public async removeFileImport(datasetId: string, revisionId: string): Promise<DatasetDTO> {
+    //     logger.debug(`Removing data table from revision: ${revisionId}`);
 
-        return this.fetch({
-            url: `dataset/${datasetId}/revision/by-id/${revisionId}/data-table`,
-            method: HttpMethod.Delete
-        }).then((response) => response.json() as unknown as DatasetDTO);
-    }
+    //     return this.fetch({
+    //         url: `dataset/${datasetId}/revision/by-id/${revisionId}/data-table`,
+    //         method: HttpMethod.Delete
+    //     }).then((response) => response.json() as unknown as DatasetDTO);
+    // }
 
     public async resetDimension(datasetId: string, dimensionId: string): Promise<DimensionDTO> {
         logger.debug(`Resetting dimension: ${dimensionId}`);

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -406,14 +406,14 @@ export class PublisherApi {
         );
     }
 
-    public async updateDatasetProviders(datasetId: string, providers: RevisionProviderDTO[]): Promise<DatasetDTO> {
+    public async updateAssignedProviders(datasetId: string, providers: RevisionProviderDTO[]): Promise<DatasetDTO> {
         return this.fetch({ url: `dataset/${datasetId}/providers`, method: HttpMethod.Patch, json: providers }).then(
             (response) => response.json() as unknown as DatasetDTO
         );
     }
 
-    public async getDatasetProviders(datasetId: string): Promise<RevisionProviderDTO[]> {
-        logger.debug('Fetching dataset providers...');
+    public async getAssignedProviders(datasetId: string): Promise<RevisionProviderDTO[]> {
+        logger.debug('Fetching assigned data providers...');
         return this.fetch({ url: `dataset/${datasetId}/providers`, method: HttpMethod.Get }).then(
             (response) => response.json() as unknown as RevisionProviderDTO[]
         );

--- a/src/utils/add-edit-links.ts
+++ b/src/utils/add-edit-links.ts
@@ -12,6 +12,11 @@ export const addEditLinks = (translations: TranslationDTO[], datasetId: string, 
             return translation;
         }
 
+        if (translation.type === 'link') {
+            translation.edit_link = req.buildUrl(`/publish/${datasetId}/related`, req.language);
+            return translation;
+        }
+
         switch (translation.key) {
             case 'description':
                 translation.edit_link = req.buildUrl(`/publish/${datasetId}/summary`, req.language);

--- a/src/utils/dataset-preview.ts
+++ b/src/utils/dataset-preview.ts
@@ -5,7 +5,6 @@ import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
 import { nextUpdateAt } from './next-update-at';
 import { markdownToSafeHTML } from './markdown-to-html';
-import { createdAtDesc, isPublished } from './revision';
 
 export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision: SingleLanguageRevision) => {
     if (!revision || !revision.metadata) {
@@ -26,7 +25,7 @@ export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision
         notes: {
             roundingApplied: rounding_applied,
             roundingDescription: await markdownToSafeHTML(rounding_description),
-            publishedRevisions: dataset.revisions.filter(isPublished).sort(createdAtDesc)
+            publishedRevisions: dataset.revisions
         },
         about: {
             summary: await markdownToSafeHTML(summary),

--- a/src/utils/dataset-preview.ts
+++ b/src/utils/dataset-preview.ts
@@ -5,6 +5,7 @@ import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
 import { nextUpdateAt } from './next-update-at';
 import { markdownToSafeHTML } from './markdown-to-html';
+import { isPublished } from './revision';
 
 export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision: SingleLanguageRevision) => {
     if (!revision || !revision.metadata) {
@@ -25,7 +26,7 @@ export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision
         notes: {
             roundingApplied: rounding_applied,
             roundingDescription: await markdownToSafeHTML(rounding_description),
-            publishedRevisions: dataset.revisions
+            publishedRevisions: dataset.revisions?.filter((rev) => isPublished(rev))
         },
         about: {
             summary: await markdownToSafeHTML(summary),

--- a/src/utils/dataset-preview.ts
+++ b/src/utils/dataset-preview.ts
@@ -1,25 +1,26 @@
-import { RevisionDTO } from '../dtos/revision';
+import { isBefore } from 'date-fns';
+
 import { SingleLanguageDataset } from '../dtos/single-language/dataset';
+import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
 import { nextUpdateAt } from './next-update-at';
 import { markdownToSafeHTML } from './markdown-to-html';
 import { createdAtDesc, isPublished } from './revision';
 
-// TODO: once we move metadata to the revision, we should not need the dataset param
-export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision: RevisionDTO) => {
-    if (!revision || !dataset.datasetInfo) {
+export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision: SingleLanguageRevision) => {
+    if (!revision || !revision.metadata) {
         throw new Error('preview requires access to the revision and metadata');
     }
 
-    const { description, quality, collection, designation } = dataset.datasetInfo;
-    const { rounding_applied, rounding_description, related_links } = dataset.datasetInfo;
+    const { summary, quality, collection, rounding_description } = revision.metadata;
+    const { rounding_applied, designation, related_links } = revision;
 
     const preview = {
         keyInfo: {
             updatedAt: revision?.publish_at,
-            nextUpdateAt: nextUpdateAt(revision, dataset.datasetInfo!),
+            nextUpdateAt: nextUpdateAt(revision),
             designation,
-            providers: dataset.providers?.map(({ provider_name, source_name }) => ({ provider_name, source_name })),
+            providers: revision.providers?.map(({ provider_name, source_name }) => ({ provider_name, source_name })),
             timePeriod: { start: dataset.start_date, end: dataset.end_date }
         },
         notes: {
@@ -28,7 +29,7 @@ export const getDatasetPreview = async (dataset: SingleLanguageDataset, revision
             publishedRevisions: dataset.revisions.filter(isPublished).sort(createdAtDesc)
         },
         about: {
-            summary: await markdownToSafeHTML(description),
+            summary: await markdownToSafeHTML(summary),
             quality: await markdownToSafeHTML(quality),
             collection: await markdownToSafeHTML(collection),
             relatedLinks: related_links

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -1,17 +1,16 @@
 import { isBefore } from 'date-fns';
 
 import { DatasetDTO } from '../dtos/dataset';
-import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 import { DatasetStatus } from '../enums/dataset-status';
 import { PublishingStatus } from '../enums/publishing-status';
 
 import { getLatestRevision } from './revision';
 
-export const getDatasetStatus = (dataset: DatasetDTO | SingleLanguageDataset): DatasetStatus => {
+export const getDatasetStatus = (dataset: DatasetDTO): DatasetStatus => {
     return dataset.live && isBefore(dataset.live, new Date()) ? DatasetStatus.Live : DatasetStatus.New;
 };
 
-export const getPublishingStatus = (dataset: DatasetDTO | SingleLanguageDataset): PublishingStatus => {
+export const getPublishingStatus = (dataset: DatasetDTO): PublishingStatus => {
     const revision = getLatestRevision(dataset);
 
     if (getDatasetStatus(dataset) === DatasetStatus.New) {

--- a/src/utils/download-headers.ts
+++ b/src/utils/download-headers.ts
@@ -1,7 +1,6 @@
-import { RevisionDTO } from '../dtos/revision';
 import { FileFormat } from '../enums/file-format';
 
-export const getDownloadHeaders = (format: FileFormat | undefined, revision: RevisionDTO) => {
+export const getDownloadHeaders = (format: FileFormat | undefined, revisionId: string) => {
     if (!format) return undefined;
 
     const formats = {
@@ -20,7 +19,7 @@ export const getDownloadHeaders = (format: FileFormat | undefined, revision: Rev
     return {
         /* eslint-disable @typescript-eslint/naming-convention */
         'Content-Type': opts.contentType,
-        'Content-disposition': `attachment;filename=${revision.id}.${opts.ext}`
+        'Content-disposition': `attachment;filename=${revisionId}.${opts.ext}`
         /* eslint-enable @typescript-eslint/naming-convention */
     };
 };

--- a/src/utils/next-update-at.ts
+++ b/src/utils/next-update-at.ts
@@ -1,13 +1,12 @@
 import { add } from 'date-fns';
 
-import { DatasetInfoDTO } from '../dtos/dataset-info';
 import { RevisionDTO } from '../dtos/revision';
+import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
 export const nextUpdateAt = (
-    revision: RevisionDTO | undefined,
-    metadata: DatasetInfoDTO
+    revision: RevisionDTO | SingleLanguageRevision | undefined
 ): Date | boolean | undefined => {
-    const update = metadata.update_frequency;
+    const update = revision?.update_frequency;
 
     if (!update) return undefined;
 

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -22,7 +22,7 @@ export const getLatestPublishedRevision = (dataset: DatasetDTO | SingleLanguageD
     return first(dataset.revisions?.filter(isPublished).sort(createdAtDesc));
 };
 
-export const getDataTable = (revision: RevisionDTO): DataTableDto | undefined => {
+export const getDataTable = (revision?: RevisionDTO): DataTableDto | undefined => {
     if (!revision) return undefined;
     return revision.data_table;
 };

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -4,8 +4,9 @@ import { isBefore } from 'date-fns';
 import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
 import { DataTableDto } from '../dtos/data-table';
+import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
-export const isPublished = (revision: RevisionDTO): boolean => {
+export const isPublished = (revision: RevisionDTO | SingleLanguageRevision): boolean => {
     return Boolean(revision.approved_at && revision.publish_at && isBefore(revision.publish_at, new Date()));
 };
 

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -4,7 +4,6 @@ import { isBefore } from 'date-fns';
 import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
 import { DataTableDto } from '../dtos/data-table';
-import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 
 export const isPublished = (revision: RevisionDTO): boolean => {
     return Boolean(revision.approved_at && revision.publish_at && isBefore(revision.publish_at, new Date()));
@@ -12,14 +11,8 @@ export const isPublished = (revision: RevisionDTO): boolean => {
 
 export const createdAtDesc = (revA: RevisionDTO, revB: RevisionDTO) => (revB.created_at < revA.created_at ? -1 : 1);
 
-export const getLatestRevision = (dataset: DatasetDTO | SingleLanguageDataset): RevisionDTO | undefined => {
-    if (!dataset) return undefined;
-    return first(dataset?.revisions?.sort(createdAtDesc));
-};
-
-export const getLatestPublishedRevision = (dataset: DatasetDTO | SingleLanguageDataset): RevisionDTO | undefined => {
-    if (!dataset) return undefined;
-    return first(dataset.revisions?.filter(isPublished).sort(createdAtDesc));
+export const getLatestRevision = (dataset: DatasetDTO): RevisionDTO | undefined => {
+    return first(dataset.revisions?.sort(createdAtDesc));
 };
 
 export const getDataTable = (revision?: RevisionDTO): DataTableDto | undefined => {

--- a/src/utils/single-lang-dataset.ts
+++ b/src/utils/single-lang-dataset.ts
@@ -1,17 +1,31 @@
 import { DatasetDTO } from '../dtos/dataset';
+import { RevisionDTO } from '../dtos/revision';
 import { SingleLanguageDataset } from '../dtos/single-language/dataset';
+import { SingleLanguageRevision } from '../dtos/single-language/revision';
+
+export const singleLangRevision = (revision?: RevisionDTO, lang?: string): SingleLanguageRevision | undefined => {
+    if (!revision || !lang) return undefined;
+
+    return {
+        ...revision,
+        metadata: revision.metadata?.find((meta) => meta.language === lang),
+        providers: revision.providers?.filter((provider) => provider.language === lang?.toLowerCase())
+    };
+};
 
 export const singleLangDataset = (dataset: DatasetDTO, lang: string): SingleLanguageDataset => {
     return {
         ...dataset,
+        start_revision: singleLangRevision(dataset.start_revision, lang),
+        end_revision: singleLangRevision(dataset.end_revision, lang),
+        draft_revision: singleLangRevision(dataset.draft_revision, lang),
+        published_revision: singleLangRevision(dataset.published_revision, lang),
         team: dataset.team?.find((team) => team.language === lang),
-        datasetInfo: dataset.datasetInfo?.find((info) => info.language === lang),
         dimensions: dataset.dimensions?.map((dimension) => {
             return {
                 ...dimension,
                 metadata: dimension.metadata?.find((meta) => meta.language === lang)
             };
-        }),
-        providers: dataset.providers?.filter((provider) => provider.language === lang.toLowerCase())
+        })
     };
 };

--- a/src/utils/single-lang-dataset.ts
+++ b/src/utils/single-lang-dataset.ts
@@ -9,7 +9,7 @@ export const singleLangRevision = (revision?: RevisionDTO, lang?: string): Singl
     return {
         ...revision,
         metadata: revision.metadata?.find((meta) => meta.language === lang),
-        providers: revision.providers?.filter((provider) => provider.language === lang?.toLowerCase())
+        providers: (revision.providers || []).filter((provider) => provider.language === lang?.toLowerCase())
     };
 };
 

--- a/src/utils/single-lang-dataset.ts
+++ b/src/utils/single-lang-dataset.ts
@@ -2,6 +2,7 @@ import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
 import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
+import { Locale } from '../enums/locale';
 
 export const singleLangRevision = (revision?: RevisionDTO, lang?: string): SingleLanguageRevision | undefined => {
     if (!revision || !lang) return undefined;
@@ -9,7 +10,11 @@ export const singleLangRevision = (revision?: RevisionDTO, lang?: string): Singl
     return {
         ...revision,
         metadata: revision.metadata?.find((meta) => meta.language === lang),
-        providers: (revision.providers || []).filter((provider) => provider.language === lang?.toLowerCase())
+        providers: (revision.providers || []).filter((provider) => provider.language === lang?.toLowerCase()),
+        related_links: revision.related_links?.map((link) => ({
+            ...link,
+            label: lang.includes(Locale.English) ? link.label_en : link.label_cy
+        }))
     };
 };
 
@@ -20,7 +25,7 @@ export const singleLangDataset = (dataset: DatasetDTO, lang: string): SingleLang
         end_revision: singleLangRevision(dataset.end_revision, lang),
         draft_revision: singleLangRevision(dataset.draft_revision, lang),
         published_revision: singleLangRevision(dataset.published_revision, lang),
-        revisions: dataset.revisions?.map((rev) => singleLangRevision(rev)!),
+        revisions: dataset.revisions?.map((rev) => singleLangRevision(rev, lang)!),
         team: dataset.team?.find((team) => team.language === lang),
         dimensions: dataset.dimensions?.map((dimension) => {
             return {

--- a/src/utils/single-lang-dataset.ts
+++ b/src/utils/single-lang-dataset.ts
@@ -20,6 +20,7 @@ export const singleLangDataset = (dataset: DatasetDTO, lang: string): SingleLang
         end_revision: singleLangRevision(dataset.end_revision, lang),
         draft_revision: singleLangRevision(dataset.draft_revision, lang),
         published_revision: singleLangRevision(dataset.published_revision, lang),
+        revisions: dataset.revisions?.map((rev) => singleLangRevision(rev)!),
         team: dataset.team?.find((team) => team.language === lang),
         dimensions: dataset.dimensions?.map((dimension) => {
             return {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -52,7 +52,7 @@ export const titleValidator = () =>
         .isLength({ max: 1000 })
         .withMessage('too_long');
 
-export const descriptionValidator = () => body('description').trim().notEmpty();
+export const summaryValidator = () => body('summary').trim().notEmpty();
 export const collectionValidator = () => body('collection').trim().notEmpty();
 
 export const qualityValidator = () => body('quality').trim().notEmpty();

--- a/src/views/publish/overview.ejs
+++ b/src/views/publish/overview.ejs
@@ -46,10 +46,12 @@
 						<% } %>
 
 						<% if (locals.publishingStatus === 'scheduled') { %>
+							<li><a class="govuk-link govuk-link--no-underline" href="<%= buildUrl(`/publish/${dataset.id}/cube-preview`, i18n.language) %>"><%= t('publish.overview.scheduled.buttons.preview') %></a></li>
 							<li><a class="govuk-link govuk-link--no-underline" href="<%= buildUrl(`/publish/${dataset.id}/overview`, i18n.language, { withdraw: 'true' }) %>"><%= t('publish.overview.scheduled.buttons.withdraw_first_revision') %></a></li>
 						<% } %>
 
 						<% if (locals.publishingStatus === 'update_scheduled') { %>
+							<li><a class="govuk-link govuk-link--no-underline" href="<%= buildUrl(`/publish/${dataset.id}/cube-preview`, i18n.language) %>"><%= t('publish.overview.scheduled.buttons.preview') %></a></li>
 							<li><a class="govuk-link govuk-link--no-underline" href="<%= buildUrl(`/publish/${dataset.id}/overview`, i18n.language, { withdraw: 'true' }) %>"><%= t('publish.overview.scheduled.buttons.withdraw_update_revision') %></a></li>
 						<% } %>
 

--- a/src/views/publish/providers.ejs
+++ b/src/views/publish/providers.ejs
@@ -12,6 +12,11 @@
         </div>
 
         <div class="govuk-width-container">
+            <p>
+                dataProviders count: <%= locals.dataProviders?.length %>
+                <br />
+                editId: <%= locals.editId %>
+            </p>
 
             <% if (locals.dataProviders?.length === 0 || locals.editId === 'new') { %>
                 <!-- Add provider form is displayed whenever we're adding a "new" provider, or if there aren't any saved currently -->

--- a/src/views/publish/providers.ejs
+++ b/src/views/publish/providers.ejs
@@ -12,12 +12,6 @@
         </div>
 
         <div class="govuk-width-container">
-            <p>
-                dataProviders count: <%= locals.dataProviders?.length %>
-                <br />
-                editId: <%= locals.editId %>
-            </p>
-
             <% if (locals.dataProviders?.length === 0 || locals.editId === 'new') { %>
                 <!-- Add provider form is displayed whenever we're adding a "new" provider, or if there aren't any saved currently -->
                 <div class="govuk-grid-row">

--- a/src/views/publish/related-links.ejs
+++ b/src/views/publish/related-links.ejs
@@ -27,8 +27,10 @@
                             </thead>
                             <tbody class="govuk-table__body">
                                 <% for (let link of locals.related_links) { %>
+                                    <% var label_en = link.label_en || `${link.label_cy} [${t('publish.related.list.not_translated')}]` %>
+                                    <% var label_cy = link.label_cy || `${link.label_en} [${t('publish.related.list.not_translated')}]` %>
                                     <tr class="govuk-table__row">
-                                        <td class="govuk-table__cell"><a href="<%= link.url %>" class="govuk-link"><%= link.label %></a></td>
+                                        <td class="govuk-table__cell"><a href="<%= link.url %>" class="govuk-link"><%= i18n.language.includes('en') ? label_en : label_cy %></a></td>
                                         <td class="govuk-table__cell nowrap">
                                             <ul class="govuk-summary-list__actions-list">
                                                 <li class="govuk-summary-list__actions-list-item">

--- a/src/views/publish/summary.ejs
+++ b/src/views/publish/summary.ejs
@@ -30,7 +30,7 @@
 
                     <form enctype="multipart/form-data" method="post">
                         <div class="govuk-form-group">
-                            <textarea class="govuk-textarea <%= locals.errors?.find(e => e.field === 'description') ? 'govuk-textarea--error' : '' %>" id="description" name="description" rows="4"><%= locals.description %></textarea>
+                            <textarea class="govuk-textarea <%= locals.errors?.find(e => e.field === 'summary') ? 'govuk-textarea--error' : '' %>" id="summary" name="summary" rows="4"><%= locals.summary %></textarea>
                         </div>
                         <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
                         <a class="govuk-button govuk-button--secondary" href="<%= buildUrl(`/publish/${locals.datasetId}/tasklist`, i18n.language) %>"><%= t('buttons.cancel')%></a>

--- a/src/views/publish/tasklist.ejs
+++ b/src/views/publish/tasklist.ejs
@@ -23,12 +23,12 @@
         <ul class="govuk-task-list">
           <li class="govuk-task-list__item govuk-task-list__item--with-link">
             <div class="govuk-task-list__name-and-hint">
-              <% if (!locals.revision.data_table) { %>
-                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/upload`, i18n.language) %>" aria-describedby="prepare-application-1-status">
+              <% if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
+                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/update-type`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>
-              <% } else if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
-                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/update-type`, i18n.language) %>" aria-describedby="prepare-application-1-status">
+              <% } else if (!locals.revision.data_table) { %>
+                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/upload`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>
               <% } else { %>

--- a/src/views/publish/tasklist.ejs
+++ b/src/views/publish/tasklist.ejs
@@ -23,7 +23,11 @@
         <ul class="govuk-task-list">
           <li class="govuk-task-list__item govuk-task-list__item--with-link">
             <div class="govuk-task-list__name-and-hint">
-              <% if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
+              <% if (!locals.revision.data_table) { %>
+                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/upload`, i18n.language) %>" aria-describedby="prepare-application-1-status">
+                  <%= t('publish.tasklist.data.datatable') %>
+                </a>
+              <% } else if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
                 <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/update-type`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>
@@ -42,7 +46,7 @@
           <% if (taskList.measure) { %>
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
               <div class="govuk-task-list__name-and-hint">
-                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/measure/`, i18n.language) %>"><%=taskList.measure.name %></a>
+                <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/measure`, i18n.language) %>"><%=taskList.measure.name %></a>
               </div>
               <div class="govuk-task-list__status">
                 <strong class="govuk-tag govuk-tag--<%= statusToColour(taskList.measure.status) %>">

--- a/src/views/publish/tasklist.ejs
+++ b/src/views/publish/tasklist.ejs
@@ -23,11 +23,11 @@
         <ul class="govuk-task-list">
           <li class="govuk-task-list__item govuk-task-list__item--with-link">
             <div class="govuk-task-list__name-and-hint">
-              <% if (locals.revision?.revision_index === 0 && !locals.revision.data_table) { %>
+              <% if (locals.revision?.revision_index === 0 && !locals.revision.data_table_id) { %>
                 <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/update-type`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>
-              <% } else if (!locals.revision.data_table) { %>
+              <% } else if (!locals.revision.data_table_id) { %>
                 <a class="govuk-link govuk-task-list__link" href="<%= buildUrl(`/publish/${locals.datasetId}/upload`, i18n.language) %>" aria-describedby="prepare-application-1-status">
                   <%= t('publish.tasklist.data.datatable') %>
                 </a>

--- a/src/views/publish/translations/export.ejs
+++ b/src/views/publish/translations/export.ejs
@@ -24,7 +24,13 @@
 					<tbody class="govuk-table__body">
 						<% translations.forEach(function(translation) { %>
 							<tr class="govuk-table__row">
-								<td class="govuk-table__cell"><%= translation.type === 'metadata' ? t(`translations.export.field.${translation.key}`) : t(`translations.export.dimension`, { key: translation.key }) %></td>
+								<% if (translation.type === 'dimension') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.dimension`, { key: translation.key }) %></td>
+								<% } else if (translation.type === 'metadata') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.field.${translation.key}`) %></td>
+								<% } else if (translation.type === 'link') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.link`, { key: translation.key }) %></td>
+								<% } %>
 								<td class="govuk-table__cell"><%= i18n.language.includes('en') ? translation.english : translation.cymraeg %></td>
 								<td class="govuk-table__cell"><a href="<%= translation.edit_link %>"><%= t('translations.export.buttons.change') %></a></td>
 							</tr>

--- a/src/views/publish/translations/import.ejs
+++ b/src/views/publish/translations/import.ejs
@@ -24,7 +24,13 @@
 					<tbody class="govuk-table__body">
 						<% translations.forEach(function(translation) { %>
 							<tr class="govuk-table__row">
-								<td class="govuk-table__cell"><%= translation.type === 'metadata' ? t(`translations.export.field.${translation.key}`) : t(`translations.export.dimension`, { key: translation.key }) %></td>
+								<% if (translation.type === 'dimension') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.dimension`, { key: translation.key }) %></td>
+								<% } else if (translation.type === 'metadata') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.field.${translation.key}`) %></td>
+								<% } else if (translation.type === 'link') { %>
+									<td class="govuk-table__cell"><%= t(`translations.export.link`, { key: translation.key }) %></td>
+								<% } %>
 								<td class="govuk-table__cell"><%= translation.english %></td>
 								<td class="govuk-table__cell"><%= translation.cymraeg %></td>
 							</tr>

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -34,7 +34,7 @@ describe('Error handling', () => {
   afterAll(() => mockBackend.close());
 
   test('should delete the jwt cookie and redirect to login page after logout', async () => {
-    mockBackend.use(http.get('http://localhost:3001/dataset/active', () => new HttpResponse(null, { status: 401 })));
+    mockBackend.use(http.get('http://localhost:3001/dataset', () => new HttpResponse(null, { status: 401 })));
 
     const res = await request(app).get('/en-GB');
     const jwtCookie = parseCookies(res.headers['set-cookie']).find((cookie) => cookie.name === 'jwt');
@@ -51,14 +51,14 @@ describe('Error handling', () => {
   });
 
   test('should render the error page for 500s', async () => {
-    mockBackend.use(http.get('http://localhost:3001/dataset/active', () => new HttpResponse(null, { status: 500 })));
+    mockBackend.use(http.get('http://localhost:3001/dataset', () => new HttpResponse(null, { status: 500 })));
     const res = await request(app).get('/en-GB');
     expect(res.status).toBe(500);
     expect(res.text).toContain(t('errors.server_error', { lng: Locale.English }));
   });
 
   test('should render the error page for everything else', async () => {
-    mockBackend.use(http.get('http://localhost:3001/dataset/active', () => HttpResponse.error()));
+    mockBackend.use(http.get('http://localhost:3001/dataset', () => HttpResponse.error()));
     const res = await request(app).get('/en-GB');
     expect(res.status).toBe(500);
     expect(res.text).toContain(t('errors.server_error', { lng: Locale.English }));

--- a/tests/mocks/fixtures.ts
+++ b/tests/mocks/fixtures.ts
@@ -8,7 +8,6 @@ export const datasetWithTitle: DatasetDTO = {
   id: '5caeb8ed-ea64-4a58-8cf0-b728308833e5',
   created_at: '2024-09-05T10:05:03.871Z',
   created_by: 'Test User',
-  datasetInfo: [{ language: 'en-GB', title: 'Dataset with title' }],
   dimensions: [],
   revisions: [],
   fact_table: []
@@ -18,7 +17,6 @@ export const datasetWithImport: DatasetDTO = {
   id: '7d3d49c0-9fc9-4ce2-ba48-5c466f30946c',
   created_at: '2024-09-05T10:05:03.871Z',
   created_by: 'Test User',
-  datasetInfo: [{ language: 'en-GB', title: 'Dataset with import' }],
   dimensions: [],
   fact_table: [
     {
@@ -61,6 +59,7 @@ export const datasetWithImport: DatasetDTO = {
       online_cube_filename: undefined,
       publish_at: '',
       approved_at: '',
+      updated_at: '',
       created_by: 'Test User',
       data_table: {
         id: '6a8b56ea-2fc5-4413-9dc3-4d31cbe4c953',
@@ -114,7 +113,6 @@ export const datasetRevWithNoImports: DatasetDTO = {
   created_by: 'Test User',
   live: '',
   archive: '',
-  datasetInfo: [{ language: 'en-GB', title: 'Dataset revision with no import' }],
   dimensions: [],
   fact_table: [],
   revisions: [
@@ -125,6 +123,7 @@ export const datasetRevWithNoImports: DatasetDTO = {
       created_at: '2024-09-05T10:05:04.052Z',
       publish_at: '',
       approved_at: '',
+      updated_at: '',
       created_by: 'Test User'
     }
   ]
@@ -136,7 +135,6 @@ export const completedDataset: DatasetDTO = {
   created_by: 'Test User',
   live: '',
   archive: '',
-  datasetInfo: [{ language: 'en-GB', title: 'Completed dataset' }],
   dimensions: [],
   fact_table: [],
   revisions: [
@@ -148,6 +146,7 @@ export const completedDataset: DatasetDTO = {
       online_cube_filename: undefined,
       publish_at: '',
       approved_at: '',
+      updated_at: '',
       created_by: 'Test User',
       data_table: {
         id: '6a8b56ea-2fc5-4413-9dc3-4d31cbe4c953',
@@ -204,7 +203,6 @@ export const datasetView: ViewDTO = {
     live: '',
     archive: '',
     fact_table: [],
-    datasetInfo: [{ language: 'en-GB', title: 'Dataset with import' }],
     dimensions: [],
     revisions: []
   },

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -73,8 +73,8 @@ describe('PublisherApi', () => {
     });
   });
 
-  describe('getActiveDatasetList', () => {
-    it('should return an array of FileDescriptions', async () => {
+  describe('getDatasetList', () => {
+    it('should return an array of DatasetListItemDTO', async () => {
       const list: DatasetListItemDTO[] = [
         { id: randomUUID(), title: 'Example 1' },
         { id: randomUUID(), title: 'Example 2' }
@@ -82,7 +82,7 @@ describe('PublisherApi', () => {
 
       mockResponse = Promise.resolve(new Response(JSON.stringify({ files: list })));
 
-      const fileList = await statsWalesApi.getActiveDatasetList();
+      const fileList = await statsWalesApi.getDatasetList();
       expect(fileList).toEqual({ files: list });
     });
   });
@@ -106,59 +106,41 @@ describe('PublisherApi', () => {
     });
   });
 
-  describe('confirmFileImport', () => {
-    it('should return a FileImportDTO', async () => {
+  describe('confirmDataTable', () => {
+    it('should return a DataTableDTO', async () => {
       const datasetId = randomUUID();
       const revisionId = randomUUID();
       const importId = randomUUID();
-      const fileImport = { dataset_id: datasetId, revision_id: revisionId, import_id: importId };
+      const dataTable = { dataset_id: datasetId, revision_id: revisionId, import_id: importId };
 
-      mockResponse = Promise.resolve(new Response(JSON.stringify(fileImport)));
+      mockResponse = Promise.resolve(new Response(JSON.stringify(dataTable)));
 
-      const fileImportDTO = await statsWalesApi.confirmFileImport(datasetId, revisionId);
+      const dataTableDTO = await statsWalesApi.confirmDataTable(datasetId, revisionId);
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/data-table/confirm`,
         { method: HttpMethod.Patch, headers }
       );
-      expect(fileImportDTO).toEqual(fileImport);
+      expect(dataTableDTO).toEqual(dataTable);
     });
   });
 
-  describe('getSourcesForFileImport', () => {
-    it('should return a FileImportDTO', async () => {
+  describe('getSourcesForDataset', () => {
+    it('should return an array of FactTableColumnDto', async () => {
       const datasetId = randomUUID();
       const revisionId = randomUUID();
       const importId = randomUUID();
-      const fileImport = { dataset_id: datasetId, revision_id: revisionId, import_id: importId };
+      const dataTable = { dataset_id: datasetId, revision_id: revisionId, import_id: importId };
 
-      mockResponse = Promise.resolve(new Response(JSON.stringify(fileImport)));
+      mockResponse = Promise.resolve(new Response(JSON.stringify(dataTable)));
 
-      const fileImportDTO = await statsWalesApi.getSourcesForDataset(datasetId);
+      const factTableColumnDto = await statsWalesApi.getSourcesForDataset(datasetId);
 
       expect(fetchSpy).toHaveBeenCalledWith(`${baseUrl}/dataset/${datasetId}/sources`, {
         method: HttpMethod.Get,
         headers
       });
-      expect(fileImportDTO).toEqual(fileImport);
-    });
-  });
-
-  describe('removeFileImport', () => {
-    it('should return the updated DatasetDTO', async () => {
-      const datasetId = randomUUID();
-      const revisionId = randomUUID();
-      const dataset = { id: datasetId, title: 'Example Dataset' };
-
-      mockResponse = Promise.resolve(new Response(JSON.stringify(dataset)));
-
-      const datasetDTO = await statsWalesApi.removeFileImport(datasetId, revisionId);
-
-      expect(fetchSpy).toHaveBeenCalledWith(`${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/data-table`, {
-        method: HttpMethod.Delete,
-        headers
-      });
-      expect(datasetDTO).toEqual(dataset);
+      expect(factTableColumnDto).toEqual(dataTable);
     });
   });
 
@@ -169,7 +151,7 @@ describe('PublisherApi', () => {
 
       mockResponse = Promise.resolve(new Response(JSON.stringify(dataset)));
 
-      const datasetDTO = await statsWalesApi.getFullDataset(datasetId);
+      const datasetDTO = await statsWalesApi.getDataset(datasetId);
 
       expect(fetchSpy).toHaveBeenCalledWith(`${baseUrl}/dataset/${datasetId}`, {
         method: HttpMethod.Get,


### PR DESCRIPTION
This PR requires the backend PR: https://github.com/Marvell-Consulting/statswales-backend/pull/133

It allows the metadata to be versioned, and also fixes the following issues:

SW-460: Metadata properties that don't need translation should show as complete for both languages
SW-423: Show blank cell for Welsh if dimension name not provided
SW-420: Related report link text should be in translation export