### PR TITLE
filter with children should still count itself

### DIFF
--- a/src/views/components/Filters.tsx
+++ b/src/views/components/Filters.tsx
@@ -21,7 +21,8 @@ const normalizeFilters = (options: FilterTable['values']): CheckboxOptions[] => 
 
 const filterOptionCount = (options: FilterTable['values']): number => {
   return options.reduce((count, opt) => {
-    return opt.children ? count + filterOptionCount(opt.children) : count + 1;
+    const childCount = opt.children ? filterOptionCount(opt.children) : 0;
+    return count + childCount + 1;
   }, 0);
 };
 


### PR DESCRIPTION
Counter wasn't including the node itself in the count if there were child nodes.