### PR TITLE
Allow devs to rebuild any cube (inc. published) from the dev view

### DIFF
--- a/src/controllers/developer.ts
+++ b/src/controllers/developer.ts
@@ -247,16 +247,10 @@ export const downloadAllDatasetFiles = async (req: Request, res: Response, next:
 };
 
 export const rebuildCube = async (req: Request, res: Response, next: NextFunction) => {
-  const dataset = singleLangDataset(res.locals.dataset, req.language);
-  const revision = dataset.draft_revision;
-  if (!revision) {
-    logger.error('No draft revision found');
-    next(new NotFoundException('errors.draft_missing'));
-    return;
-  }
+  const dataset = res.locals.dataset;
 
   try {
-    await req.pubapi.rebuildCube(dataset.id, revision.id);
+    await req.pubapi.rebuildCube(dataset.id, dataset.end_revision_id);
     res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
   } catch (_err) {
     logger.error(_err, 'Error rebuilding the cube');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1142,7 +1142,8 @@
         "last_updated": "Last updated",
         "dataset_status": "Dataset status",
         "publish_status": "Publishing status",
-        "not_translated": "Not yet translated"
+        "not_translated": "Not yet translated",
+        "actions": "Actions"
       }
     },
     "display": {

--- a/src/views/developer/list.jsx
+++ b/src/views/developer/list.jsx
@@ -66,13 +66,21 @@ export default function DeveloperList(props) {
     },
     {
       key: 'id',
-      label: '',
-      format: (value) => {
-        const url = `/${props.i18n.language}/publish/${value}/tasklist`;
+      label: props.t('developer.list.table.actions'),
+      format: (datasetId) => {
         return (
-          <a href={url} className="govuk-link">
-            <i className="fa-solid fa-list-check"></i> {props.t('developer.list.tasklist')}
-          </a>
+          <ul className="govuk-summary-list__actions-list govuk-!-margin-bottom-0">
+            <li className="govuk-summary-list__actions-list-item">
+              <a href={`/${props.i18n.language}/publish/${datasetId}/tasklist`} className="govuk-link">
+                <i className="fa-solid fa-list-check"></i> {props.t('developer.list.tasklist')}
+              </a>
+            </li>
+            <li className="govuk-summary-list__actions-list-item">
+              <a href={`/${props.i18n.language}/developer/${datasetId}/rebuild`} className="govuk-link">
+                {props.t('publish.tasklist.rebuild_cube')}
+              </a>
+            </li>
+          </ul>
         );
       }
     }


### PR DESCRIPTION
Adds a link to the dev view to rebuild the cube.

Rebuild now sends the latest revision regardless of draft or not.