### PR TITLE
Add support for bad note code validation errors

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -401,6 +401,9 @@ export const sources = async (req: Request, res: Response, next: NextFunction) =
     } else if (errors[0].message.key === 'errors.fact_table_validation.duplicate_fact') {
       res.render('publish/duplicate-fact', { ...viewErr, dimension: { factTableColumn: '' } });
       return;
+    } else if (errors[0].message.key === 'errors.fact_table_validation.bad_note_codes') {
+      res.render('publish/bad-note-codes', { ...viewErr, dimension: { factTableColumn: '' } });
+      return;
     }
   }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1233,16 +1233,29 @@
     },
     "dimension_reset": "Something went wrong trying to reset the dimension",
     "fact_table_validation": {
-      "incomplete_fact": "Data table has {{count}} incomplete facts",
+      "incomplete_fact": "Data table has {{count}} instances incomplete facts",
+      "incomplete_fact_500": "Data table has {{count}} or more instances incomplete facts",
+      "incomplete_fact_missing": "Data table has an unknown number of incomplete facts",
       "incomplete_fact_info": "You should correct your data table and upload it again.",
-      "incomplete_table_summary": "Table containing {{rows}} incomplete facts.",
+      "incomplete_table_summary": "Table containing {{rows}} lines of incomplete facts.",
+      "incomplete_table_summary_500": "Table containing the first {{rows}} lines of incomplete facts.",
       "change_data_table": "Replace the data table",
-      "duplicate_fact": "Data table has {{count}} duplicate facts",
+      "duplicate_fact": "Data table has {{count}} or more instances duplicate facts",
+      "duplicate_fact_500": "Data table has {{count}} instances duplicate facts",
+      "duplicate_fact_missing": "Data table has an unknown number of duplicate facts",
       "unknown_duplicate_fact": "The data table has one or more duplicate facts already in the cube.",
       "duplicate_fact_info": "You should correct your data table and upload it again.",
       "change_sources_action": "Change what each column contains",
       "duplicate_fact_summary": "Duplicate facts",
-      "duplicate_table_summary": "Show all duplicate facts"
+      "duplicate_table_summary": "Show Table containing {{rows}} lines of duplicate facts",
+      "duplicate_table_summary_500": "Show Table containing the first {{rows}} lines of duplicate facts",
+      "bad_note_codes": "Date table has {{count}} instances of unrecognised note codes",
+      "bad_note_codes_500": "Date table has {{count}} or more instances of unrecognised note codes",
+      "bad_note_codes_missing": "Date table has unknown number of unrecognised note codes",
+      "bad_node_code_fact_summary": "Facts with unrecognised notes codes",
+      "bad_node_code_table_summary": "Show Table containing {{rows}} lines with unrecognised codes",
+      "bad_node_code_table_summary_500": "Show Table containing the first {{rows}} lines with unrecognised codes",
+      "bad_node_code_info": "You should check you have used standard note codes.  Correct your data table and upload it again."
     }
   },
   "consumer_view": {

--- a/src/views/publish/bad-note-codes.ejs
+++ b/src/views/publish/bad-note-codes.ejs
@@ -3,39 +3,40 @@
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper " id="main-content" role="main">
 
-        <div class="govuk-grid-row  govuk-!-margin-bottom-4">
+        <div class="govuk-grid-row govuk-!-margin-bottom-4">
             <div class="govuk-grid-column-full">
                 <div class="warning-background">
                     <div class="govuk-error-message alert-warning">
                         <h1 class="govuk-heading-xl">
                             <% if (data.length > 499) { %>
-                                <%= t('errors.fact_table_validation.incomplete_fact_500', { count: data.length }) %>
+                                <%= t('errors.fact_table_validation.bad_note_codes_500', {count: data.length}) %>
                             <% } else if (data) { %>
-                                    <%= t('errors.fact_table_validation.incomplete_fact', { count: data.length }) %>
+                                <%= t('errors.fact_table_validation.bad_note_codes', {count: data.length}) %>
                             <% } else { %>
-                                <%= t('errors.fact_table_validation.incomplete_fact_missing') %>
+                                <%= t('errors.fact_table_validation.bad_note_codes_missing') %>
                             <% } %>
                         </h1>
 
-                        <p class="govuk-heading-s"><%= t('errors.fact_table_validation.incomplete_fact_info') %></p>
+                        <p class="govuk-body"><%= t('errors.fact_table_validation.bad_node_code_info') %></p>
                     </div>
                 </div>
             </div>
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <h2 class="govuk-heading-m"><%= t('errors.fact_table_validation.duplicate_fact_summary') %></h2>
+                <h2 class="govuk-heading-m"><%= t('errors.fact_table_validation.bad_node_code_fact_summary') %></h2>
 
                 <% if (data) { %>
                     <% if (data.length > 10) { %>
                         <details class="govuk-details" data-module="govuk-details">
                             <summary class="govuk-details__summary">
                                 <% if (data.length > 499) { %>
-                                    <%= t('errors.fact_table_validation.incomplete_table_summary_500', {rows: data.length}) %>
+                                    <%= t('errors.fact_table_validation.bad_node_code_table_summary_500', {rows: data.length}) %>
                                 <% } else { %>
-                                    <%= t('errors.fact_table_validation.incomplete_table_summary', {rows: data.length}) %>
+                                        <%= t('errors.fact_table_validation.bad_node_code_table_summary', {rows: data.length}) %>
                                 <% } %>
                             </summary>
+                            <summary class="govuk-details__summary"></summary>
                             <%- include("../partials/dimension-preview-table", headers, data);%>
                         </details>
                     <% } else { %>
@@ -45,6 +46,11 @@
 
                 <p class="govuk-heading-s"><%= t('publish.time_dimension_review.actions') %></p>
                 <ul class="govuk-list">
+                    <li>
+                        <a href="<%= buildUrl(`/publish/${locals.dataset.id}/sources`, i18n.language) %>">
+                            <%= t('errors.fact_table_validation.change_sources_action') %>
+                        </a>
+                    </li>
                     <li>
                         <a href="<%= buildUrl(`/publish/${locals.dataset.id}/upload`, i18n.language) %>">
                             <%= t('errors.fact_table_validation.change_data_table') %>

--- a/src/views/publish/duplicate-fact.ejs
+++ b/src/views/publish/duplicate-fact.ejs
@@ -7,7 +7,15 @@
             <div class="govuk-grid-column-full">
                 <div class="warning-background">
                     <div class="govuk-error-message alert-warning">
-                        <h1 class="govuk-heading-xl"><%= t('errors.fact_table_validation.duplicate_fact', {count: data.length}) %></h1>
+                        <h1 class="govuk-heading-xl">
+                            <% if (data.length > 499) { %>
+                                <%= t('errors.fact_table_validation.duplicate_fact_500', {count: data.length}) %>
+                            <% } else if (data) { %>
+                                    <%= t('errors.fact_table_validation.duplicate_fact', {count: data.length}) %>
+                            <% } else { %>
+                                    <%= t('errors.fact_table_validation.duplicate_fact_missing') %>
+                            <% } %>
+                        </h1>
 
                         <p class="govuk-body"><%= t('errors.fact_table_validation.duplicate_fact_info') %></p>
                     </div>
@@ -21,7 +29,14 @@
                 <% if (data) { %>
                     <% if (data.length > 10) { %>
                         <details class="govuk-details" data-module="govuk-details">
-                            <summary class="govuk-details__summary"><%= t('errors.fact_table_validation.duplicate_table_summary') %></summary>
+                            <summary class="govuk-details__summary">
+                                <% if (data.length > 499) { %>
+                                    <%= t('errors.fact_table_validation.duplicate_table_summary_500', {rows: data.length}) %>
+                                <% } else { %>
+                                        <%= t('errors.fact_table_validation.duplicate_table_summary') %>
+                                <% } %>
+                            </summary>
+                            <summary class="govuk-details__summary"></summary>
                             <%- include("../partials/dimension-preview-table", headers, data);%>
                         </details>
                     <% } else { %>


### PR DESCRIPTION
Adds support for bad note code validation errors and updates the existing incomplete and duplicate fact errors with clearer messaging around only showing the first 500 lines from a dataset.