### PR TITLE
Fix broken link on reports

### DIFF
--- a/src/views/publish/related-links.jsx
+++ b/src/views/publish/related-links.jsx
@@ -20,7 +20,7 @@ export default function RelatedLinks(props) {
           ? row.label_en || `${row.label_cy} ${notTranslated}`
           : row.label_cy || `${row.label_en} ${notTranslated}`;
         return (
-          <a href="${value}" className="govuk-link">
+          <a href={value} className="govuk-link">
             {label}
           </a>
         );


### PR DESCRIPTION
The reports links were rendering as relative paths rather than full URLs resulting in the links failing to work when they're clicked on.  Minor fix to a minor issue.