### PR TITLE
SW-926: incomplete facts error page was failing to render because of broken object path

### DIFF
--- a/src/publisher/views/publish/empty-fact.jsx
+++ b/src/publisher/views/publish/empty-fact.jsx
@@ -31,7 +31,9 @@ export default function EmptyFact(props) {
                 <details className="govuk-details" data-module="govuk-details">
                   <summary className="govuk-details__summary">
                     {props.data.length > 499
-                      ? props.t('errors.fact_table_validation.incomplete_table_summary_500', { rows: props.data.length })
+                      ? props.t('errors.fact_table_validation.incomplete_table_summary_500', {
+                          rows: props.data.length
+                        })
                       : props.t('errors.fact_table_validation.incomplete_table_summary', { rows: props.data.length })}
                   </summary>
                   <DimensionPreviewTable {...props} />

--- a/src/publisher/views/publish/empty-fact.jsx
+++ b/src/publisher/views/publish/empty-fact.jsx
@@ -4,10 +4,10 @@ import DimensionPreviewTable from '../components/DimensionPreviewTable';
 
 export default function EmptyFact(props) {
   const title =
-    props.data.length > 499
-      ? props.t('errors.fact_table_validation.incomplete_fact_500', { count: data.length })
+    props.data?.length > 499
+      ? props.t('errors.fact_table_validation.incomplete_fact_500', { count: props.data.length })
       : props.data
-        ? props.t('errors.fact_table_validation.incomplete_fact', { count: data.length })
+        ? props.t('errors.fact_table_validation.incomplete_fact', { count: props.data.length })
         : props.t('errors.fact_table_validation.incomplete_fact_missing');
   return (
     <Layout {...props} title={title}>
@@ -30,11 +30,11 @@ export default function EmptyFact(props) {
               {props.data.length > 10 ? (
                 <details className="govuk-details" data-module="govuk-details">
                   <summary className="govuk-details__summary">
-                    {data.length > 499
-                      ? props.t('errors.fact_table_validation.incomplete_table_summary_500', { rows: data.length })
-                      : props.t('errors.fact_table_validation.incomplete_table_summary', { rows: data.length })}
+                    {props.data.length > 499
+                      ? props.t('errors.fact_table_validation.incomplete_table_summary_500', { rows: props.data.length })
+                      : props.t('errors.fact_table_validation.incomplete_table_summary', { rows: props.data.length })}
                   </summary>
-                  : <DimensionPreviewTable {...props} />
+                  <DimensionPreviewTable {...props} />
                 </details>
               ) : (
                 <DimensionPreviewTable {...props} />


### PR DESCRIPTION
At some point this got extracted to a separate component and the prop path was not updated.

Also fixed an errant colon that was appearing in the rendered page.