### PR TITLE
Bugfix - SW-816 - tabs and links focus fixes

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -429,7 +429,7 @@
 }
 .wg a:focus,
 .wg .govuk-link:focus {
-  outline: 3px solid transparent;
+  outline: 3px solid #ffd530;
   background-color: transparent;
   box-shadow: none;
 }

--- a/src/public/scss/_wg.scss
+++ b/src/public/scss/_wg.scss
@@ -503,7 +503,7 @@
 
   a:focus,
   .govuk-link:focus {
-    outline: 3px solid transparent;
+    outline: 3px solid colours.$yellow;
     background-color: transparent;
     box-shadow: none;
   }

--- a/src/views/components/Tabs.tsx
+++ b/src/views/components/Tabs.tsx
@@ -9,15 +9,16 @@ type Tab = {
 
 export type TabsProps = {
   tabs: Tab[];
-  tabIndexBase?: number;
+  title?: string;
 };
 
-export default function Tabs({ tabs, tabIndexBase = 0 }: TabsProps) {
+export default function Tabs({ tabs, title }: TabsProps) {
   return (
     <div className="govuk-tabs" data-module="govuk-tabs">
       <div className="tabs">
         <div className="govuk-width-container">
           <div className="govuk-main-wrapper govuk-!-padding-bottom-0">
+            {title && <h2 className="govuk-tabs__title">{title}</h2>}
             <ul className="govuk-tabs__list" role="tablist">
               {tabs.map((tab, i) => (
                 <li
@@ -31,7 +32,6 @@ export default function Tabs({ tabs, tabIndexBase = 0 }: TabsProps) {
                     id={`tab_${tab.id}`}
                     role="tab"
                     aria-controls={tab.id}
-                    tabIndex={tabIndexBase + i}
                   >
                     {tab.label}
                   </a>

--- a/src/views/consumer/view.jsx
+++ b/src/views/consumer/view.jsx
@@ -236,21 +236,19 @@ export default function ConsumerView(props) {
         </div>
       )}
 
-      <div className="govuk-tabs" data-module="govuk-tabs">
-        <h2 className="govuk-tabs__title">{props.t('toc')}</h2>
+      <Tabs
+        title={props.t('toc')}
+        tabs={[
+          ...(props?.isDeveloper && props?.showDeveloperTab
+            ? [{ label: props.t('developer.heading'), id: 'developer', children: <DeveloperView {...props} /> }]
+            : []),
+          { label: props.t('consumer_view.data'), id: 'data', children: DataPanel },
+          { label: props.t('consumer_view.about_this_dataset'), id: 'about_dataset', children: AboutPanel },
+          { label: props.t('consumer_view.download'), id: 'download_dataset', children: DownloadPanel }
+        ]}
+      />
 
-        <Tabs
-          tabs={[
-            ...(props?.isDeveloper && props?.showDeveloperTab
-              ? [{ label: props.t('developer.heading'), id: 'developer', children: <DeveloperView {...props} /> }]
-              : []),
-            { label: props.t('consumer_view.data'), id: 'data', children: DataPanel },
-            { label: props.t('consumer_view.about_this_dataset'), id: 'about_dataset', children: AboutPanel },
-            { label: props.t('consumer_view.download'), id: 'download_dataset', children: DownloadPanel }
-          ]}
-        />
-
-        {/* <div className="govuk-tabs__panel govuk-tabs__panel&#45;&#45;hidden" id="history" role="tabpanel" aria-labelledby="tab_history">
+      {/* <div className="govuk-tabs__panel govuk-tabs__panel&#45;&#45;hidden" id="history" role="tabpanel" aria-labelledby="tab_history">
                   <div className="govuk-grid-row">
                       <div className="govuk-grid-column-two-thirds">
 
@@ -280,7 +278,7 @@ export default function ConsumerView(props) {
                       </div>
                   </div>
               </div> */}
-      </div>
+      {/* </div> */}
     </LayoutComponent>
   );
 }

--- a/src/views/consumer/view.jsx
+++ b/src/views/consumer/view.jsx
@@ -247,38 +247,6 @@ export default function ConsumerView(props) {
           { label: props.t('consumer_view.download'), id: 'download_dataset', children: DownloadPanel }
         ]}
       />
-
-      {/* <div className="govuk-tabs__panel govuk-tabs__panel&#45;&#45;hidden" id="history" role="tabpanel" aria-labelledby="tab_history">
-                  <div className="govuk-grid-row">
-                      <div className="govuk-grid-column-two-thirds">
-
-                          <p><b>Next update expected (provisional):</b>  This dataset will not be updated</p>
-
-                          <h2 className="govuk-heading-m">Updates</h2>
-
-                          <dl className="govuk-summary-list">
-                              <div className="govuk-summary-list__row">
-                                  <dt style="width:16%" className="govuk-summary-list__key">
-                                      19 December 2019
-                                  </dt>
-                                  <dd className="govuk-summary-list__value">
-                                      Provisional values for Isle of Anglesey were revised. The 2019 dataset is now completed and will not be updated further.
-                                  </dd>
-                              </div>
-                              <div className="govuk-summary-list__row">
-                                  <dt className="govuk-summary-list__key">
-                                      14 September 2019
-                                  </dt>
-                                  <dd className="govuk-summary-list__value">
-                                      Dataset first published.
-                                  </dd>
-                              </div>
-                          </dl>
-
-                      </div>
-                  </div>
-              </div> */}
-      {/* </div> */}
     </LayoutComponent>
   );
 }


### PR DESCRIPTION
* Updated focus link styles to include yellow outline
* Fixed bug with tabs where listeners were firing twice, meaning second tab could not be selected with keyboard