### PR TITLE
SW-714: fix translation import when link ids include hyphen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "marked-gfm-heading-id": "^4.1.1",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^3.3.7",
+        "nanoid-dictionary": "^5.0.0",
         "passport": "^0.7.0",
         "pino": "^9.4.0",
         "pino-http": "^10.3.0",
@@ -8232,6 +8233,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/nanoid-dictionary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid-dictionary/-/nanoid-dictionary-5.0.0.tgz",
+      "integrity": "sha512-/iCyQHwt36XkaIvSE9fcC8p6DiMPCZMTSMj9UT56Cv6T7f5CuxvOMhpNncaNieQ4z4d32p7ruEtAfRsb7Ya8Gw==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "marked-gfm-heading-id": "^4.1.1",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.7",
+    "nanoid-dictionary": "^5.0.0",
     "passport": "^0.7.0",
     "pino": "^9.4.0",
     "pino-http": "^10.3.0",

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -3,7 +3,8 @@ import { Readable } from 'node:stream';
 import { NextFunction, Request, Response } from 'express';
 import { get, set, sortBy } from 'lodash';
 import { FieldValidationError, matchedData } from 'express-validator';
-import { nanoid } from 'nanoid';
+import { customAlphabet } from 'nanoid';
+import { alphanumeric } from 'nanoid-dictionary';
 import { v4 as uuid } from 'uuid';
 import { isBefore, isValid } from 'date-fns';
 import { parse } from 'csv-parse';
@@ -75,6 +76,10 @@ import { PublishingStatus } from '../enums/publishing-status';
 import { NotAllowedException } from '../exceptions/not-allowed.exception';
 import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
+
+// the default nanoid alphabet includes hyphens which causes issues with the translation export/import process in Excel
+// - it tries to be smart and interprets strings that start with a hypen as a formula.
+const nanoid = customAlphabet(alphanumeric, 5);
 
 export const start = (req: Request, res: Response) => {
   req.session.errors = undefined;
@@ -2203,7 +2208,7 @@ export const provideRelatedLinks = async (req: Request, res: Response, next: Nex
 
   let errors: ViewError[] | undefined;
   let related_links = sortBy(revision?.related_links || [], 'created_at');
-  let link: RelatedLinkDTO = { id: nanoid(4), url: '', label_en: '', label_cy: '', created_at: now };
+  let link: RelatedLinkDTO = { id: nanoid(), url: '', label_en: '', label_cy: '', created_at: now };
 
   if (deleteId) {
     try {


### PR DESCRIPTION
Excel tries to be smart and will treat any strings such as "-RxC" in a CSV as a formula instead of just a string. You can't prevent this by just quoting the string.

Instead, lets just limit the available charset for link ids to just alphanumeric chars.