### PR TITLE
Fix revisit logic for dimension

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -857,7 +857,7 @@ export const lookupReview = async (req: Request, res: Response, next: NextFuncti
       return;
     }
     let errors: ViewErrDTO | undefined;
-    const revisit = Boolean(dimension.factTableColumn !== dimension.metadata?.name);
+    const revisit = !!dimension.metadata?.name;
 
     if (req.method === 'POST') {
       switch (req.body?.confirm) {


### PR DESCRIPTION
Previously we set the initial dimension name to the fact column name, now it is set to an empty string. This should be used to determine revisit status