### PR TITLE
fix react warnings about value prop

### DIFF
--- a/src/publisher/views/admin/user-create.jsx
+++ b/src/publisher/views/admin/user-create.jsx
@@ -22,7 +22,7 @@ export default function UserCreate(props) {
                 id="email"
                 name="email"
                 type="email"
-                value={props.values.email}
+                defaultValue={props.values.email}
               />
             </div>
             <button type="submit" className="govuk-button" data-module="govuk-button">

--- a/src/publisher/views/admin/user-group-email.jsx
+++ b/src/publisher/views/admin/user-group-email.jsx
@@ -32,7 +32,7 @@ export default function UserGroupEmail(props) {
                 id="email_cy"
                 name="email_cy"
                 type="email"
-                value={props.values.email_cy}
+                defaultValue={props.values.email_cy}
               />
             </div>
             <div className="govuk-form-group">
@@ -50,7 +50,7 @@ export default function UserGroupEmail(props) {
                 id="email_en"
                 name="email_en"
                 type="email"
-                value={props.values.email_en}
+                defaultValue={props.values.email_en}
               />
             </div>
 

--- a/src/publisher/views/admin/user-group-name.jsx
+++ b/src/publisher/views/admin/user-group-name.jsx
@@ -29,7 +29,7 @@ export default function UserGroupName(props) {
                 id="name_cy"
                 name="name_cy"
                 type="text"
-                value={props.values.name_cy}
+                defaultValue={props.values.name_cy}
               />
             </div>
             <div className="govuk-form-group">
@@ -46,7 +46,7 @@ export default function UserGroupName(props) {
                 id="name_en"
                 name="name_en"
                 type="text"
-                value={props.values.name_en}
+                defaultValue={props.values.name_en}
               />
             </div>
 

--- a/src/publisher/views/auth/local.jsx
+++ b/src/publisher/views/auth/local.jsx
@@ -43,7 +43,7 @@ export default function LocalAuth(props) {
                 id="username"
                 name="username"
                 type="text"
-                value={props.username}
+                defaultValue={props.username}
               />
             </div>
             <button type="submit" className="govuk-button" data-module="govuk-button">

--- a/src/publisher/views/publish/related-links.jsx
+++ b/src/publisher/views/publish/related-links.jsx
@@ -150,7 +150,7 @@ export default function RelatedLinks(props) {
                         id="link_label"
                         name="link_label"
                         type="text"
-                        value={props.link.label}
+                        defaultValue={props.link.label}
                       />
                     </div>
                   </fieldset>

--- a/src/publisher/views/publish/schedule.jsx
+++ b/src/publisher/views/publish/schedule.jsx
@@ -22,7 +22,7 @@ export default function Schedule(props) {
             name={name}
             type="text"
             inputMode="numeric"
-            value={props.values?.[name] ? props.values[name] : ''}
+            defaultValue={props.values?.[name] ? props.values[name] : ''}
           />
         </div>
       </div>

--- a/src/publisher/views/publish/title.jsx
+++ b/src/publisher/views/publish/title.jsx
@@ -31,7 +31,7 @@ export default function Title(props) {
             id="title"
             name="title"
             type="text"
-            value={props.title}
+            defaultValue={props.title}
           />
         </div>
         <button type="submit" className="govuk-button" data-module="govuk-button">


### PR DESCRIPTION
React will whinge about using the prop "value" on inputs:

>Warning: Failed prop type: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.

Use "defaultValue" instead and the warning log messages will go away.