### PR TITLE
SW-675: Set cache-control no-cache header for pub/dev routes

### DIFF
--- a/src/middleware/no-cache.ts
+++ b/src/middleware/no-cache.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const noCache = (req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  next();
+};

--- a/src/middleware/no-cache.ts
+++ b/src/middleware/no-cache.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 
 export const noCache = (req: Request, res: Response, next: NextFunction) => {
-  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  res.setHeader('Cache-Control', 'no-cache, must-revalidate, proxy-revalidate');
   next();
 };

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,12 +17,13 @@ import {
 } from '../controllers/admin';
 import { ensureAdmin } from '../middleware/ensure-admin';
 import { flashMessages } from '../middleware/flash';
+import { noCache } from '../middleware/no-cache';
 
 export const admin = Router();
 
 const upload = multer({ storage: multer.memoryStorage() });
 
-admin.use(ensureAdmin, flashMessages);
+admin.use(ensureAdmin, noCache, flashMessages);
 
 admin.use('/group', (req: Request, res: Response, next: NextFunction) => {
   res.locals.activePage = 'groups';

--- a/src/routes/developer.ts
+++ b/src/routes/developer.ts
@@ -4,6 +4,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { fetchDataset } from '../middleware/fetch-dataset';
 import { ensureDeveloper } from '../middleware/ensure-developer';
 import { flashMessages } from '../middleware/flash';
+import { noCache } from '../middleware/no-cache';
 import {
   displayDatasetPreview,
   downloadAllDatasetFiles,
@@ -15,7 +16,7 @@ import {
 
 export const developer = Router();
 
-developer.use(ensureDeveloper, flashMessages);
+developer.use(ensureDeveloper, noCache, flashMessages);
 
 developer.use((req: Request, res: Response, next: NextFunction) => {
   res.locals.activePage = 'developer';

--- a/src/routes/publish.ts
+++ b/src/routes/publish.ts
@@ -49,12 +49,13 @@ import {
 } from '../controllers/publish';
 import { DatasetInclude as Include } from '../enums/dataset-include';
 import { flashMessages } from '../middleware/flash';
+import { noCache } from '../middleware/no-cache';
 
 export const publish = Router();
 
 const upload = multer({ storage: multer.memoryStorage() });
 
-publish.use(flashMessages);
+publish.use(noCache, flashMessages);
 
 publish.get('/', start);
 


### PR DESCRIPTION
Users keep complaining about seeing stale statuses in the tasklist, so just force their browser to always refetch.