### PR TITLE
Make node_modules/.cache writeable by node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ COPY package*.json ./
 # install only production dependencies
 RUN npm ci --omit=dev
 
+RUN chown -R node:node /app
+
 # copy in the built application source from the builder image
 COPY --from=builder --chown=node:node /app/dist ./dist
 


### PR DESCRIPTION
We're getting the error:

```
2025-07-08T09:47:42.456262470Z Babel could not write cache to file: /app/node_modules/.cache/@babel/register/.babel.7.27.1.production.json
2025-07-08T09:47:42.456305114Z due to a permission issue. Cache is disabled.
```

in the logs which is due to `/app/node_modules` not having write perms for the node user.