### PR TITLE
SW-817: show alternate title + [Not yet translated] if not available in current language

### DIFF
--- a/src/shared/utils/single-lang-dataset.ts
+++ b/src/shared/utils/single-lang-dataset.ts
@@ -1,15 +1,32 @@
+import { t } from 'i18next';
 import { DatasetDTO } from '../dtos/dataset';
 import { RevisionDTO } from '../dtos/revision';
+import { RevisionMetadataDTO } from '../dtos/revision-metadata';
 import { SingleLanguageDataset } from '../dtos/single-language/dataset';
 import { SingleLanguageRevision } from '../dtos/single-language/revision';
 import { Locale } from '../enums/locale';
+
+const getTitle = (metadata: RevisionMetadataDTO[], lang: string): string => {
+  const metaEN = metadata.find((m) => m.language === Locale.EnglishGb);
+  const metaCY = metadata.find((m) => m.language === Locale.WelshGb);
+
+  if (lang.includes(Locale.English)) {
+    return metaEN?.title ? metaEN.title : `${metaCY?.title} [${t('homepage.table.not_translated', { lng: lang })}]`;
+  }
+  return metaCY?.title ? metaCY.title : `${metaEN?.title} [${t('homepage.table.not_translated', { lng: lang })}]`;
+};
 
 export const singleLangRevision = (revision?: RevisionDTO, lang?: string): SingleLanguageRevision | undefined => {
   if (!revision || !lang) return undefined;
 
   return {
     ...revision,
-    metadata: revision.metadata?.find((meta) => meta.language === lang),
+    metadata: revision.metadata
+      ? {
+          ...revision.metadata?.find((meta) => meta.language === lang),
+          title: getTitle(revision.metadata, lang)
+        }
+      : {},
     providers: (revision.providers || []).filter((provider) => provider.language === lang?.toLowerCase()),
     related_links: revision.related_links?.map((link) => ({
       ...link,


### PR DESCRIPTION
If we do not have a translated title yet, then display the original title along with "Not yet translated" in the appropriate language.

<img width="1455" height="626" alt="Screenshot 2025-07-29 at 15 06 09" src="https://github.com/user-attachments/assets/ce68a023-c0a9-49cc-9ddd-d9f30d650b15" />


<img width="1431" height="651" alt="Screenshot 2025-07-29 at 15 06 16" src="https://github.com/user-attachments/assets/98268cf4-87fa-4d8b-97ea-17064b140d1c" />
