### PR TITLE
SW-898: show data update type as subheading on upload & upload preview pages

### DIFF
--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -205,6 +205,7 @@ export const provideTitle = async (req: Request, res: Response) => {
 export const uploadDataTable = async (req: Request, res: Response) => {
   const dataset = res.locals.dataset;
   const revision = dataset.draft_revision;
+  const isUpdate = Boolean(revision.previous_revision_id);
   const revisit = dataset.dimensions?.length > 0;
   const supportedFormats = Object.values(DuckDBSupportFileFormats).map((format) => format.toLowerCase());
   const session = get(req.session, `dataset[${dataset.id}]`, { updateType: undefined });
@@ -213,6 +214,8 @@ export const uploadDataTable = async (req: Request, res: Response) => {
 
   if (session.updateType) {
     updateType = session.updateType;
+  } else if (isUpdate && revision.data_table?.action) {
+    updateType = revision.data_table.action;
   } else {
     updateType = req.body?.updateType;
   }
@@ -297,6 +300,7 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
   const isUpdate = Boolean(revision.previous_revision_id);
   const revisit = !isUpdate && !hasUnknownColumns;
   const session = get(req.session, `dataset[${dataset.id}]`, { updateType: undefined });
+  const updateType = isUpdate && dataTable.action;
 
   let errors: ViewError[] | undefined;
   let previewData: ViewDTO | undefined;
@@ -359,7 +363,7 @@ export const factTablePreview = async (req: Request, res: Response, next: NextFu
     res.status(400);
     errors = [{ field: 'preview', message: { key: 'errors.preview.failed_to_get_preview' } }];
   }
-  res.render('publish/preview', { ...previewData, ignoredCount, pagination, revisit, errors });
+  res.render('publish/preview', { ...previewData, ignoredCount, pagination, revisit, updateType, errors });
 };
 
 export const sources = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -96,7 +96,7 @@ import { FilterTable } from '../../shared/dtos/filter-table';
 import qs from 'qs';
 import { DEFAULT_PAGE_SIZE } from '../../consumer/controllers/consumer';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
-import { UpdateType } from '../../shared/enums/update-type';
+import { NextUpdateType } from '../../shared/enums/next-update-type';
 
 // the default nanoid alphabet includes hyphens which causes issues with the translation export/import process in Excel
 // - it tries to be smart and interprets strings that start with a hypen as a formula.
@@ -2145,7 +2145,7 @@ export const provideUpdateFrequency = async (req: Request, res: Response) => {
         };
       });
 
-      if (update_frequency.update_type === UpdateType.Update) {
+      if (update_frequency.update_type === NextUpdateType.Update) {
         update_frequency.date = {
           year: req.body?.year,
           month: req.body?.month ? req.body?.month.padStart(2, '0') : '',

--- a/src/publisher/validators/index.ts
+++ b/src/publisher/validators/index.ts
@@ -3,7 +3,7 @@ import { body, FieldValidationError, param, ValidationChain } from 'express-vali
 import { ResultWithContext } from 'express-validator/lib/chain/context-runner';
 
 import { Designation } from '../../shared/enums/designation';
-import { UpdateType } from '../../shared/enums/update-type';
+import { NextUpdateType } from '../../shared/enums/next-update-type';
 
 export const hasError = async (validator: ValidationChain, req: Request) => {
   return !(await validator.run(req)).isEmpty();
@@ -83,7 +83,7 @@ export const taskDecisionValidator = () => body('decision').isIn(['approve', 're
 
 export const taskDecisionReasonValidator = () => body('reason').if(body('decision').equals('reject')).trim().notEmpty();
 
-export const updateTypeValidator = () => body('update_type').isIn(Object.values(UpdateType));
+export const updateTypeValidator = () => body('update_type').isIn(Object.values(NextUpdateType));
 
 export const updateDayValidator = () =>
   body('day')

--- a/src/publisher/views/publish/preview.jsx
+++ b/src/publisher/views/publish/preview.jsx
@@ -47,6 +47,9 @@ export default function Preview(props) {
   const title = props.revisit ? props.t('publish.preview.heading_summary') : props.t('publish.preview.heading');
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage title={title}>
+      {props.updateType && (
+        <span className="region-subhead"><T>{`publish.update_type.${props.updateType}`}</T></span>
+      )}
       <h1 className="govuk-heading-xl">{title}</h1>
 
       <ErrorHandler />

--- a/src/publisher/views/publish/preview.jsx
+++ b/src/publisher/views/publish/preview.jsx
@@ -48,7 +48,9 @@ export default function Preview(props) {
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage title={title}>
       {props.updateType && (
-        <span className="region-subhead"><T>{`publish.update_type.${props.updateType}`}</T></span>
+        <span className="region-subhead">
+          <T>{`publish.update_type.${props.updateType}`}</T>
+        </span>
       )}
       <h1 className="govuk-heading-xl">{title}</h1>
 

--- a/src/publisher/views/publish/update-type.jsx
+++ b/src/publisher/views/publish/update-type.jsx
@@ -3,12 +3,17 @@ import Layout from '../components/Layout';
 import ErrorHandler from '../components/ErrorHandler';
 import RadioGroup from '../../../shared/views/components/RadioGroup';
 import T from '../../../shared/views/components/T';
+import { DataTableAction } from '../../../shared/enums/data-table-action';
 
 export default function UpdateType(props) {
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
   const backLink = returnLink;
-
   const title = props.t('publish.update_type.heading');
+
+  const options = Object.values(DataTableAction).map((action) => ({
+    value: action,
+    label: <T>{`publish.update_type.${action}`}</T>
+  }));
 
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage title={title}>
@@ -23,12 +28,7 @@ export default function UpdateType(props) {
             <RadioGroup
               name="updateType"
               labelledBy="update-type-heading"
-              options={[
-                { value: 'add', label: <T>publish.update_type.add</T> },
-                { value: 'add_revise', label: <T>publish.update_type.add_revise</T> },
-                { value: 'revise', label: <T>publish.update_type.revise</T> },
-                { value: 'replace_all', label: <T>publish.update_type.replace_all</T> }
-              ]}
+              options={options}
             />
 
             <div className="govuk-button-group">

--- a/src/publisher/views/publish/update-type.jsx
+++ b/src/publisher/views/publish/update-type.jsx
@@ -25,11 +25,7 @@ export default function UpdateType(props) {
             {title}
           </h1>
           <form method="post" role="continue" id="updateType">
-            <RadioGroup
-              name="updateType"
-              labelledBy="update-type-heading"
-              options={options}
-            />
+            <RadioGroup name="updateType" labelledBy="update-type-heading" options={options} />
 
             <div className="govuk-button-group">
               <button

--- a/src/publisher/views/publish/upload.jsx
+++ b/src/publisher/views/publish/upload.jsx
@@ -31,6 +31,9 @@ export default function Title(props) {
 
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage title={title}>
+      {props.updateType && (
+        <span className="region-subhead"><T>{`publish.update_type.${props.updateType}`}</T></span>
+      )}
       <h1 className="govuk-heading-xl">{title}</h1>
 
       <ErrorHandler />

--- a/src/publisher/views/publish/upload.jsx
+++ b/src/publisher/views/publish/upload.jsx
@@ -32,7 +32,9 @@ export default function Title(props) {
   return (
     <Layout {...props} backLink={backLink} returnLink={returnLink} formPage title={title}>
       {props.updateType && (
-        <span className="region-subhead"><T>{`publish.update_type.${props.updateType}`}</T></span>
+        <span className="region-subhead">
+          <T>{`publish.update_type.${props.updateType}`}</T>
+        </span>
       )}
       <h1 className="govuk-heading-xl">{title}</h1>
 

--- a/src/shared/dtos/data-table.ts
+++ b/src/shared/dtos/data-table.ts
@@ -1,3 +1,4 @@
+import { DataTableAction } from '../enums/data-table-action';
 import { DataTableDescriptionDto } from './data-table-description-dto';
 
 export interface DataTableDto {
@@ -10,4 +11,5 @@ export interface DataTableDto {
   hash: string;
   uploaded_at?: string;
   descriptors: DataTableDescriptionDto[];
+  action?: DataTableAction;
 }

--- a/src/shared/dtos/update-frequency.ts
+++ b/src/shared/dtos/update-frequency.ts
@@ -1,4 +1,4 @@
-import { UpdateType } from '../enums/update-type';
+import { NextUpdateType } from '../enums/next-update-type';
 
 export interface UpdateDateDTO {
   day?: string;
@@ -7,6 +7,6 @@ export interface UpdateDateDTO {
 }
 
 export interface UpdateFrequencyDTO {
-  update_type: UpdateType;
+  update_type: NextUpdateType;
   date?: UpdateDateDTO;
 }

--- a/src/shared/enums/data-table-action.ts
+++ b/src/shared/enums/data-table-action.ts
@@ -1,0 +1,6 @@
+export enum DataTableAction {
+  Add = 'add',
+  AddRevise = 'add_revise',
+  Revise = 'revise',
+  ReplaceAll = 'replace_all'
+}

--- a/src/shared/enums/next-update-type.ts
+++ b/src/shared/enums/next-update-type.ts
@@ -1,4 +1,4 @@
-export enum UpdateType {
+export enum NextUpdateType {
   Update = 'update',
   Replacement = 'replacement',
   None = 'none'

--- a/src/shared/validators/index.ts
+++ b/src/shared/validators/index.ts
@@ -3,7 +3,7 @@ import { body, FieldValidationError, param, ValidationChain } from 'express-vali
 import { ResultWithContext } from 'express-validator/lib/chain/context-runner';
 
 import { Designation } from '../../shared/enums/designation';
-import { UpdateType } from '../../shared/enums/update-type';
+import { NextUpdateType } from '../enums/next-update-type';
 
 export const hasError = async (validator: ValidationChain, req: Request) => {
   return !(await validator.run(req)).isEmpty();
@@ -83,7 +83,7 @@ export const taskDecisionValidator = () => body('decision').isIn(['approve', 're
 
 export const taskDecisionReasonValidator = () => body('reason').if(body('decision').equals('reject')).trim().notEmpty();
 
-export const updateTypeValidator = () => body('update_type').isIn(Object.values(UpdateType));
+export const updateTypeValidator = () => body('update_type').isIn(Object.values(NextUpdateType));
 
 export const updateDayValidator = () =>
   body('day')

--- a/src/shared/views/components/dataset/KeyInfo.jsx
+++ b/src/shared/views/components/dataset/KeyInfo.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import T from '../T';
-import { UpdateType } from '../../../enums/update-type';
+import { NextUpdateType } from '../../../enums/next-update-type';
 import { parse } from 'date-fns';
 
 export default function KeyInfo(props) {
@@ -9,7 +9,7 @@ export default function KeyInfo(props) {
 
     if (nextUpdateAt?.update_type) {
       switch (nextUpdateAt.update_type) {
-        case UpdateType.Update:
+        case NextUpdateType.Update:
           const { day, month, year } = nextUpdateAt.date || {};
           const date = parse(`${day || '01'} ${month} ${year}`, 'dd MM yyyy', new Date());
 
@@ -19,10 +19,10 @@ export default function KeyInfo(props) {
             return props.dateFormat(date, 'MMMM yyyy', { locale: props.i18n.language });
           }
 
-        case UpdateType.Replacement:
+        case NextUpdateType.Replacement:
           return <T>dataset_view.key_information.next_update_replacement</T>;
 
-        case UpdateType.None:
+        case NextUpdateType.None:
           return <T>dataset_view.key_information.next_update_none</T>;
       }
     }


### PR DESCRIPTION
Make it clear what type of update is in progress when rendering the update journey.

<img width="1443" height="1187" alt="Screenshot 2025-07-23 at 13 06 51" src="https://github.com/user-attachments/assets/4f6281a4-6318-4eb9-a797-257b32171f73" />

<img width="1444" height="972" alt="Screenshot 2025-07-23 at 13 07 04" src="https://github.com/user-attachments/assets/658287a4-2744-4590-bcdb-61a1a64d1231" />

<img width="1465" height="1157" alt="Screenshot 2025-07-23 at 13 07 12" src="https://github.com/user-attachments/assets/ec809f1a-3b77-41d9-8821-861b9f5c3b65" />
