### PR TITLE
Disable DuckDB file downloads

### DIFF
--- a/src/views/consumer/view.jsx
+++ b/src/views/consumer/view.jsx
@@ -172,12 +172,12 @@ export default function ConsumerView(props) {
                 value: 'parquet',
                 label: 'Parquet',
                 hint: props.t('consumer_view.data_metadata_hint')
-              },
-              {
-                value: 'duckdb',
-                label: 'DuckDB',
-                hint: props.t('consumer_view.everything_hint')
               }
+              // {
+              //   value: 'duckdb',
+              //   label: 'DuckDB',
+              //   hint: props.t('consumer_view.everything_hint')
+              // }
             ]}
           />
 

--- a/tests-e2e/required/happy-path.spec.ts
+++ b/tests-e2e/required/happy-path.spec.ts
@@ -309,9 +309,10 @@ test.describe('Happy path', () => {
     await previewPage.click('#xlsx', { force: true });
     const excelDownload = await downloadFile(previewPage, previewPage.getByRole('button', { name: 'Download data' }));
     await checkFile(testInfo, excelDownload);
-    await previewPage.click('#duckdb', { force: true });
-    const duckDBDownload = await downloadFile(previewPage, previewPage.getByRole('button', { name: 'Download data' }));
-    await checkFile(testInfo, duckDBDownload);
+    // Disabled while DuckDB file download is unavailable
+    // await previewPage.click('#duckdb', { force: true });
+    // const duckDBDownload = await downloadFile(previewPage, previewPage.getByRole('button', { name: 'Download data' }));
+    // await checkFile(testInfo, duckDBDownload);
 
     // data table
     // TODO: link has a leading space


### PR DESCRIPTION
Comments out the option to download a duckdb file while this unavailable on the backend.  Hope to reintroduce shortly when we can move that code to a non-blocking worker thread.