### PR TITLE
SW-739: update frequency is now captured as a date input

### DIFF
--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -13,13 +13,11 @@ import {
   collectionValidator,
   dayValidator,
   designationValidator,
-  frequencyUnitValidator,
-  frequencyValueValidator,
   getErrors,
   groupIdValidator,
   hasError,
   hourValidator,
-  isUpdatedValidator,
+  updateTypeValidator,
   linkIdValidator,
   linkLabelValidator,
   linkUrlValidator,
@@ -33,6 +31,9 @@ import {
   taskDecisionValidator,
   titleValidator,
   topicIdValidator,
+  updateDayValidator,
+  updateMonthValidator,
+  updateYearValidator,
   uuidValidator,
   yearValidator
 } from '../validators';
@@ -46,7 +47,6 @@ import { TaskListState } from '../dtos/task-list-state';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { singleLangDataset, singleLangRevision } from '../utils/single-lang-dataset';
 import { Designation } from '../enums/designation';
-import { DurationUnit } from '../enums/duration-unit';
 import { RelatedLinkDTO } from '../dtos/related-link';
 import { RevisionProviderDTO } from '../dtos/revision-provider';
 import { ProviderSourceDTO } from '../dtos/provider-source';
@@ -96,6 +96,7 @@ import { FilterTable } from '../dtos/filter-table';
 import qs from 'qs';
 import { DEFAULT_PAGE_SIZE } from './consumer';
 import { SortByInterface } from '../interfaces/sort-by';
+import { UpdateType } from '../enums/update-type';
 
 // the default nanoid alphabet includes hyphens which causes issues with the translation export/import process in Excel
 // - it tries to be smart and interprets strings that start with a hypen as a formula.
@@ -2106,40 +2107,52 @@ export const provideQuality = async (req: Request, res: Response) => {
 };
 
 export const provideUpdateFrequency = async (req: Request, res: Response) => {
-  let errors: ViewError[] | undefined;
   const dataset = singleLangDataset(res.locals.dataset, req.language);
   const revision = dataset.draft_revision;
   let update_frequency = revision?.update_frequency;
+  let errors: ViewError[] = [];
+  let dateError;
 
   if (req.method === 'POST') {
     update_frequency = {
-      is_updated: req.body?.is_updated ? req.body?.is_updated === 'true' : undefined,
-      frequency_unit: req.body?.is_updated === 'true' ? req.body?.frequency_unit : undefined,
-      frequency_value: req.body?.is_updated === 'true' ? req.body?.frequency_value : undefined
+      update_type: req.body?.update_type
     };
 
     try {
-      const validators = [isUpdatedValidator(), frequencyValueValidator(), frequencyUnitValidator()];
+      const validators = [updateTypeValidator(), updateDayValidator(), updateMonthValidator(), updateYearValidator()];
 
       errors = (await getErrors(validators, req)).map((error: FieldValidationError) => {
         return {
           field: error.path,
-          message: { key: `publish.update_frequency.form.${error.path}.error.missing` }
+          message: { key: `publish.update_frequency.form.${error.path}.error` }
         };
       });
+
+      if (update_frequency.update_type === UpdateType.Update) {
+        update_frequency.date = {
+          year: req.body?.year,
+          month: req.body?.month ? req.body?.month.padStart(2, '0') : '',
+          day: req.body?.day ? req.body?.day.padStart(2, '0') : ''
+        };
+
+        const updateDate = new TZDate(
+          Number(update_frequency.date.year),
+          // month is 0-11
+          Number(update_frequency.date.month) - 1,
+          Number(update_frequency.date.day || '1'),
+          'Europe/London'
+        );
+
+        if (!isValid(updateDate) || isBefore(updateDate, new Date())) {
+          dateError = { field: 'date', message: { key: 'publish.update_frequency.form.date.error.invalid' } };
+          errors.push(dateError);
+        }
+      }
 
       if (errors.length > 0) {
         res.status(400);
         throw new Error();
       }
-
-      const { is_updated, frequency_unit, frequency_value } = matchedData(req);
-
-      update_frequency = {
-        is_updated,
-        frequency_unit: is_updated ? frequency_unit : undefined,
-        frequency_value: is_updated ? frequency_value : undefined
-      };
 
       await req.pubapi.updateMetadata(dataset.id, { update_frequency, language: req.language });
       res.redirect(req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language));
@@ -2151,7 +2164,7 @@ export const provideUpdateFrequency = async (req: Request, res: Response) => {
     }
   }
 
-  res.render('publish/update-frequency', { ...update_frequency, unitOptions: Object.values(DurationUnit), errors });
+  res.render('publish/update-frequency', { update_frequency, errors });
 };
 
 export const provideDataProviders = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/controllers/publish.ts
+++ b/src/controllers/publish.ts
@@ -2109,7 +2109,7 @@ export const provideQuality = async (req: Request, res: Response) => {
 export const provideUpdateFrequency = async (req: Request, res: Response) => {
   const dataset = singleLangDataset(res.locals.dataset, req.language);
   const revision = dataset.draft_revision;
-  let update_frequency = revision?.update_frequency;
+  let update_frequency = revision?.update_frequency || { update_type: undefined, date: undefined };
   let errors: ViewError[] = [];
   let dateError;
 

--- a/src/dtos/update-frequency.ts
+++ b/src/dtos/update-frequency.ts
@@ -1,5 +1,12 @@
+import { UpdateType } from '../enums/update-type';
+
+export interface UpdateDateDTO {
+  day?: string;
+  month: string;
+  year: string;
+}
+
 export interface UpdateFrequencyDTO {
-  is_updated?: boolean;
-  frequency_value?: number;
-  frequency_unit?: string;
+  update_type: UpdateType;
+  date?: UpdateDateDTO;
 }

--- a/src/enums/duration-unit.ts
+++ b/src/enums/duration-unit.ts
@@ -1,6 +1,0 @@
-export enum DurationUnit {
-  Day = 'day',
-  Week = 'week',
-  Month = 'month',
-  Year = 'year'
-}

--- a/src/enums/update-type.ts
+++ b/src/enums/update-type.ts
@@ -1,0 +1,5 @@
+export enum UpdateType {
+  Update = 'update',
+  Replacement = 'replacement',
+  None = 'none'
+}

--- a/src/i18n/cy.json
+++ b/src/i18n/cy.json
@@ -610,7 +610,7 @@
     "update_frequency": {
       "heading": "A fydd y set ddata hon yn cael ei diweddaru'n rheolaidd?",
       "form": {
-        "is_updated": {
+        "update_type": {
           "options": {
             "yes": {
               "label": "Bydd"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -133,7 +133,10 @@
     "key_information": {
       "heading": "Main information",
       "last_update": "Most recent update",
-      "next_update": "Next update expected (provisional)",
+      "next_update": "Next update expected",
+      "next_update_missing": "Next update expected not entered yet",
+      "next_update_replacement": "This dataset is not expected to be updated, but is expected to be replaced in the future",
+      "next_update_none": "This dataset is not expected to be updated or replaced in the future",
       "data_provider": "Data provider",
       "data_providers": "Data provider {{index}}",
       "data_source": "Data source",
@@ -143,7 +146,6 @@
       "time_covered": "Time period covered",
       "time_period": "{{start}} to {{end}}",
       "update_missing": "Publish date not entered yet",
-      "next_update_missing": "Publish date or update frequency not entered yet",
       "not_updated": "This dataset will not be updated"
     },
     "downloads": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -616,38 +616,40 @@
       }
     },
     "update_frequency": {
-      "heading": "Will this dataset be regularly updated?",
+      "heading": "Will this dataset be updated or replaced in the future?",
       "form": {
-        "is_updated": {
+        "update_type": {
           "options": {
-            "yes": {
-              "label": "Yes"
+            "update": {
+              "label": "An update is expected"
             },
-            "no": {
-              "label": "No"
+            "replacement": {
+              "label": "This dataset is not expected to be updated, but is expected to be replaced in the future"
+            },
+            "none": {
+              "label": "This dataset is not expected to be updated or replaced in the future"
             }
           },
+          "error": "Select whether this dataset will be updated or replaced in the future"
+        },
+        "date": {
+          "label": "Enter the date the next update is expected",
+          "hint": "For example, {{example}}. If you do not know the exact date, you must enter at least a month and a year.",
           "error": {
-            "missing": "Select if this dataset will be regularly updated or not"
+            "missing": "Enter the date the next update is expected",
+            "invalid": "The date the next update is expected must be a real date in the future"
           }
         },
-        "frequency_value": {
-          "label": "Enter the period between updates. For example, 1 year.",
-          "error": {
-            "missing": "Enter the number of weeks, months or years for the period between updates"
-          }
+        "day": {
+          "label": "Day"
         },
-        "frequency_unit": {
-          "options": {
-            "select": "Select",
-            "day": "days",
-            "week": "weeks",
-            "month": "months",
-            "year": "years"
-          },
-          "error": {
-            "missing": "Select whether the period between updates is in weeks, months or years"
-          }
+        "month": {
+          "label": "Month",
+          "error": "The date the next update is expected must include a month"
+        },
+        "year": {
+          "label": "Year",
+          "error": "The date the next update is expected must include a year"
         }
       }
     },
@@ -962,7 +964,7 @@
         "statistical_quality": "Statistical quality",
         "data_sources": "Data sources",
         "related_reports": "Related reports",
-        "update_frequency": "How often this dataset is updated",
+        "update_frequency": "If this dataset will be updated or replaced in the future",
         "designation": "Designation",
         "relevant_topics": "Relevant topics"
       },

--- a/src/interfaces/preview-metadata.ts
+++ b/src/interfaces/preview-metadata.ts
@@ -2,12 +2,13 @@ import { Designation } from '../enums/designation';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
 import { RelatedLinkDTO } from '../dtos/related-link';
 import { OrganisationDTO } from '../dtos/organisation';
+import { UpdateFrequencyDTO } from '../dtos/update-frequency';
 
 export interface PreviewMetadata {
   title?: string;
   keyInfo: {
     updatedAt?: string;
-    nextUpdateAt?: string;
+    nextUpdateAt?: UpdateFrequencyDTO;
     designation?: Designation;
     providers?: {
       provider_name?: string;

--- a/src/interfaces/preview-metadata.ts
+++ b/src/interfaces/preview-metadata.ts
@@ -7,7 +7,7 @@ export interface PreviewMetadata {
   title?: string;
   keyInfo: {
     updatedAt?: string;
-    nextUpdateAt?: Date | boolean;
+    nextUpdateAt?: string;
     designation?: Designation;
     providers?: {
       provider_name?: string;

--- a/src/utils/dataset-preview.ts
+++ b/src/utils/dataset-preview.ts
@@ -1,7 +1,6 @@
 import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
-import { nextUpdateAt } from './next-update-at';
 import { markdownToSafeHTML } from './markdown-to-html';
 import { isPublished } from './revision';
 import { PreviewMetadata } from '../interfaces/preview-metadata';
@@ -21,7 +20,7 @@ export const getDatasetPreview = async (
     title: revision.metadata.title,
     keyInfo: {
       updatedAt: revision?.publish_at,
-      nextUpdateAt: nextUpdateAt(revision),
+      nextUpdateAt: revision.update_frequency,
       designation,
       providers: providers?.map(({ provider_name, source_name }) => ({ provider_name, source_name })),
       timePeriod: { start: dataset.start_date, end: dataset.end_date }

--- a/src/utils/next-update-at.ts
+++ b/src/utils/next-update-at.ts
@@ -1,18 +1,6 @@
-import { add } from 'date-fns';
-
 import { RevisionDTO } from '../dtos/revision';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
 
-export const nextUpdateAt = (
-  revision: RevisionDTO | SingleLanguageRevision | undefined
-): Date | boolean | undefined => {
-  const update = revision?.update_frequency;
-
-  if (!update) return undefined;
-
-  if (update.is_updated === false) return false;
-
-  if (!revision?.publish_at || !update.frequency_unit || !update.frequency_value) return undefined;
-
-  return add(revision.publish_at, { [`${update.frequency_unit}s`]: update.frequency_value });
+export const nextUpdateAt = (revision: RevisionDTO | SingleLanguageRevision | undefined): string => {
+  return '';
 };

--- a/src/utils/next-update-at.ts
+++ b/src/utils/next-update-at.ts
@@ -1,6 +1,0 @@
-import { RevisionDTO } from '../dtos/revision';
-import { SingleLanguageRevision } from '../dtos/single-language/revision';
-
-export const nextUpdateAt = (revision: RevisionDTO | SingleLanguageRevision | undefined): string => {
-  return '';
-};

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -3,7 +3,7 @@ import { body, FieldValidationError, param, ValidationChain } from 'express-vali
 import { ResultWithContext } from 'express-validator/lib/chain/context-runner';
 
 import { Designation } from '../enums/designation';
-import { DurationUnit } from '../enums/duration-unit';
+import { UpdateType } from '../enums/update-type';
 
 export const hasError = async (validator: ValidationChain, req: Request) => {
   return !(await validator.run(req)).isEmpty();
@@ -58,12 +58,6 @@ export const roundingAppliedValidator = () => body('rounding_applied').notEmpty(
 export const roundingDescriptionValidator = () =>
   body('rounding_description').if(body('rounding_applied').equals('true')).trim().notEmpty();
 
-export const isUpdatedValidator = () => body('is_updated').notEmpty().bail().isBoolean().toBoolean();
-export const frequencyValueValidator = () =>
-  body('frequency_value').if(body('is_updated').equals('true')).notEmpty().bail().isInt().toInt(10);
-export const frequencyUnitValidator = () =>
-  body('frequency_unit').if(body('is_updated').equals('true')).isIn(Object.values(DurationUnit));
-
 export const linkIdValidator = () => body('link_id').trim().notEmpty();
 export const linkUrlValidator = () =>
   body('link_url').trim().notEmpty().bail().isURL({ require_tld: true, require_protocol: true });
@@ -88,3 +82,14 @@ export const groupIdValidator = (groupIds: string[]) => body('group_id').trim().
 export const taskDecisionValidator = () => body('decision').isIn(['approve', 'reject']);
 
 export const taskDecisionReasonValidator = () => body('reason').if(body('decision').equals('reject')).trim().notEmpty();
+
+export const updateTypeValidator = () => body('update_type').isIn(Object.values(UpdateType));
+
+export const updateDayValidator = () =>
+  body('day').if(body('update_type').equals('update')).isInt({ min: 1, max: 31, allow_leading_zeroes: true });
+
+export const updateMonthValidator = () =>
+  body('month').if(body('update_type').equals('update')).isInt({ min: 1, max: 12, allow_leading_zeroes: true });
+
+export const updateYearValidator = () =>
+  body('year').if(body('update_type').equals('update')).isInt({ min: 1000, max: 9999, allow_leading_zeroes: false });

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -86,7 +86,11 @@ export const taskDecisionReasonValidator = () => body('reason').if(body('decisio
 export const updateTypeValidator = () => body('update_type').isIn(Object.values(UpdateType));
 
 export const updateDayValidator = () =>
-  body('day').if(body('update_type').equals('update')).isInt({ min: 1, max: 31, allow_leading_zeroes: true });
+  body('day')
+    .trim()
+    .optional({ values: 'falsy' })
+    .if(body('update_type').equals('update'))
+    .isInt({ min: 1, max: 31, allow_leading_zeroes: true });
 
 export const updateMonthValidator = () =>
   body('month').if(body('update_type').equals('update')).isInt({ min: 1, max: 12, allow_leading_zeroes: true });

--- a/src/views/components/dataset/KeyInfo.jsx
+++ b/src/views/components/dataset/KeyInfo.jsx
@@ -4,7 +4,7 @@ import { UpdateType } from '../../../enums/update-type';
 import { parse } from 'date-fns';
 
 export default function KeyInfo(props) {
-  function NextUpdate () {
+  function NextUpdate() {
     const nextUpdateAt = props.keyInfo.nextUpdateAt;
     console.log(nextUpdateAt);
 

--- a/src/views/components/dataset/KeyInfo.jsx
+++ b/src/views/components/dataset/KeyInfo.jsx
@@ -1,6 +1,34 @@
 import React, { Fragment } from 'react';
+import T from '../T';
+import { UpdateType } from '../../../enums/update-type';
+import { parse } from 'date-fns';
 
 export default function KeyInfo(props) {
+  function NextUpdate () {
+    const nextUpdateAt = props.keyInfo.nextUpdateAt;
+    console.log(nextUpdateAt);
+
+    switch (nextUpdateAt.update_type) {
+      case UpdateType.Update:
+        const { day, month, year } = nextUpdateAt.date || {};
+        const date = parse(`${day || '01'} ${month} ${year}`, 'dd MM yyyy', new Date());
+
+        if (day) {
+          return props.dateFormat(date, 'd MMMM yyyy', { locale: props.i18n.language });
+        } else {
+          return props.dateFormat(date, 'MMMM yyyy', { locale: props.i18n.language });
+        }
+
+      case UpdateType.Replacement:
+        return <T>dataset_view.key_information.next_update_replacement</T>;
+
+      case UpdateType.None:
+        return <T>dataset_view.key_information.next_update_none</T>;
+    }
+
+    return <T>dataset_view.key_information.next_update_missing</T>;
+  }
+
   return (
     <div className="dataset-key-information">
       <h2 className="govuk-heading-m">{props.t('dataset_view.key_information.heading')}</h2>
@@ -18,11 +46,7 @@ export default function KeyInfo(props) {
         <div id="next-updated" className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{props.t('dataset_view.key_information.next_update')}</dt>
           <dd className="govuk-summary-list__value">
-            {props.keyInfo.nextUpdateAt
-              ? props.dateFormat(props.keyInfo.nextUpdateAt, 'MMMM yyyy', { locale: props.i18n.language })
-              : props.keyInfo.nextUpdateAt === false
-                ? props.t('dataset_view.key_information.not_updated')
-                : props.t('dataset_view.key_information.next_update_missing')}
+            <NextUpdate />
           </dd>
         </div>
 

--- a/src/views/publish/tasklist.jsx
+++ b/src/views/publish/tasklist.jsx
@@ -163,12 +163,6 @@ export default function Tasklist(props) {
               describedBy="prepare-application-5-status"
             />
             <TasklistItem
-              id="update_frequency"
-              path="update-frequency"
-              status={props.taskList.metadata.frequency}
-              describedBy="prepare-application-5-status"
-            />
-            <TasklistItem
               id="designation"
               status={props.taskList.metadata.designation}
               describedBy="prepare-application-5-status"
@@ -177,6 +171,12 @@ export default function Tasklist(props) {
               id="relevant_topics"
               path="topics"
               status={props.taskList.metadata.topics}
+              describedBy="prepare-application-5-status"
+            />
+            <TasklistItem
+              id="update_frequency"
+              path="update-frequency"
+              status={props.taskList.metadata.frequency}
               describedBy="prepare-application-5-status"
             />
           </ul>

--- a/src/views/publish/update-frequency.jsx
+++ b/src/views/publish/update-frequency.jsx
@@ -72,7 +72,8 @@ export default function UpdateFrequency(props) {
 
                           {props.dateError && (
                             <p id="publication-date-error" className="govuk-error-message">
-                              <span className="govuk-visually-hidden">Error:</span> {props.t(props.dateError.message.key)}
+                              <span className="govuk-visually-hidden">Error:</span>{' '}
+                              {props.t(props.dateError.message.key)}
                             </p>
                           )}
 

--- a/src/views/publish/update-frequency.jsx
+++ b/src/views/publish/update-frequency.jsx
@@ -77,9 +77,9 @@ export default function UpdateFrequency(props) {
                           )}
 
                           <div className="govuk-date-input" id="update-expected-date">
-                            <Field name="day" value={props.update_frequency.date?.day} />
-                            <Field name="month" value={props.update_frequency.date?.month} />
-                            <Field name="year"  value={props.update_frequency.date?.year} width={5} />
+                            <Field name="day" value={props.update_frequency?.date?.day} />
+                            <Field name="month" value={props.update_frequency?.date?.month} />
+                            <Field name="year" value={props.update_frequency?.date?.year} width={5} />
                           </div>
                         </fieldset>
                       </div>
@@ -94,7 +94,7 @@ export default function UpdateFrequency(props) {
                     label: <T>publish.update_frequency.form.update_type.options.none.label</T>
                   }
                 ]}
-                value={props.update_frequency.update_type}
+                value={props.update_frequency?.update_type}
               />
 
               <button type="submit" className="govuk-button" data-module="govuk-button">

--- a/src/views/publish/update-frequency.jsx
+++ b/src/views/publish/update-frequency.jsx
@@ -1,14 +1,40 @@
 import React from 'react';
+import { addYears, format } from 'date-fns';
+import clsx from 'clsx';
+
 import Layout from '../components/layouts/Publisher';
 import ErrorHandler from '../components/ErrorHandler';
-import clsx from 'clsx';
 import RadioGroup from '../components/RadioGroup';
 import T from '../components/T';
-import Select from '../components/Select';
 
 export default function UpdateFrequency(props) {
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   const backLink = returnLink;
+
+  function Field({ name, value, width = 3 }) {
+    return (
+      <div className="govuk-date-input__item">
+        <div className="govuk-form-group">
+          <label className="govuk-label govuk-date-input__label" htmlFor={`update-expected-date-${name}`}>
+            {props.t(`publish.update_frequency.form.${name}.label`)}
+          </label>
+          <input
+            className={clsx(`govuk-input govuk-date-input__input govuk-input--width-${width}`, {
+              'govuk-input--error': props.errors?.find((e) => e.field === name)
+            })}
+            id={`update-expected-date-${name}`}
+            name={name}
+            type="text"
+            inputMode="numeric"
+            defaultValue={value}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const oneYearFromNow = format(addYears(new Date(), 1), 'dd MM yyyy');
+
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage>
       <div className="govuk-width-container">
@@ -22,59 +48,57 @@ export default function UpdateFrequency(props) {
               <ErrorHandler />
 
               <RadioGroup
-                name="is_updated"
+                name="update_type"
                 labelledBy="is-updated"
                 options={[
                   {
-                    value: 'true',
-                    label: <T>publish.update_frequency.form.is_updated.options.yes.label</T>,
+                    value: 'update',
+                    label: <T>publish.update_frequency.form.update_type.options.update.label</T>,
                     children: (
                       <div
                         className={clsx('govuk-form-group', {
                           'govuk-form-group--error': props.errors?.find((e) =>
-                            ['frequency_unit', 'frequency_value'].includes(e.field)
+                            ['update_day', 'update_month', 'update_year'].includes(e.field)
                           )
                         })}
                       >
-                        <fieldset className="govuk-fieldset" role="group" aria-describedby="isUpdatedYes">
+                        <fieldset className="govuk-fieldset" role="group" aria-describedby="isUpdatedUpdate">
                           <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
-                            <T>publish.update_frequency.form.frequency_value.label</T>
+                            <T>publish.update_frequency.form.date.label</T>
                           </legend>
-                          <input
-                            className="govuk-input govuk-input--width-2"
-                            id="frequency_value"
-                            name="frequency_value"
-                            type="text"
-                            defaultValue={props.frequency_value}
-                          />{' '}
-                          <Select
-                            name="frequency_unit"
-                            className="govuk-!-display-inline"
-                            options={[
-                              {
-                                value: '',
-                                label: <T>publish.update_frequency.form.frequency_unit.options.select</T>
-                              },
-                              ...props.unitOptions.map((unit) => ({
-                                value: unit,
-                                label: <T>publish.update_frequency.form.frequency_unit.options.{unit}</T>
-                              }))
-                            ]}
-                          />
+                          <div id="update-expected-hint" className="govuk-hint">
+                            <T example={oneYearFromNow}>publish.update_frequency.form.date.hint</T>
+                          </div>
+
+                          {props.dateError && (
+                            <p id="publication-date-error" className="govuk-error-message">
+                              <span className="govuk-visually-hidden">Error:</span> {props.t(props.dateError.message.key)}
+                            </p>
+                          )}
+
+                          <div className="govuk-date-input" id="update-expected-date">
+                            <Field name="day" value={props.update_frequency.date?.day} />
+                            <Field name="month" value={props.update_frequency.date?.month} />
+                            <Field name="year"  value={props.update_frequency.date?.year} width={5} />
+                          </div>
                         </fieldset>
                       </div>
                     )
                   },
                   {
-                    value: 'false',
-                    label: <T>publish.update_frequency.form.is_updated.options.no.label</T>
+                    value: 'replacement',
+                    label: <T>publish.update_frequency.form.update_type.options.replacement.label</T>
+                  },
+                  {
+                    value: 'none',
+                    label: <T>publish.update_frequency.form.update_type.options.none.label</T>
                   }
                 ]}
-                value={props.is_updated}
+                value={props.update_frequency.update_type}
               />
 
               <button type="submit" className="govuk-button" data-module="govuk-button">
-                {props.t('buttons.continue')}
+                <T>buttons.continue</T>
               </button>
             </form>
           </div>

--- a/tests-e2e/required/happy-path.spec.ts
+++ b/tests-e2e/required/happy-path.spec.ts
@@ -227,9 +227,11 @@ test.describe('Happy path', () => {
     expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${id}/tasklist`);
 
     // update frequency
-    await page.getByRole('link', { name: 'How often this dataset is updated' }).click();
+    await page.getByRole('link', { name: 'If this dataset will be updated or replaced in the future' }).click();
     expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${id}/update-frequency`);
-    await page.getByLabel('No').click({ force: true });
+    await page
+      .getByLabel('This dataset is not expected to be updated or replaced in the future')
+      .click({ force: true });
     await page.getByRole('button', { name: 'Continue' }).click();
     expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${id}/tasklist`);
 


### PR DESCRIPTION
Previously we just allowed the user to specify an interval for the next update.

This updates the UI to provide radio buttons to determine the type of update, and a date input to specify the expected update date.

<img width="1445" height="1258" alt="Screenshot 2025-07-15 at 14 29 51" src="https://github.com/user-attachments/assets/734416f8-1581-463d-9120-1e8856096b6f" />
