### PR TITLE
SW-955: make lang cookie httpOnly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "highlight.js": "^11.11.1",
         "i18next": "^23.15.1",
         "i18next-fs-backend": "^2.3.2",
-        "i18next-http-middleware": "^3.6.0",
+        "i18next-http-middleware": "^3.8.0",
         "jsdom": "^25.0.1",
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
@@ -7627,9 +7627,9 @@
       "license": "MIT"
     },
     "node_modules/i18next-http-middleware": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.7.1.tgz",
-      "integrity": "sha512-nVTSGB1P4Gad5PFQYf3xVUOzJ4tVSQYD8Rs0luyWkjEMwqdqAcZ9CqIzqYwVLgB5/BKr1COI0oAei5dlYzmGbg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.8.0.tgz",
+      "integrity": "sha512-G3DpT/ibwOx6BCI5A2xUmZ2ybUDUrI6emCdEE7AX9TKvz+WzA6peuyv0BxC8kIrJHtrdnmUWwk4rDN9nxWvsFg==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "highlight.js": "^11.11.1",
     "i18next": "^23.15.1",
     "i18next-fs-backend": "^2.3.2",
-    "i18next-http-middleware": "^3.6.0",
+    "i18next-http-middleware": "^3.8.0",
     "jsdom": "^25.0.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",

--- a/src/shared/middleware/translation.ts
+++ b/src/shared/middleware/translation.ts
@@ -25,7 +25,8 @@ i18next
       lookupHeader: 'accept-language',
       caches: ['cookie'],
       cookieDomain,
-      cookieSecure: config.session.secure
+      cookieSecure: config.session.secure,
+      cookieHttpOnly: true
     },
     backend: {
       loadPath: `${__dirname}/../i18n/{{lng}}.json`


### PR DESCRIPTION
Per recommendation from the IT Healthcheck - 

Set the language cookie HttpOnly flag so that it cannot be accessed by client-side scripts.