### PR TITLE
Prevent migrations running in localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,6 @@ services:
       TEST_DB_HOST: 'db'
       TEST_DB_PORT: 5432
       AZURE_BLOB_STORAGE_URL: 'http://blobstorage:10000/devstoreaccount1'
+    command: node dist/server.js # override command to prevent running migrations (autosync is on for CI env)
     post_start:
       - command: sh -c "npm run seed:required && npm run seed:ci"


### PR DESCRIPTION
The dockerfile now causes the container to run the migrations before starting up.

We don't want this in localstack env because db autosync is turned on.