### PR TITLE
Update support link to Slack (Welsh)

### DIFF
--- a/src/i18n/cy.json
+++ b/src/i18n/cy.json
@@ -33,7 +33,7 @@
   "header": {
     "product_name": "StatsCymru F3.0",
     "beta": "Beta",
-    "feedback": "Rydych chi'n edrych ar fersiwn newydd o StatsCymru.  Gallwch gael cymorth trwy droi at <a class=\"govuk-link\" href=\"mailto:{{support_email}}\">{{support_email}}</a>.",
+    "feedback": "Rydych chi'n edrych ar fersiwn newydd o StatsCymru.  Gallwch gael cymorth trwy droi at <a class=\"govuk-link\" href=\"http://statswales3support.slack.com\">Slack</a>.",
     "logo": "StatsCymru logo",
     "navigation": {
       "menu": "Dewislen",


### PR DESCRIPTION
Don't think we need to change the text here, just added the Slack link:
![Screenshot 2025-05-01 at 10 46 21](https://github.com/user-attachments/assets/2f3b66c6-f86b-4dc0-8fc1-af2c59a4a5a7)
