### PR TITLE
Fix publisher frontend healthcheck

### DIFF
--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -113,12 +113,7 @@ export class PublisherApi {
   }
 
   public async ping(): Promise<boolean> {
-    logger.debug(`Pinging backend...`);
-
-    return this.fetch({ url: 'healthcheck' }).then(() => {
-      logger.debug('API responded to ping');
-      return true;
-    });
+    return this.fetch({ url: 'healthcheck' }).then(() => true);
   }
 
   public async getEnabledAuthProviders(): Promise<AuthProvider[]> {

--- a/src/shared/routes/healthcheck.ts
+++ b/src/shared/routes/healthcheck.ts
@@ -2,11 +2,16 @@ import { Router, Request, Response } from 'express';
 
 export const healthcheck = Router();
 
+const getApi = (req: Request): { ping: () => Promise<boolean> } => {
+  // healthcheck is included in both publisher and consumer entrypoints
+  return req.conapi || req.pubapi;
+};
+
 healthcheck.get('/', async (req: Request, res: Response) => {
   let backend = false;
 
   try {
-    backend = await req.conapi.ping();
+    backend = await getApi(req).ping();
   } catch (_err) {
     // do nothing
   }
@@ -18,7 +23,7 @@ const stillAlive = async (req: Request, res: Response) => {
   let backend = false;
 
   try {
-    backend = await req.conapi.ping();
+    backend = await getApi(req).ping();
     if (backend === false) {
       throw new Error('Backend unreachable');
     }


### PR DESCRIPTION
Both the publisher and consumer frontends include the same healthcheck route which was trying to call the consumer api service, but it is not available in the publisher side.

Instead, just use whichever api service is available as they both support a ping to the backend.