### PR TITLE
SW-923 Add the option to change a dataset without automated note codes

### DIFF
--- a/src/shared/enums/data-table-action.ts
+++ b/src/shared/enums/data-table-action.ts
@@ -2,5 +2,6 @@ export enum DataTableAction {
   Add = 'add',
   AddRevise = 'add_revise',
   Revise = 'revise',
+  Correction = 'correction',
   ReplaceAll = 'replace_all'
 }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1065,6 +1065,7 @@
       "add_revise": "Add new data and revise existing data",
       "revise": "Revise existing data only",
       "replace_all": "Replace all existing data",
+      "correction": "Change existing data without automated handling of note codes",
       "errors": {
         "missing": "Select the data table update you need to make"
       }


### PR DESCRIPTION
Add the option to change a dataset without triggering automated note code processing.  In the code referred to as a correction.