### PR TITLE
Fix guidance is broken on frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN chown -R node:node /app
 
 # copy in the built application source from the builder image
 COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/docs ./docs
 
 HEALTHCHECK --interval=5m --timeout=3s \
     CMD curl --fail http://localhost:3000 || exit 1


### PR DESCRIPTION
The docs dir got missed when we hardened the frontend image.

It's needed for the guidance.