### PR TITLE
Chore - SW-755 - replace javascript:history:back()

### DIFF
--- a/src/views/components/T.jsx
+++ b/src/views/components/T.jsx
@@ -8,5 +8,5 @@ export default function T({ children, raw, className, ...props }) {
   if (raw) {
     return <span className={className} dangerouslySetInnerHTML={{ __html: content }} />;
   }
-  return <span>{content}</span>;
+  return <span className={className}>{content}</span>;
 }

--- a/src/views/components/TranslationsPreviewTable.jsx
+++ b/src/views/components/TranslationsPreviewTable.jsx
@@ -39,7 +39,9 @@ export default function TranslationsPreviewTable(props) {
           {
             key: 'edit_link',
             label: props.t('translations.export.table.action'),
-            format: (value) => <a href={value}>{props.t('translations.export.buttons.change')}</a>
+            format: (value) => (
+              <a href={`${value}?referrer=${props.referrer}`}>{props.t('translations.export.buttons.change')}</a>
+            )
           }
         ])
   ];

--- a/src/views/publish/collection.jsx
+++ b/src/views/publish/collection.jsx
@@ -4,8 +4,8 @@ import ErrorHandler from '../components/ErrorHandler';
 import clsx from 'clsx';
 
 export default function Collection(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">

--- a/src/views/publish/date-chooser.jsx
+++ b/src/views/publish/date-chooser.jsx
@@ -5,8 +5,15 @@ import Table from '../components/Table';
 import RadioGroup from '../components/RadioGroup';
 
 export default function DateChooser(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url.includes('change-format')
+    ? props.data
+      ? props.referrer
+      : props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}/change-type`, props.i18n.language)
+    : props.data
+      ? props.referrer
+      : props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}`, props.i18n.language);
+
   const columns = props.headers.map((col, index) => ({
     key: index,
     label:

--- a/src/views/publish/delete-draft.jsx
+++ b/src/views/publish/delete-draft.jsx
@@ -4,8 +4,8 @@ import DatasetStatus from '../components/dataset/DatasetStatus';
 import ErrorHandler from '../components/ErrorHandler';
 
 export default function DeleteDraft(props) {
-  const backLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-grid-row">

--- a/src/views/publish/designation.jsx
+++ b/src/views/publish/designation.jsx
@@ -4,8 +4,8 @@ import ErrorHandler from '../components/ErrorHandler';
 import RadioGroup from '../components/RadioGroup';
 
 export default function Designation(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">

--- a/src/views/publish/dimension-chooser.jsx
+++ b/src/views/publish/dimension-chooser.jsx
@@ -5,8 +5,10 @@ import DimensionPreviewTable from '../components/DimensionPreviewTable';
 import RadioGroup from '../components/RadioGroup';
 
 export default function DimensionChooser(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url.includes('change-type')
+    ? props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}`, props.i18n.language)
+    : returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/dimension-match-failure.jsx
+++ b/src/views/publish/dimension-match-failure.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Layout from '../components/layouts/Publisher';
 
 export default function DimensionMatchFailure(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink}>
       <span className="region-subhead">{props.dimension.metadata.name}</span>
@@ -53,7 +53,7 @@ export default function DimensionMatchFailure(props) {
                 <li
                   key={index}
                   className="govuk-list--bullet"
-                  __dangerouslySetInnerHTML={{
+                  dangerouslySetInnerHTML={{
                     __html: `
                           "${value.toString().replace(
                             ' ',

--- a/src/views/publish/dimension-name.jsx
+++ b/src/views/publish/dimension-name.jsx
@@ -16,7 +16,7 @@ export default function DimensionName(props) {
           return props.buildUrl(`/publish/${props.datasetId}/measure/review`, props.i18n.language);
         case 'date_period':
         case 'date':
-          return props.buildUrl(`/publish/${props.datasetId}/date/${props.id}/review`, props.i18n.language);
+          return props.buildUrl(`/publish/${props.datasetId}/dates/${props.id}/review`, props.i18n.language);
         default:
           return props.buildUrl(`/publish/${props.datasetId}/lookup/${props.id}/review`, props.i18n.language);
       }
@@ -32,16 +32,13 @@ export default function DimensionName(props) {
           ? props.t('publish.dimension_name.measure_heading')
           : props.t('publish.dimension_name.dimension_heading')}
       </h1>
-
       <ErrorHandler {...props} />
-
       <p className="govuk-body">{props.t('publish.dimension_name.hint')}</p>
       <ul className="govuk-list govuk-list--bullet">
         <li>{props.t('publish.dimension_name.concise')}</li>
         <li>{props.t('publish.dimension_name.unique')}</li>
         <li>{props.t('publish.dimension_name.language')}</li>
       </ul>
-
       <form encType="multipart/form-data" method="post">
         <div className="govuk-form-group">
           <input className="govuk-input" id="name" name="name" type="text" defaultValue={props.dimensionName} />

--- a/src/views/publish/dimension-revisit.jsx
+++ b/src/views/publish/dimension-revisit.jsx
@@ -4,8 +4,10 @@ import ErrorHandler from '../components/ErrorHandler';
 import DimensionPreviewTable from '../components/DimensionPreviewTable';
 
 export default function DimensionRevisit(props) {
-  const backLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url.includes('change-type')
+    ? props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}`, props.i18n.language)
+    : returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink}>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/lookup-table-preview.jsx
+++ b/src/views/publish/lookup-table-preview.jsx
@@ -4,8 +4,20 @@ import ErrorHandler from '../components/ErrorHandler';
 import DimensionPreviewTable from '../components/DimensionPreviewTable';
 
 export default function LookupTablePreview(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+
+  const backLink = props.revisit
+    ? props.dimension.type === 'text'
+      ? props.buildUrl(`publish/${props.datasetId}/dimension/${props.dimension.id}/change-type`)
+      : props.dimension.type === 'numbers'
+        ? props.buildUrl(`publish/${props.datasetId}/numbers/${props.dimension.id}/change-type`)
+        : props.referrer
+    : props.dimension.type === 'text'
+      ? props.buildUrl(`publish/${props.datasetId}/dimension/${props.dimension.id}`)
+      : props.dimension.type === 'numbers'
+        ? props.buildUrl(`publish/${props.datasetId}/numbers/${props.dimension.id}`)
+        : props.referrer;
+
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/measure-match-failure.jsx
+++ b/src/views/publish/measure-match-failure.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Layout from '../components/layouts/Publisher';
 
 export default function MeasureMatchFailure(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink}>
       <span className="region-subhead">{props.measure.metadata.name}</span>

--- a/src/views/publish/measure-preview.jsx
+++ b/src/views/publish/measure-preview.jsx
@@ -4,8 +4,10 @@ import ErrorHandler from '../components/ErrorHandler';
 import MeasurePreviewTable from '../components/MeasurePreviewTable';
 
 export default function MeasurePreview(props) {
-  const backLink = props.buildUrl(`/publish/${props.datasetId}/measure`, props.i18n.language);
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url.includes('change-lookup')
+    ? props.buildUrl(`/publish/${props.datasetId}/measure`, props.i18n.language)
+    : returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.measure.metadata.name}</span>

--- a/src/views/publish/measure-review.jsx
+++ b/src/views/publish/measure-review.jsx
@@ -4,8 +4,8 @@ import MeasurePreviewTable from '../components/MeasurePreviewTable';
 import Layout from '../components/layouts/Publisher';
 
 export default function MeasureReview(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.buildUrl(`/publish/${props.datasetId}/measure`, props.i18n.language);
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.measure.metadata.name}</span>

--- a/src/views/publish/number-chooser.jsx
+++ b/src/views/publish/number-chooser.jsx
@@ -5,8 +5,10 @@ import DimensionPreviewTable from '../components/DimensionPreviewTable';
 import RadioGroup from '../components/RadioGroup';
 
 export default function NumberChooser(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.revisit
+    ? props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}/change-type`, props.i18n.language)
+    : props.buildUrl(`/publish/${props.datasetId}/dimension/${props.dimension.id}`, props.i18n.language);
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/period-match-failure.jsx
+++ b/src/views/publish/period-match-failure.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Layout from '../components/layouts/Publisher';
 
 export default function PeriodMatchFailure(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink}>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/period-type.jsx
+++ b/src/views/publish/period-type.jsx
@@ -5,7 +5,7 @@ import RadioGroup from '../components/RadioGroup';
 
 export default function PeriodType(props) {
   const backLink = props.buildUrl(
-    `/publish/${props.datasetId}/dates/${props.dimension.id}/period/year-format`,
+    `/publish/${props.datasetId}/dates/${props.dimension.id}/period`,
     props.i18n.language
   );
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);

--- a/src/views/publish/preview.jsx
+++ b/src/views/publish/preview.jsx
@@ -6,9 +6,9 @@ import Table from '../components/Table';
 import RadioGroup from '../components/RadioGroup';
 
 export default function Preview(props) {
-  const backLink = props.revisit && props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   const returnLink =
     props.revisit && props.datasetId && props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.revisit && returnLink;
   const colgroup = (
     <>
       {props.headers.map((header, index) => (
@@ -123,20 +123,20 @@ export default function Preview(props) {
                       }
                     ]}
                   />
+                  <div className="govuk-button-group">
+                    <button
+                      type="submit"
+                      name="confirm"
+                      value="true"
+                      className="govuk-button"
+                      data-module="govuk-button"
+                      style={{ verticalAlign: 'unset' }}
+                      data-prevent-double-click="true"
+                    >
+                      {props.t('buttons.continue')}
+                    </button>
+                  </div>
                 </form>
-                <div className="govuk-button-group">
-                  <button
-                    type="submit"
-                    name="confirm"
-                    value="true"
-                    className="govuk-button"
-                    data-module="govuk-button"
-                    style={{ verticalAlign: 'unset' }}
-                    data-prevent-double-click="true"
-                  >
-                    {props.t('buttons.continue')}
-                  </button>
-                </div>
               </div>
             </div>
           ) : (

--- a/src/views/publish/providers.jsx
+++ b/src/views/publish/providers.jsx
@@ -5,8 +5,10 @@ import Table from '../components/Table';
 import RadioGroup from '../components/RadioGroup';
 
 export default function Providers(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.url.includes('?edit=')
+    ? props.buildUrl(`/publish/${props.datasetId}/providers`, props.i18n.language)
+    : returnLink;
   const columns = [
     'provider',
     {

--- a/src/views/publish/quality.jsx
+++ b/src/views/publish/quality.jsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import RadioGroup from '../components/RadioGroup';
 
 export default function Quality(props) {
-  const backLink = 'javascript:history.back()';
+  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>

--- a/src/views/publish/related-links.jsx
+++ b/src/views/publish/related-links.jsx
@@ -7,8 +7,9 @@ import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
 
 export default function RelatedLinks(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  console.log(props.referrer);
+  const backLink = props.referrer;
 
   const columns = [
     {

--- a/src/views/publish/schedule.jsx
+++ b/src/views/publish/schedule.jsx
@@ -4,8 +4,8 @@ import ErrorHandler from '../components/ErrorHandler';
 import clsx from 'clsx';
 
 export default function Schedule(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
 
   function Field({ name, width = 3 }) {
     return (

--- a/src/views/publish/sources.jsx
+++ b/src/views/publish/sources.jsx
@@ -3,9 +3,9 @@ import Layout from '../components/layouts/Publisher';
 import ErrorHandler from '../components/ErrorHandler';
 
 export default function Sources(props) {
-  const backLink = props.revisit && 'javascript:history.back()';
   const returnLink =
     props.revisit && props.datasetId && props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <h1 className="govuk-heading-xl">{props.t('publish.sources.heading')}</h1>

--- a/src/views/publish/summary.jsx
+++ b/src/views/publish/summary.jsx
@@ -4,8 +4,8 @@ import Layout from '../components/layouts/Publisher';
 import clsx from 'clsx';
 
 export default function Summary(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">

--- a/src/views/publish/title.jsx
+++ b/src/views/publish/title.jsx
@@ -4,9 +4,9 @@ import ErrorHandler from '../components/ErrorHandler';
 import clsx from 'clsx';
 
 export default function Title(props) {
-  const backLink = props.revisit && 'javascript:history.back()';
   const returnLink =
     props.revisit && props.datasetId && props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.revisit && returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <h1 className="govuk-heading-xl">{props.t('publish.title.heading')}</h1>

--- a/src/views/publish/topics.jsx
+++ b/src/views/publish/topics.jsx
@@ -3,8 +3,8 @@ import Layout from '../components/layouts/Publisher';
 import ErrorHandler from '../components/ErrorHandler';
 
 export default function Topics(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-grid-row">

--- a/src/views/publish/translations/export.jsx
+++ b/src/views/publish/translations/export.jsx
@@ -3,7 +3,7 @@ import Layout from '../../components/layouts/Publisher';
 import TranslationsPreviewTable from '../../components/TranslationsPreviewTable';
 
 export default function Export(props) {
-  const backLink = 'javascript:history.back()';
+  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink}>

--- a/src/views/publish/translations/import.jsx
+++ b/src/views/publish/translations/import.jsx
@@ -4,8 +4,8 @@ import TranslationsPreviewTable from '../../components/TranslationsPreviewTable'
 import ErrorHandler from '../../components/ErrorHandler';
 
 export default function Import(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">

--- a/src/views/publish/update-frequency.jsx
+++ b/src/views/publish/update-frequency.jsx
@@ -6,8 +6,8 @@ import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
 
 export default function UpdateFrequency(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">

--- a/src/views/publish/update-type.jsx
+++ b/src/views/publish/update-type.jsx
@@ -5,8 +5,8 @@ import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
 
 export default function UpdateType(props) {
-  const backLink = 'javascript:history.back()';
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = returnLink;
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <ErrorHandler {...props} />

--- a/src/views/publish/year-format.jsx
+++ b/src/views/publish/year-format.jsx
@@ -5,8 +5,11 @@ import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
 
 export default function YearFormat(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.buildUrl(
+    `/publish/${props.datasetId}/dates/${props.dimension.id}/period`,
+    props.i18n.language
+  );
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.dimension.metadata.name}</span>

--- a/src/views/publish/year-type.jsx
+++ b/src/views/publish/year-type.jsx
@@ -5,8 +5,10 @@ import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
 
 export default function YearType(props) {
-  const backLink = props.referrer;
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
+  const backLink = props.revisit
+    ? props.buildUrl(`/publish/${props.datasetId}/dates/${props.dimension.id}/change-format`, props.i18n.language)
+    : props.buildUrl(`/publish/${props.datasetId}/dates/${props.dimension.id}`, props.i18n.language);
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <span className="region-subhead">{props.dimension.metadata.name}</span>


### PR DESCRIPTION
* Replaced all instances with derived last page
* This could still be improved by passing a query param if visiting from translations edit links
* Fixed as bug on publish/preview where you cannot click the continue button (as was outside the form)