### PR TITLE
SW-561: Add publisher contact info to about dataset tab

### DIFF
--- a/src/consumer/views/view.jsx
+++ b/src/consumer/views/view.jsx
@@ -11,7 +11,7 @@ import Pagination from '../../shared/views/components/Pagination';
 import KeyInfo from '../../shared/views/components/dataset/KeyInfo';
 import Notes from '../../shared/views/components/dataset/Notes';
 import About from '../../shared/views/components/dataset/About';
-import Published from '../../shared/views/components/dataset/Published';
+import Publisher from '../../shared/views/components/dataset/Publisher';
 import RadioGroup from '../../shared/views/components/RadioGroup';
 import { Filters } from '../../shared/views/components/Filters';
 // import { CheckboxGroup, CheckboxOptions } from '../../shared/views/components/CheckboxGroup';
@@ -122,7 +122,7 @@ export default function ConsumerView(props) {
         <KeyInfo {...props} keyInfo={props.datasetMetadata.keyInfo} />
         <Notes {...props} notes={props.datasetMetadata.notes} />
         <About {...props} about={props.datasetMetadata.about} />
-        <Published {...props} published={props.datasetMetadata.published} />
+        <Publisher {...props} publisher={props.datasetMetadata.publisher} />
       </div>
     </div>
   );

--- a/src/shared/dtos/dataset.ts
+++ b/src/shared/dtos/dataset.ts
@@ -3,6 +3,7 @@ import { RevisionDTO } from './revision';
 import { MeasureDTO } from './measure';
 import { FactTableColumnDto } from './fact-table-column-dto';
 import { TaskDTO } from './task';
+import { PublisherDTO } from './publisher-dto';
 
 export interface DatasetDTO {
   id: string;
@@ -25,4 +26,5 @@ export interface DatasetDTO {
   end_date?: string;
   user_group_id?: string;
   tasks?: TaskDTO[];
+  publisher?: PublisherDTO;
 }

--- a/src/shared/dtos/publisher-dto.ts
+++ b/src/shared/dtos/publisher-dto.ts
@@ -1,0 +1,7 @@
+import { OrganisationDTO } from './organisation';
+import { UserGroupListItemDTO } from './user/user-group-list-item-dto';
+
+export interface PublisherDTO {
+  group: UserGroupListItemDTO;
+  organisation: OrganisationDTO;
+}

--- a/src/shared/dtos/single-language/dataset.ts
+++ b/src/shared/dtos/single-language/dataset.ts
@@ -1,6 +1,7 @@
 import { SingleLanguageDimension } from './dimension';
 import { SingleLanguageRevision } from './revision';
 import { SingleLanguageMeasure } from './measure';
+import { PublisherDTO } from '../publisher-dto';
 
 export interface SingleLanguageDataset {
   id: string;
@@ -17,4 +18,5 @@ export interface SingleLanguageDataset {
   published_revision?: SingleLanguageRevision;
   start_date?: string;
   end_date?: string;
+  publisher?: PublisherDTO;
 }

--- a/src/shared/interfaces/preview-metadata.ts
+++ b/src/shared/interfaces/preview-metadata.ts
@@ -1,8 +1,8 @@
 import { Designation } from '../enums/designation';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
 import { RelatedLinkDTO } from '../dtos/related-link';
-import { OrganisationDTO } from '../dtos/organisation';
 import { UpdateFrequencyDTO } from '../dtos/update-frequency';
+import { PublisherDTO } from '../dtos/publisher-dto';
 
 export interface PreviewMetadata {
   title?: string;
@@ -30,7 +30,5 @@ export interface PreviewMetadata {
     collection: string;
     relatedLinks?: RelatedLinkDTO[];
   };
-  published: {
-    organisation?: OrganisationDTO;
-  };
+  publisher?: PublisherDTO;
 }

--- a/src/shared/utils/dataset-preview.ts
+++ b/src/shared/utils/dataset-preview.ts
@@ -36,9 +36,7 @@ export const getDatasetPreview = async (
       collection: await markdownToSafeHTML(collection),
       relatedLinks: related_links
     },
-    published: {
-      organisation: undefined
-    }
+    publisher: dataset.publisher
   };
 
   return preview;

--- a/src/shared/views/components/dataset/Publisher.jsx
+++ b/src/shared/views/components/dataset/Publisher.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Published(props) {
+export default function Publisher(props) {
   return (
     <div className="dataset-published">
       <h2 className="govuk-heading-m govuk-!-margin-top-6">{props.t('dataset_view.published.heading')}</h2>
@@ -9,12 +9,14 @@ export default function Published(props) {
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{props.t('dataset_view.published.org')}</dt>
           <dd className="govuk-summary-list__value">
-            {props.published.organisation?.name || props.t('dataset_view.not_entered')}
+            {props.publisher?.organisation?.name || props.t('dataset_view.not_entered')}
           </dd>
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{props.t('dataset_view.published.contact')}</dt>
-          <dd className="govuk-summary-list__value"></dd>
+          <dd className="govuk-summary-list__value">
+            {props.publisher.group.email || props.t('dataset_view.not_entered')}
+          </dd>
         </div>
       </dl>
     </div>

--- a/src/shared/views/components/dataset/Publisher.jsx
+++ b/src/shared/views/components/dataset/Publisher.jsx
@@ -15,7 +15,7 @@ export default function Publisher(props) {
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{props.t('dataset_view.published.contact')}</dt>
           <dd className="govuk-summary-list__value">
-            {props.publisher.group.email || props.t('dataset_view.not_entered')}
+            {props.publisher?.group?.email || props.t('dataset_view.not_entered')}
           </dd>
         </div>
       </dl>


### PR DESCRIPTION
Displays the publisher contact info on the about page of the dataset.

<img width="763" height="230" alt="Screenshot 2025-07-24 at 15 40 43" src="https://github.com/user-attachments/assets/e29bde0d-db3d-4ac9-9576-65f07845d573" />
