### PR TITLE
Fix fact table validation error message

### DIFF
--- a/src/views/publish/empty-fact.ejs
+++ b/src/views/publish/empty-fact.ejs
@@ -21,7 +21,7 @@
                 <% if (data) { %>
                     <% if (data.length > 10) { %>
                         <details class="govuk-details" data-module="govuk-details">
-                            <summary class="govuk-details__summary"><%= t('fact_table_validation.incomplete_table_summary') %></summary>
+                            <summary class="govuk-details__summary"><%= t('errors.fact_table_validation.incomplete_table_summary', {rows: data.length}) %></summary>
                             <%- include("../partials/dimension-preview-table", headers, data);%>
                         </details>
                     <% } else { %>


### PR DESCRIPTION
The wrong tag was used on the view for fact table validation.  So a small fix to use the correct tag.