### PR TITLE
Fetch the enabled auth providers from the backend

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -12,8 +12,15 @@ const config = appConfig();
 const cookieDomain = new URL(config.auth.jwt.cookieDomain).hostname;
 logger.debug(`JWT cookie domain is '${cookieDomain}'`);
 
-auth.get('/login', (req: Request, res: Response) => {
-  const providers = config.auth.providers;
+auth.get('/login', async (req: Request, res: Response) => {
+  let providers;
+
+  try {
+    providers = await req.conapi.getEnabledAuthProviders();
+  } catch (err) {
+    logger.error(err, 'Could not fetch auth providers from backend');
+    providers = config.auth.providers;
+  }
 
   if (req.query.error && req.query.error === 'expired') {
     logger.error(`Authentication token has expired`);

--- a/src/services/consumer-api.ts
+++ b/src/services/consumer-api.ts
@@ -9,6 +9,7 @@ import { Locale } from '../enums/locale';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 import { FileFormat } from '../enums/file-format';
+import { AuthProvider } from '../enums/auth-providers';
 
 const config = appConfig();
 
@@ -58,6 +59,12 @@ export class ConsumerApi {
 
   public async ping(): Promise<boolean> {
     return this.fetch({ url: 'healthcheck' }).then(() => true);
+  }
+
+  public async getEnabledAuthProviders(): Promise<AuthProvider[]> {
+    return this.fetch({ url: 'auth/providers' })
+      .then((response) => response.json())
+      .then((body) => body.enabled as unknown as AuthProvider[]);
   }
 
   public async getPublishedDatasetList(page = 1, limit = 20): Promise<ResultsetWithCount<DatasetListItemDTO>> {

--- a/tests/mocks/backend.ts
+++ b/tests/mocks/backend.ts
@@ -2,6 +2,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 
 import { DatasetListItemDTO } from '../../src/dtos/dataset-list-item';
+import { appConfig } from '../../src/config';
 
 import {
   datasets,
@@ -127,5 +128,10 @@ export const mockBackend = setupServer(
 
   http.get('http://example.com:3001/healthcheck', () => {
     return HttpResponse.json({ message: 'success' });
+  }),
+
+  http.get('http://localhost:3001/auth/providers', () => {
+    const enabled = appConfig().auth.providers;
+    return HttpResponse.json({ enabled });
   })
 );


### PR DESCRIPTION
This should prevent a situation where the frontend is displaying auth provider buttons for providers that aren't enabled in the corresponding back end.