### PR TITLE
SW-543: run the full stack in docker for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ Copy the [.env-example](.env-example) file to `.env` and provide the missing val
 
 ## Running the service
 
-To start the app in development mode:
+To start the app in development mode (connects to external services):
 
 ```bash
 npm install
 npm run dev
 ```
 
-or, if you don't have Docker:
+or, start the app in localstack mode (runs all required services in docker):
 
 ```bash
 npm install
-npm run local
+npm run localstack
 ```
 
 The service should now be available on port 3000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   backend:
     image: ghcr.io/marvell-consulting/statswales-backend:latest
+    pull_policy: always
     ports:
       - "3001:3001"
     depends_on:
@@ -22,4 +23,5 @@ services:
     environment:
       APP_ENV: 'ci'
       LOG_LEVEL: 'debug'
-      TEST_DB_PORT: 3002
+      TEST_DB_HOST: 'db'
+      TEST_DB_PORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,3 +3,23 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  db:
+    image: postgres:17
+    ports:
+      - "3002:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: statswales-backend-test
+
+  backend:
+    image: ghcr.io/marvell-consulting/statswales-backend:latest
+    ports:
+      - "3001:3001"
+    depends_on:
+      - db
+    environment:
+      APP_ENV: 'ci'
+      LOG_LEVEL: 'debug'
+      TEST_DB_PORT: 3002

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,7 @@ services:
 
   blobstorage:
     image: mcr.microsoft.com/azure-storage/azurite
-    container_name: 'azurite'
-    # command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --debug=/tmp/debug.log
+    command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --debug=/tmp/debug.log
     ports:
       - "10000:10000"
       - "10001:10001"
@@ -36,6 +35,6 @@ services:
       LOG_LEVEL: 'debug'
       TEST_DB_HOST: 'db'
       TEST_DB_PORT: 5432
+      AZURE_BLOB_STORAGE_URL: 'http://blobstorage:10000/devstoreaccount1'
     post_start:
-      - command: npm run seed:required
-      - command: npm run seed:ci
+      - command: sh -c "npm run seed:required && npm run seed:ci"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,6 @@ services:
       LOG_LEVEL: 'debug'
       TEST_DB_HOST: 'db'
       TEST_DB_PORT: 5432
+    post_start:
+      - command: npm run seed:required
+      - command: npm run seed:ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,24 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: statswales-backend-test
 
+  blobstorage:
+    image: mcr.microsoft.com/azure-storage/azurite
+    container_name: 'azurite'
+    # command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --debug=/tmp/debug.log
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+
   backend:
     image: ghcr.io/marvell-consulting/statswales-backend:latest
     pull_policy: always
     ports:
       - "3001:3001"
     depends_on:
+      - redis
       - db
+      - blobstorage
     environment:
       APP_ENV: 'ci'
       LOG_LEVEL: 'debug'

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,0 @@
-{
-  "watch": ["src"],
-  "ext": ".ts,.js",
-  "ignore": [],
-  "exec": "npx ts-node ./src/server.ts"
-}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:check": "npm-run-all check dev",
     "predev": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis; else docker compose up -d redis; fi }; f'",
     "dev": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
+    "prelocal": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d db backend; else docker compose up -d db backend; fi }; f'",
     "local": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
     "start": "npm run build && node dist/server.js | pino-colada",
     "start:container": "node dist/server.js"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "dev:check": "npm-run-all check dev",
     "predev": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis; else docker compose up -d redis; fi }; f'",
     "dev": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
-    "prelocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis db blockstorage backend; else docker compose up -d redis db blockstorage backend; fi }; f'",
+    "prelocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis db blobstorage backend; else docker compose up -d redis db blobstorage backend; fi }; f'",
     "localstack": "trap 'exit 0' SIGINT; nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
-    "postlocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose stop redis db blockstorage backend; else docker compose stop redis db blockstorage backend; fi }; f'",
+    "postlocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose stop redis db blobstorage backend; else docker compose stop redis db blobstorage backend; fi }; f'",
     "start": "npm run build && node dist/server.js | pino-colada",
     "start:container": "node dist/server.js"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "predev": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis; else docker compose up -d redis; fi }; f'",
     "dev": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
     "prelocal": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d db backend; else docker compose up -d db backend; fi }; f'",
-    "local": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
+    "local": "trap 'exit 0' SIGINT; nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
+    "postlocal": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose stop db backend; else docker compose stop db backend; fi }; f'",
     "start": "npm run build && node dist/server.js | pino-colada",
     "start:container": "node dist/server.js"
   },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "dev:check": "npm-run-all check dev",
     "predev": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis; else docker compose up -d redis; fi }; f'",
     "dev": "nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
-    "prelocal": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d db backend; else docker compose up -d db backend; fi }; f'",
-    "local": "trap 'exit 0' SIGINT; nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
-    "postlocal": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose stop db backend; else docker compose stop db backend; fi }; f'",
+    "prelocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose up -d redis db blockstorage backend; else docker compose up -d redis db blockstorage backend; fi }; f'",
+    "localstack": "trap 'exit 0' SIGINT; nodemon --watch src -e ts,ejs,json,scss --exec npm run start",
+    "postlocalstack": "bash -c 'f() { if [ $(command -v podman) ]; then podman compose stop redis db blockstorage backend; else docker compose stop redis db blockstorage backend; fi }; f'",
     "start": "npm run build && node dist/server.js | pino-colada",
     "start:container": "node dist/server.js"
   },


### PR DESCRIPTION
This allows the full StatsWales stack to be run without needing to manually start or configure any external services (backend, db, file storage, etc) as they will all be started automatically inside Docker.

You could even work entirely offline if you have previously pulled the stack by commenting out `pull_policy: always` in `docker-compose.yml`.

This will also be the basis for running full e2e tests in CI.

Try it: 
`npm run localstack`

