### PR TITLE
SW-640: select user group for dataset

### DIFF
--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -1,11 +1,11 @@
-import { User } from '../../interfaces/user.interface';
 import { PublisherApi } from '../../services/publisher-api';
 import { Locale } from '../../enums/locale';
 import { ConsumerApi } from '../../services/consumer-api';
+import { UserDTO } from '../../dtos/user/user';
 
 declare module 'express-serve-static-core' {
   interface Request {
-    user?: User;
+    user?: UserDTO;
     jwt?: string;
     pubapi: PublisherApi;
     conapi: ConsumerApi;

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -15,6 +15,7 @@ import {
   frequencyUnitValidator,
   frequencyValueValidator,
   getErrors,
+  groupIdValidator,
   hourValidator,
   isUpdatedValidator,
   linkIdValidator,
@@ -68,20 +69,69 @@ import { NumberType } from '../enums/number-type';
 import { PreviewMetadata } from '../interfaces/preview-metadata';
 import slugify from 'slugify';
 import { DuckDBSupportFileFormats } from '../enums/support-fileformats';
+import { singleLangUserGroup } from '../utils/single-lang-user-group';
+import { getEditorUserGroups } from '../utils/get-editor-user-groups';
 
 export const start = (req: Request, res: Response) => {
   req.session.errors = undefined;
   req.session.dimensionPatch = undefined;
   req.session.updateType = undefined;
   req.session.save();
-  res.render('publish/start');
+
+  const editorGroups = getEditorUserGroups(req.user);
+
+  // user must be in at least one group to start a new dataset
+  if (editorGroups.length < 1) {
+    req.session.errors = [{ field: '', message: { key: 'publish.start.errors.no_groups' } }];
+    req.session.save();
+    res.redirect(req.buildUrl('/', req.language));
+    return;
+  }
+
+  // if the user is only in a single group, we can bypass group selection and go straight to title
+  const datasetGroup = editorGroups[0].group;
+  const nextStep = editorGroups.length === 1 ? `title?group_id=${datasetGroup.id}` : 'group';
+
+  res.render('publish/start', { nextStep });
+};
+
+export const provideDatasetGroup = async (req: Request, res: Response) => {
+  const availableGroups = getEditorUserGroups(req.user).map((g) => singleLangUserGroup(g.group, req.language)) || [];
+  const validGroupIds = availableGroups.map((group) => group.id) as string[];
+  const values = req.body;
+  let errors: ViewError[] = [];
+
+  if (req.method === 'POST') {
+    try {
+      errors = (await getErrors(groupIdValidator(validGroupIds), req)).map((error: FieldValidationError) => {
+        return {
+          field: 'group_id',
+          message: { key: `publish.group.form.group_id.error.${error.value ? 'invalid' : 'missing'}` }
+        };
+      });
+
+      if (errors.length > 0) {
+        res.status(400);
+        throw new Error();
+      }
+
+      res.redirect(req.buildUrl(`/publish/title?group_id=${values.group_id}`, req.language));
+      return;
+    } catch (err) {
+      if (err instanceof ApiException) {
+        errors = [{ field: 'api', message: { key: 'errors.try_later' } }];
+      }
+    }
+  }
+
+  res.render('publish/group', { availableGroups, values, errors });
 };
 
 export const dimensionColumnNameRegex = /^[a-zA-ZÀ-ž0-9()\-_ £¢€$%+]+$/;
 
 export const provideTitle = async (req: Request, res: Response) => {
   let errors: ViewError[] = [];
-
+  const group_id = req.query.group_id as string;
   const existingDataset = res.locals.dataset ? singleLangDataset(res.locals.dataset, req.language) : undefined;
   const revisit = Boolean(existingDataset); // dataset will not exist the first time through
   let title = existingDataset?.draft_revision?.metadata?.title;
@@ -103,7 +153,13 @@ export const provideTitle = async (req: Request, res: Response) => {
         await req.pubapi.updateMetadata(existingDataset.id, { title, language: req.language });
         res.redirect(req.buildUrl(`/publish/${existingDataset.id}/tasklist`, req.language));
       } else {
-        const dataset = await req.pubapi.createDataset(title, req.language);
+        if (!group_id) {
+          res.status(400);
+          errors.push({ field: '', message: { key: 'publish.title.form.group_id.error.missing' } });
+          throw new Error();
+        }
+
+        const dataset = await req.pubapi.createDataset(title!, group_id, req.language);
         res.redirect(req.buildUrl(`/publish/${dataset.id}/upload`, req.language));
       }
       return;

--- a/src/dtos/user/user.ts
+++ b/src/dtos/user/user.ts
@@ -13,7 +13,7 @@ export interface UserDTO {
   global_roles: GlobalRole[];
   groups: UserGroupWithRolesDTO[];
   status: UserStatus;
-  created_at: Date;
-  updated_at: Date;
-  last_login_at: Date;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string;
 }

--- a/src/enums/global-role.ts
+++ b/src/enums/global-role.ts
@@ -1,3 +1,4 @@
 export enum GlobalRole {
-  ServiceAdmin = 'admin'
+  ServiceAdmin = 'service_admin',
+  Developer = 'developer'
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -211,7 +211,10 @@
       "p1": "To create a new dataset, you'll need:",
       "data_table": "a data table containing data values and references to all relevant dimensions",
       "lookup_table": "any user-generated lookup tables you need to include (if relevant)",
-      "metadata": "metadata about this dataset, in the language in which you're viewing this service"
+      "metadata": "metadata about this dataset, in the language in which you're viewing this service",
+      "errors": {
+        "no_groups": "You must be an editor in at least one group to create a dataset"
+      }
     },
     "dimension_name": {
       "dimension_heading": "What should this dimension be called on the StatsWales website?",
@@ -479,6 +482,17 @@
       "try_different_format": "Indicate different date formatting",
       "no_matches": "None of the dates matched the format supplied"
     },
+    "group": {
+      "heading": "Which group should this dataset belong to?",
+      "form": {
+        "group_id": {
+          "error": {
+            "invalid": "Select a group for this dataset",
+            "missing": "Select a group for this dataset"
+          }
+        }
+      }
+    },
     "title": {
       "heading": "What is the title of this dataset?",
       "appear": "This is the title that will appear on the StatsWales website",
@@ -492,7 +506,12 @@
             "too_short": "The title of this dataset must be 3 characters or more",
             "unique": "The entered title is already in use for a currently published dataset. Enter a unique title for this dataset."
           }
-        }
+        },
+        "group_id": {
+            "error": {
+              "missing": "No group has been selected for this dataset. You need to create this dataset again from the dataset list."
+            }
+          }
       }
     },
     "summary": {
@@ -1386,6 +1405,9 @@
             "options": {
               "service_admin": {
                 "label": "Service administrator"
+              },
+              "developer": {
+                "label": "Developer"
               },
               "editor": {
                 "label": "Editor"

--- a/src/interfaces/jwt-payload-with-user.ts
+++ b/src/interfaces/jwt-payload-with-user.ts
@@ -1,7 +1,7 @@
 import { JwtPayload } from 'jsonwebtoken';
 
-import { User } from './user.interface';
+import { UserDTO } from '../dtos/user/user';
 
 export interface JWTPayloadWithUser extends JwtPayload {
-  user?: User;
+  user?: UserDTO;
 }

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -1,8 +1,0 @@
-export interface User {
-  id: string;
-  email: string;
-  name: string;
-  givenName?: string;
-  familyName?: string;
-  isDeveloper?: boolean;
-}

--- a/src/middleware/ensure-authenticated.ts
+++ b/src/middleware/ensure-authenticated.ts
@@ -4,6 +4,7 @@ import JWT from 'jsonwebtoken';
 import { JWTPayloadWithUser } from '../interfaces/jwt-payload-with-user';
 import { logger } from '../utils/logger';
 import { appConfig } from '../config';
+import { GlobalRole } from '../enums/global-role';
 
 const config = appConfig();
 
@@ -33,11 +34,8 @@ export const ensureAuthenticated = (req: Request, res: Response, next: NextFunct
 
     if (decoded.user) {
       req.user = decoded.user;
-      // TODO: replace with role-based permissions are available
-      const developer = /@marvell-consulting.com$/.test(decoded.user.email);
-      req.user.isDeveloper = developer;
-      res.locals.isDeveloper = developer;
-      res.locals.isAdmin = developer;
+      res.locals.isAdmin = req.user.global_roles.includes(GlobalRole.ServiceAdmin);
+      res.locals.isDeveloper = req.user.global_roles.includes(GlobalRole.Developer);
     }
 
     res.locals.isAuthenticated = true;

--- a/src/middleware/ensure-developer.ts
+++ b/src/middleware/ensure-developer.ts
@@ -1,18 +1,19 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { logger } from '../utils/logger';
-import { User } from '../interfaces/user.interface';
 import { ForbiddenException } from '../exceptions/forbidden.exception';
+import { GlobalRole } from '../enums/global-role';
 
 export const ensureDeveloper = (req: Request, res: Response, next: NextFunction) => {
   logger.debug(`checking if user is a developer...`);
 
   try {
-    const user = req.user as User;
-    // TODO: replace with role based perms once available
-    if (!user || !user.email.includes('@marvell-consulting.com')) {
+    const user = req.user;
+
+    if (!user || !user.global_roles.includes(GlobalRole.Developer)) {
       throw new ForbiddenException('user is not a developer');
     }
+
     logger.info('user is a developer');
   } catch (err) {
     next(err);

--- a/src/routes/homepage.ts
+++ b/src/routes/homepage.ts
@@ -1,13 +1,13 @@
 import { NextFunction, Request, Response, Router } from 'express';
 
-import { flashMessages } from '../middleware/flash';
+import { flashErrors, flashMessages } from '../middleware/flash';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 import { getPaginationProps } from '../utils/pagination';
 
 export const homepage = Router();
 
-homepage.use(flashMessages);
+homepage.use(flashMessages, flashErrors);
 
 homepage.use((req: Request, res: Response, next: NextFunction) => {
   res.locals.activePage = 'home';
@@ -15,14 +15,20 @@ homepage.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 homepage.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  const errors = res.locals.errors;
+
   try {
     const page = parseInt(req.query.page_number as string, 10) || 1;
     const limit = parseInt(req.query.page_size as string, 10) || 20;
+
+    // user must be in at least one group to start a new dataset
+    const canCreate = req.user?.groups?.length || 0 > 0;
+
     const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getDatasetList(page, limit);
     const { data, count } = results;
     const pagination = getPaginationProps(page, limit, count);
     const flash = res.locals.flash;
-    res.render('homepage', { data, ...pagination, flash });
+    res.render('homepage', { data, ...pagination, flash, canCreate, errors });
   } catch (err) {
     next(err);
   }

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -43,7 +43,8 @@ import {
   updateDatatable,
   measureName,
   setupNumberDimension,
-  deleteDraftDataset
+  deleteDraftDataset,
+  provideDatasetGroup
 } from '../controllers/publish';
 import { DatasetInclude as Include } from '../enums/dataset-include';
 
@@ -54,6 +55,9 @@ const upload = multer({ storage: multer.memoryStorage() });
 publish.get('/', start);
 
 /* Dataset creation */
+publish.get('/group', provideDatasetGroup);
+publish.post('/group', upload.none(), provideDatasetGroup);
+
 publish.get('/title', provideTitle);
 publish.post('/title', upload.none(), provideTitle);
 

--- a/src/services/publisher-api.ts
+++ b/src/services/publisher-api.ts
@@ -101,9 +101,9 @@ export class PublisherApi {
     });
   }
 
-  public async createDataset(title?: string, language?: string): Promise<DatasetDTO> {
+  public async createDataset(title: string, userGroupId: string, language?: string): Promise<DatasetDTO> {
     logger.debug(`Creating new dataset...`);
-    const json: RevisionMetadataDTO = { title, language };
+    const json = { title, user_group_id: userGroupId, language };
 
     return this.fetch({ url: 'dataset', method: HttpMethod.Post, json }).then(
       (response) => response.json() as unknown as DatasetDTO

--- a/src/utils/get-editor-user-groups.ts
+++ b/src/utils/get-editor-user-groups.ts
@@ -1,0 +1,7 @@
+import { UserDTO } from '../dtos/user/user';
+import { UserGroupWithRolesDTO } from '../dtos/user/user-group-with-roles-dto';
+import { GroupRole } from '../enums/group-role';
+
+export const getEditorUserGroups = (user?: UserDTO): UserGroupWithRolesDTO[] => {
+  return user?.groups?.filter((g) => g.roles.includes(GroupRole.Editor)) || [];
+};

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -83,3 +83,5 @@ export const hourValidator = () => body('hour').isInt({ min: 0, max: 23, allow_l
 export const minuteValidator = () => body('minute').isInt({ min: 0, max: 59, allow_leading_zeroes: true });
 
 export const organisationIdValidator = () => body('organisation').trim().notEmpty().isUUID(4);
+
+export const groupIdValidator = (groupIds: string[]) => body('group_id').trim().isIn(groupIds);

--- a/src/views/homepage.ejs
+++ b/src/views/homepage.ejs
@@ -4,6 +4,7 @@
     <main class="govuk-main-wrapper" id="main-content" role="main">
 
         <%- include("partials/flash-messages"); %>
+        <%- include("partials/error-handler"); %>
 
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
@@ -11,11 +12,13 @@
             </div>
         </div>
 
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-half">
-                <a class="govuk-button" href="<%= buildUrl(`/publish`, i18n.language) %>"><%= t('homepage.buttons.create') %></a>
+        <% if (canCreate) { %>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-half">
+                    <a class="govuk-button" href="<%= buildUrl(`/publish`, i18n.language) %>"><%= t('homepage.buttons.create') %></a>
+                </div>
             </div>
-        </div>
+        <% } %>
 
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">

--- a/src/views/publish/group.ejs
+++ b/src/views/publish/group.ejs
@@ -1,0 +1,34 @@
+<%- include("../partials/header"); %>
+    <div class="govuk-width-container app-width-container">
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+
+                    <h1 class="govuk-heading-xl"><%= t('publish.group.heading') %></h1>
+
+
+                    <form enctype="multipart/form-data" method="post">
+                        <%- include("../partials/error-handler"); %>
+
+                        <div class="govuk-form-group <%= locals.errors?.find(e => e.field === 'group_id') ? 'govuk-form-group--error' : '' %>">
+                            <fieldset class="govuk-fieldset" aria-describedby="group_id">
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <% locals.availableGroups?.forEach(group => { %>
+                                        <div class="govuk-radios__item">
+                                            <input class="govuk-radios__input" id="<%= `group_${group.id}` %>" name="group_id" type="radio" value="<%= group.id %>" <%= values.group_id === group.id ? 'checked' : '' %> />
+                                            <label class="govuk-label govuk-radios__label" for="<%= `group_${group.id}` %>"><%= group.name %></label>
+                                        </div>
+                                    <% }) %>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" class="govuk-button" data-module="govuk-button"><%= t('buttons.continue') %></button>
+                    </form>
+
+                </div>
+            </div>
+        </main>
+    </div>
+
+<%- include("../partials/footer"); %>

--- a/src/views/publish/start.ejs
+++ b/src/views/publish/start.ejs
@@ -2,17 +2,22 @@
 
 <div class="govuk-width-container app-width-container">
 	<main class="govuk-main-wrapper" id="main-content" role="main">
+
 		<h1 class="govuk-heading-xl"><%= t('publish.start.title') %></h1>
 		<%- include("../partials/error-handler"); %>
+
 		<p class="govuk-body"><%= t('publish.start.p1') %></p>
+
 		<ul class="govuk-list govuk-list--bullet">
 			<li><%= t('publish.start.data_table') %></li>
 			<li><%= t('publish.start.lookup_table') %></li>
 			<li><%= t('publish.start.metadata') %></li>
 		</ul>
+
 		<div class="govuk-button-group">
-			<a href="<%= buildUrl('/publish/title', i18n.language) %>" class="govuk-button"><%= t('buttons.continue') %></a>
+			<a href="<%= buildUrl(`/publish/${nextStep}`, i18n.language) %>" class="govuk-button"><%= t('buttons.continue') %></a>
 		</div>
+
 	</main>
 </div>
 


### PR DESCRIPTION
Adds a new page between start -> dataset title screens, that allows the user to select the user group that they belong to that owns the dataset.

If the user is only an editor in a single group, then this page is skipped and that group will be used as the owner for the dataset.

![Screenshot 2025-04-11 at 17 44 25](https://github.com/user-attachments/assets/7940bb9e-bdc5-4cf6-800f-32d1e1e465d7)
