### PR TITLE
SW-933: add same support link for request a data source

### DIFF
--- a/src/publisher/views/publish/providers.jsx
+++ b/src/publisher/views/publish/providers.jsx
@@ -165,7 +165,7 @@ export default function Providers(props) {
                               className="govuk-fieldset__legend govuk-fieldset__legend--s"
                               dangerouslySetInnerHTML={{
                                 __html: props.t('publish.providers.add_source.form.source.note', {
-                                  request_data_source_url: props.request_data_source_url
+                                  request_data_provider_url: props.request_data_provider_url
                                 })
                               }}
                             />

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -690,7 +690,7 @@
             }
           },
           "source": {
-            "note": "Os na allwch chi ddod o hyd i'r ffynhonnell yn y rhestr, gallwch <a class=\"govuk-link\" href=\"{{request_data_source_url}}\">ofyn bod ffynhonnell data yn cael ei hychwanegu</a>.",
+            "note": "Os na allwch chi ddod o hyd i'r ffynhonnell yn y rhestr, gallwch <a class=\"govuk-link\" href=\"{{request_data_provider_url}}\">ofyn bod ffynhonnell data yn cael ei hychwanegu</a>.",
             "hint": "Dechrau teipio neu ddewis o'r rhestr",
             "error": {
               "missing": "Dewis ffynhonnell o restr y ffynonellau ar gyfer y darparwr data a ddewiswyd"

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -738,7 +738,7 @@
             }
           },
           "source": {
-            "note": "If you cannot find the source in the list, you can <a class=\"govuk-link\" href=\"{{request_data_source_url}}\">request a data source be added</a>.",
+            "note": "If you cannot find the source in the list, you can <a class=\"govuk-link\" href=\"{{request_data_provider_url}}\">request a data source be added</a>.",
             "hint": "Start typing or select from the list",
             "error": {
               "missing": "Select a source from the list of sources for the selected data provider"


### PR DESCRIPTION
Previously we updated the support email link for adding a provider.

Use the same mailto: support address for "request a data source be added"

<img width="1001" height="398" alt="Screenshot 2025-07-29 at 16 18 47" src="https://github.com/user-attachments/assets/18b99553-6cb2-4978-9537-be108b3fbe64" />
