### PR TITLE
SW-871: all dates should be translated

### DIFF
--- a/src/routes/consumer.ts
+++ b/src/routes/consumer.ts
@@ -1,11 +1,18 @@
 import { Router } from 'express';
 
-import { listTopics, downloadPublishedDataset, viewPublishedDataset } from '../controllers/consumer';
+import {
+  listTopics,
+  downloadPublishedDataset,
+  viewPublishedDataset,
+  listPublishedDatasets
+} from '../controllers/consumer';
 import { fetchPublishedDataset } from '../middleware/fetch-dataset';
 
 export const consumer = Router();
 
 consumer.get('/', listTopics);
+
+consumer.get('/all', listPublishedDatasets);
 
 consumer.get('/topic/:topicId{/:topicSlug}', listTopics);
 

--- a/src/services/consumer-api.ts
+++ b/src/services/consumer-api.ts
@@ -78,7 +78,7 @@ export class ConsumerApi {
     logger.debug(`Fetching published dataset list...`);
     const qs = `${new URLSearchParams({ page: page.toString(), limit: limit.toString() }).toString()}`;
 
-    return this.fetch({ url: `v1/list?${qs}` }).then(
+    return this.fetch({ url: `v1?${qs}` }).then(
       (response) => response.json() as unknown as ResultsetWithCount<DatasetListItemDTO>
     );
   }

--- a/src/views/admin/user-list.jsx
+++ b/src/views/admin/user-list.jsx
@@ -26,7 +26,9 @@ export default function UserList(props) {
       key: 'last_login_at',
       label: props.t('admin.user.list.table.login'),
       format: (value) =>
-        value ? props.dateFormat(value, 'd MMMM yyyy h:mm a') : props.t('admin.user.view.login_never')
+        value
+          ? props.dateFormat(value, 'd MMMM yyyy h:mm a', { locale: props.i18n.language })
+          : props.t('admin.user.view.login_never')
     },
     {
       key: 'status',

--- a/src/views/admin/user-view.jsx
+++ b/src/views/admin/user-view.jsx
@@ -44,7 +44,7 @@ export default function UserView(props) {
               <dt className="govuk-summary-list__key">{props.t('admin.user.view.details.login')}</dt>
               <dd className="govuk-summary-list__value">
                 {props.user.last_login_at
-                  ? props.dateFormat(props.user.last_login_at, 'd MMMM yyyy h:mm a')
+                  ? props.dateFormat(props.user.last_login_at, 'd MMMM yyyy h:mm a', { locale: props.i18n.language })
                   : props.t('admin.user.view.login_never')}
               </dd>
             </div>

--- a/src/views/components/consumer/ViewTable.jsx
+++ b/src/views/components/consumer/ViewTable.jsx
@@ -9,7 +9,7 @@ export default function ViewTable(props) {
       col.source_type === 'line_number' ? (
         <span className="linespan">{value}</span>
       ) : col.name === props.t('consumer_view.start_data') || col.name === props.t('consumer_view.end_data') ? (
-        props.dateFormat(props.parseISO(value.split('T')[0]), 'do MMMM yyyy')
+        props.dateFormat(props.parseISO(value.split('T')[0]), 'do MMMM yyyy', { locale: props.i18n.language })
       ) : (
         value
       ),

--- a/src/views/components/dataset/KeyInfo.jsx
+++ b/src/views/components/dataset/KeyInfo.jsx
@@ -10,7 +10,7 @@ export default function KeyInfo(props) {
           <dt className="govuk-summary-list__key">{props.t('dataset_view.key_information.last_update')}</dt>
           <dd className="govuk-summary-list__value">
             {props.keyInfo.updatedAt
-              ? props.dateFormat(props.keyInfo.updatedAt, 'd MMMM yyyy')
+              ? props.dateFormat(props.keyInfo.updatedAt, 'd MMMM yyyy', { locale: props.i18n.language })
               : props.t('dataset_view.key_information.update_missing')}
           </dd>
         </div>
@@ -19,7 +19,7 @@ export default function KeyInfo(props) {
           <dt className="govuk-summary-list__key">{props.t('dataset_view.key_information.next_update')}</dt>
           <dd className="govuk-summary-list__value">
             {props.keyInfo.nextUpdateAt
-              ? props.dateFormat(props.keyInfo.nextUpdateAt, 'MMMM yyyy')
+              ? props.dateFormat(props.keyInfo.nextUpdateAt, 'MMMM yyyy', { locale: props.i18n.language })
               : props.keyInfo.nextUpdateAt === false
                 ? props.t('dataset_view.key_information.not_updated')
                 : props.t('dataset_view.key_information.next_update_missing')}
@@ -76,8 +76,8 @@ export default function KeyInfo(props) {
           <dd className="govuk-summary-list__value">
             {props.keyInfo.timePeriod.start && props.keyInfo.timePeriod.end
               ? props.t('dataset_view.key_information.time_period', {
-                  start: props.dateFormat(props.keyInfo.timePeriod.start, 'MMMM yyyy'),
-                  end: props.dateFormat(props.keyInfo.timePeriod.end, 'MMMM yyyy')
+                  start: props.dateFormat(props.keyInfo.timePeriod.start, 'MMMM yyyy', { locale: props.i18n.language }),
+                  end: props.dateFormat(props.keyInfo.timePeriod.end, 'MMMM yyyy', { locale: props.i18n.language })
                 })
               : props.t('dataset_view.period_cover_missing')}
           </dd>

--- a/src/views/components/dataset/Notes.jsx
+++ b/src/views/components/dataset/Notes.jsx
@@ -17,7 +17,9 @@ export default function Notes(props) {
               <ul className="govuk-list">
                 {props.notes.publishedRevisions.map((revision, index) => (
                   <li key={index}>
-                    <strong>{props.dateFormat(revision.publish_at, 'd MMMM yyyy')}</strong>
+                    <strong>
+                      {props.dateFormat(revision.publish_at, 'd MMMM yyyy', { locale: props.i18n.language })}
+                    </strong>
                   </li>
                 ))}
               </ul>

--- a/src/views/consumer/list.jsx
+++ b/src/views/consumer/list.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import Layout from '../components/layouts/Publisher';
-import Pagination, { PaginationProps } from '../components/Pagination';
-import { Locals } from '../context/Locals';
-import { DatasetListItemDTO } from '../../dtos/dataset-list-item';
+import Pagination from '../components/Pagination';
 
-type ConsumerListProps = Locals &
-  PaginationProps & {
-    data: DatasetListItemDTO[];
-  };
-
-export default function ConsumerList(props: ConsumerListProps) {
+export default function ConsumerList(props) {
   return (
     <Layout {...props}>
       <div className="govuk-grid-row govuk-!-margin-bottom-6">
@@ -39,7 +32,7 @@ export default function ConsumerList(props: ConsumerListProps) {
                 <div className="index-list__meta">
                   <p>
                     <span className="govuk-body-s caption index-list__item__meta">
-                      {props.dateFormat(dataset.published_date, 'd MMMM yyyy')}
+                      {props.dateFormat(dataset.published_date, 'd MMMM yyyy', { locale: props.i18n.language })}
                     </span>
                   </p>
                 </div>

--- a/src/views/publish/date-chooser.jsx
+++ b/src/views/publish/date-chooser.jsx
@@ -28,7 +28,7 @@ export default function DateChooser(props) {
       switch (col.name) {
         case 'start_date':
         case 'end_date':
-          return props.dateFormat(props.parseISO(value.split('T')[0]), 'do MMMM yyyy');
+          return props.dateFormat(props.parseISO(value.split('T')[0]), 'do MMMM yyyy', { locale: props.i18n.language });
       }
       return value;
     }

--- a/src/views/publish/overview.jsx
+++ b/src/views/publish/overview.jsx
@@ -199,7 +199,9 @@ export default function Overview(props) {
                   className="govuk-body govuk-!-margin-0"
                   dangerouslySetInnerHTML={{
                     __html: props.t('publish.overview.pending.publish_at', {
-                      publishAt: props.dateFormat(props.revision?.publish_at, 'h:mmaaa, d MMMM yyyy')
+                      publishAt: props.dateFormat(props.revision?.publish_at, 'h:mmaaa, d MMMM yyyy', {
+                        locale: props.i18n.language
+                      })
                     })
                   }}
                 />
@@ -219,7 +221,9 @@ export default function Overview(props) {
                 className="govuk-body"
                 dangerouslySetInnerHTML={{
                   __html: props.t('publish.overview.scheduled.publish_at', {
-                    publishAt: props.dateFormat(props.revision?.publish_at, 'h:mmaaa, d MMMM yyyy')
+                    publishAt: props.dateFormat(props.revision?.publish_at, 'h:mmaaa, d MMMM yyyy', {
+                      locale: props.i18n.language
+                    })
                   })
                 }}
               ></p>

--- a/src/views/publish/task-decision.jsx
+++ b/src/views/publish/task-decision.jsx
@@ -24,7 +24,12 @@ export default function TaskDecision(props) {
             </p>
 
             <p className="govuk-body govuk-!-margin-0">
-              <T publishAt={props.dateFormat(props.revision.publish_at, 'h:mmaaa, d MMMM yyyy')} raw>
+              <T
+                publishAt={props.dateFormat(props.revision.publish_at, 'h:mmaaa, d MMMM yyyy', {
+                  locale: props.i18n.language
+                })}
+                raw
+              >
                 publish.overview.pending.publish_at
               </T>
             </p>


### PR DESCRIPTION
Some of the dates displayed on the frontend were always rendered in English.

We already have support for localised dates, just needs to be passed a locale.