### PR TITLE
Better fetch errors

### DIFF
--- a/src/consumer/services/consumer-api.ts
+++ b/src/consumer/services/consumer-api.ts
@@ -77,7 +77,7 @@ export class ConsumerApi {
       })
       .catch((error) => {
         if (error instanceof ApiException) throw error;
-        logger.error(error, `An unknown fetch error occurred attempting to access ${this.backendUrl}/${url}`);
+        logger.error(error, `An unknown error occurred attempting to fetch ${this.backendUrl}/${url}`);
         throw new UnknownException(error.mesage);
       });
   }

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -113,7 +113,7 @@ export class PublisherApi {
       .catch((error) => {
         if (error instanceof ApiException) throw error;
         logger.error(error, `An unknown fetch error occurred attempting to access ${this.backendUrl}/${url}`);
-        throw new UnknownException(error.mesage);
+        throw new UnknownException(error.message);
       });
   }
 

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -112,7 +112,7 @@ export class PublisherApi {
       })
       .catch((error) => {
         if (error instanceof ApiException) throw error;
-        logger.error(error, `An unknown fetch error occurred attempting to access ${this.backendUrl}/${url}`);
+        logger.error(error, `An unknown error occurred attempting to fetch ${this.backendUrl}/${url}`);
         throw new UnknownException(error.message);
       });
   }

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -9,6 +9,7 @@ import { ViewException } from '../src/shared/exceptions/view.exception';
 import { SourceAssignmentDTO } from '../src/shared/dtos/source-assignment-dto';
 import { DatasetListItemDTO } from '../src/shared/dtos/dataset-list-item';
 import { PublisherApi } from '../src/publisher/services/publisher-api';
+import { UnknownException } from '../src/shared/exceptions/unknown.exception';
 
 describe('PublisherApi', () => {
   let statsWalesApi: PublisherApi;
@@ -46,10 +47,10 @@ describe('PublisherApi', () => {
   });
 
   describe('Error handling', () => {
-    it('should throw an ApiException when the backend is unreachable', async () => {
+    it('should throw an UnknownException when the backend is unreachable', async () => {
       mockResponse = Promise.reject(new Error('Service Unavailable'));
       await expect(statsWalesApi.fetch({ url: 'example.com/api' })).rejects.toThrow(
-        new ApiException('Service Unavailable', 503)
+        new UnknownException('Service Unavailable')
       );
     });
 


### PR DESCRIPTION
We were not logging the original fetch error message if it rejected and threw an error