### PR TITLE
if the task was already closed, just redirect back to overview

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -2695,6 +2695,11 @@ export const taskDecision = async (req: Request, res: Response, next: NextFuncti
       return;
     }
 
+    if (!task.open) {
+      res.redirect(req.buildUrl(`/publish/${res.locals.datasetId}/overview`, req.language));
+      return;
+    }
+
     taskType = `${task.action}.${task.status}`;
 
     if (req.method === 'POST') {


### PR DESCRIPTION
There was a bug where refreshing the task decision page after it was already closed left us with broken translations due to the task having the status of withdrawn.

This is not a valid screen so just redirect the user back to the overview page.