### PR TITLE
SW-883: fix move dataset between groups

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -2632,7 +2632,17 @@ export const updateDatatable = async (req: Request, res: Response) => {
 
 export const moveDatasetGroup = async (req: Request, res: Response, next: NextFunction) => {
   const dataset = res.locals.dataset;
-  const availableGroups = getApproverUserGroups(req.user).map((g) => singleLangUserGroup(g.group, req.language)) || [];
+  let user: UserDTO;
+
+  try {
+    user = await req.pubapi.getUser();
+  } catch (err) {
+    logger.error(err, `Failed to fetch current user`);
+    next(new UnknownException(`Couldn't fetch current user`));
+    return;
+  }
+
+  const availableGroups = getApproverUserGroups(user).map((g) => singleLangUserGroup(g.group, req.language)) || [];
   const validGroupIds = availableGroups.map((group) => group.id) as string[];
   let values = { group_id: dataset.user_group_id };
   let errors: ViewError[] = [];

--- a/src/views/publish/move-group.jsx
+++ b/src/views/publish/move-group.jsx
@@ -22,7 +22,7 @@ export default function MoveGroup(props) {
                 value: group.id,
                 label: group.name
               }))}
-              value={values.group_id}
+              value={props.values.group_id}
             />
 
             <button type="submit" className="govuk-button" data-module="govuk-button">

--- a/src/views/publish/overview.jsx
+++ b/src/views/publish/overview.jsx
@@ -112,7 +112,7 @@ function ActionsTab({
 
         {canMoveGroup && (
           <li>
-            <ActionLink path="move" action="move" />
+            <ActionLink path={`/publish/${datasetId}/move`} action="move" />
           </li>
         )}
       </ul>


### PR DESCRIPTION
Move dataset got broken at some point with the changes to the templates and also the change to user group names not being in the cookie any longer.

e2e test to follow imminently but needs changes to the backend for user group seeds.