### PR TITLE
SW-942: open dataset preview in a new tab from overview

### DIFF
--- a/src/publisher/views/publish/overview.jsx
+++ b/src/publisher/views/publish/overview.jsx
@@ -96,7 +96,7 @@ function ActionsTab({
 
         {publishingStatus !== 'published' && (
           <li>
-            <ActionLink path={`/publish/${datasetId}/cube-preview`} action="preview" />
+            <ActionLink path={`/publish/${datasetId}/cube-preview`} action="preview" newTab />
           </li>
         )}
 

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1015,7 +1015,7 @@
         "withdraw_update_revision": "Change update before publication",
         "continue_update": "Continue update",
         "continue": "Continue creating dataset",
-        "preview": "View dataset preview",
+        "preview": "View dataset preview (opens in new tab)",
         "move": "Move dataset to another group"
       },
       "history": {


### PR DESCRIPTION
When a user is reviewing a dataset, then it makes sense to open it in a new tab so that they can still see the overview / approval screen.