### PR TITLE
Mandate having a notes code column

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -353,6 +353,11 @@ export const sources = async (req: Request, res: Response, next: NextFunction) =
         error = { field: 'source', message: { key: 'errors.sources.unknowns_found' } };
       }
 
+      if (counts.footnotes === 0) {
+        logger.error('User failed to identify the mandated footnotes column');
+        error = { field: 'source', message: { key: 'errors.sources.no_notes_column' } };
+      }
+
       if (counts.dataValues > 1) {
         logger.error('User tried to specify multiple data value sources');
         error = { field: 'source', message: { key: 'errors.sources.multiple_datavalues' } };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1131,6 +1131,7 @@
     },
     "sources": {
       "unknowns_found": "Select what each column in the data table contains",
+      "no_notes_column": "There should be one column in the data table for note codes. Check you've selected the correct options or check the data table is correct.",
       "multiple_datavalues": "There should only be one column in the data table for data values. Check you've selected the correct options or check the data table is correct.",
       "multiple_footnotes": "There should only be one column in the data table for note codes. Check you've selected the correct options or check the data table is correct.",
       "multiple_measures": "There should only be one column in the data table for measure or data types. Check you've selected the correct options or check the data table is correct.",


### PR DESCRIPTION
This adds a check before sending the request to the backend to make sure there is a notes column present during column matching.