### PR TITLE
hardcode support email instead of using env

### DIFF
--- a/src/shared/config/envs/default.ts
+++ b/src/shared/config/envs/default.ts
@@ -11,8 +11,8 @@ export const getDefaultConfig = (): AppConfig => {
   return {
     env: AppEnv.Default, // MUST be overridden by other configs
     supportEmail: {
-      en: process.env.SUPPORT_EMAIL || 'StatsWales@gov.wales',
-      cy: process.env.SUPPORT_EMAIL_CY || 'StatsCymru@llyw.cymru'
+      en: 'StatsWales@gov.wales',
+      cy: 'StatsCymru@llyw.cymru'
     },
     frontend: {
       publisher: {


### PR DESCRIPTION
We have the correct support emails now so might as well just hard code them instead of adding extra env vars.