### PR TITLE
SW-696: Cookie banner and settings page

### DIFF
--- a/docs/cookies/cy/cookie-statement.md
+++ b/docs/cookies/cy/cookie-statement.md
@@ -1,26 +1,28 @@
-# Cwcis
+# Cookies on StatsWales
 
-Ffeiliau yw cwcis sy’n cael eu cadw ar eich ffôn, eich llechen neu eich cyfrifiadur pan fyddwch yn ymweld â gwefan.
+Cookies are files saved on your phone, tablet or computer when you visit a website.
 
-Rydym yn defnyddio cwcis i gofio eich manylion mewngofnodi, eich dewisiadau a’r wybodaeth a nodwyd gennych.
+We use cookies to store information about how you use the StatsWales website, such as the pages you visit. These cookies
+are not used to identify you personally.
 
-## Cwcis hanfodol
+## Cookie settings
 
-Mae cwcis hanfodol yn gwneud pethau fel cofio eich manylion mewngofnodi ac maent yn cadw eich cynnydd trwy ffurflen. Mae angen i’r cwcis hyn fod ymlaen bob amser.
+### Strictly necessary cookies
 
-| Enw                  | Diben                                                                                                | Yn dod i ben |
-| :------------------- | :--------------------------------------------------------------------------------------------------- | :----------- |
-| `jwt`                | Dweud wrthym pwy ydych chi ac mae’n caniatáu i chi gyflawni gweithredoedd ar y wefan hon             | 1 diwrnod    |
-| `lang`               | Mae’n dweud wrthym yr iaith yr ydych chi wedi dewis ei defnyddio                                     | 1 blwyddyn   |
-| `statswales.backend` | Cwcis sesiwn sy’n storio gwybodaeth a nodwyd gennych, fel nad oes yn rhaid i chi ei nodi eto bob tro | 1 diwrnod    |
+These essential cookies do things like:
 
-## FontAwesome
+ * display errors and success messages where these apply
+ * store information you've entered so you do not have to re-enter it every time
 
-Rydym yn defnyddio FontAwesome i ddangos eiconau mewn mannau amrywiol o gwmpas y wefan er mwyn gwneud y wefan yn haws i’w defnyddio. Mae FontAwesome yn defnyddio’r cwcis canlynol.
+These cookies always need to be on.
 
-| Enw            | Diben                                                                                                | Yn dod i ben |
-| :------------- | :--------------------------------------------------------------------------------------------------- | :----------- |
-| `_ga`          | Defnyddir y rhif hwn a gynhyrchir ar hap i bennu ymwelwyr unigryw sy’n defnyddio Font Awesome        | 2 flynedd    |
-| `_ga_*`        | Defnyddir y rhif hwn a gynhyrchir ar hap i bennu ymwelwyr unigryw sy’n defnyddio Font Awesome        | 18 mis       |
-| `__stripe_sid` | Mae Stripe yn gosod y cwci hwn fel rhan o weithgarwch darganfod ac atal twyll wrth brosesu taliadau. | 1 blwyddyn   |
-| `__stripe_mid` | Mae Stripe yn gosod y cwci hwn fel rhan o weithgarwch darganfod ac atal twyll wrth brosesu taliadau. | 1 awr        |
+
+### Cookies that measure website use
+We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics
+sets cookies that store anonymised information about:
+
+ * how you got to the site
+ * the pages you visit on StatsWales, and how long you spend on each page
+ * what you click on while you're visiting the site
+
+We do not allow Google to use or share the data about how you use this site.

--- a/docs/cookies/en/cookie-statement.md
+++ b/docs/cookies/en/cookie-statement.md
@@ -1,26 +1,28 @@
-# Cookies
+# Cookies on StatsWales
 
 Cookies are files saved on your phone, tablet or computer when you visit a website.
 
-We use cookies to remember your login details, your preferences and the information you've entered.
+We use cookies to store information about how you use the StatsWales website, such as the pages you visit. These cookies
+are not used to identify you personally.
 
-## Essential cookies
+## Cookie settings
 
-Essential cookies do things like remember your login details and save your progress through a form. These cookies always need to be on.
+### Strictly necessary cookies
 
-| Name                 | Purpose                                                                                             | Expires |
-| :------------------- | :-------------------------------------------------------------------------------------------------- | :------ |
-| `jwt`                | Tells us who you are and allows you to perform actions on this site                                 | 1 day   |
-| `lang`               | Tells us the language you have chosen to use                                                        | 1 year  |
-| `statswales.backend` | Session cookies that stores information you've entered so you do not have to re-enter it every time | 1 day   |
+These essential cookies do things like:
 
-## FontAwesome
+ * display errors and success messages where these apply
+ * store information you've entered so you do not have to re-enter it every time
 
-We use FontAwesome to display icons in various places around the site to make the site easier to use. FontAwesome uses the following cookies.
+These cookies always need to be on.
 
-| Name           | Purpose                                                                                     | Expires   |
-| :------------- | :------------------------------------------------------------------------------------------ | :-------- |
-| `_ga`          | This randomly generated number is used to determine unique visitors using Font Awesome      | 2 years   |
-| `_ga_*`        | This randomly generated number is used to determine unique visitors using Font Awesome      | 18 months |
-| `__stripe_sid` | Stripe sets this cookie as part of fraud detection and prevention when processing payments. | 1 year    |
-| `__stripe_mid` | Stripe sets this cookie as part of fraud detection and prevention when processing payments. | 1 hour    |
+
+### Cookies that measure website use
+We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics
+sets cookies that store anonymised information about:
+
+ * how you got to the site
+ * the pages you visit on StatsWales, and how long you spend on each page
+ * what you click on while you're visiting the site
+
+We do not allow Google to use or share the data about how you use this site.

--- a/src/consumer/app.ts
+++ b/src/consumer/app.ts
@@ -16,8 +16,9 @@ import { healthcheck } from '../shared/routes/healthcheck';
 import { errorHandler } from '../shared/routes/error-handler';
 import { notFound } from '../shared/routes/not-found';
 import { consumer } from './routes/consumer';
-import { cookies } from '../shared/routes/cookie';
+import { cookies } from '../shared/routes/cookies';
 import { handleAsset404 } from '../shared/middleware/asset-404';
+import { cookieBanner } from '../shared/middleware/cookie-banner';
 
 const app: Application = express();
 const config = appConfig();
@@ -39,6 +40,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(httpLogger);
 app.use(cookieParser());
+app.use(cookieBanner);
 app.use(i18nextMiddleware.handle(i18next));
 app.use(languageSwitcher);
 app.use(initServices);

--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import clsx from 'clsx';
 import { Locals, LocalsProvider, useLocals } from '../../../shared/views/context/Locals';
+import CookieBanner from '../../../shared/views/components/CookieBanner';
 
 const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; noPad?: boolean }>) => {
   const { i18n, t, buildUrl } = useLocals();
@@ -46,6 +47,8 @@ const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; 
         <a href="#main-content" className="govuk-skip-link" data-module="govuk-skip-link">
           Skip to main content
         </a>
+
+        <CookieBanner />
 
         <div className="govuk-phase-banner">
           <div className="govuk-width-container">

--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -1,19 +1,12 @@
 import React, { PropsWithChildren } from 'react';
 import clsx from 'clsx';
+import T from '../../../shared/views/components/T';
 import { Locals, LocalsProvider, useLocals } from '../../../shared/views/context/Locals';
 import CookieBanner from '../../../shared/views/components/CookieBanner';
 
 const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; noPad?: boolean }>) => {
-  const { i18n, t, buildUrl } = useLocals();
-  const links = [
-    'contact_us',
-    'accessibility',
-    'copyright_statement',
-    'cookies',
-    'privacy',
-    'terms_conditions',
-    'modern_slavery'
-  ];
+  const { i18n, t, buildUrl, supportEmail } = useLocals();
+
   return (
     <html lang={i18n.language} className="govuk-template wg">
       <head>
@@ -122,21 +115,45 @@ const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; 
         </main>
 
         <footer className="wg-footer">
+          <div className="footer-top">
+            <div className="govuk-width-container">
+              <a href="#top" role="button" className="govuk-button govuk-button--secondary govuk-button--top">
+                {t('footer.top_of_page')}
+              </a>
+            </div>
+          </div>
           <div className="govuk-width-container govuk-!-padding-top-9">
             <ul className="footer-menu govuk-list">
-              {links.map((link) => (
-                <li className="govuk-footer__inline-list-item" key={link}>
-                  <a className="govuk-footer__link" href="#">
-                    {t(`footer.${link}`)}
-                  </a>
-                </li>
-              ))}
+              <li className="menu__item">
+                <a href={`mailto:${supportEmail}`}>
+                  <T>footer.contact_us</T>
+                </a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/accessibility-statement-govwales">{t('footer.accessibility')}</a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/copyright-statement">{t('footer.copyright_statement')}</a>
+              </li>
+              <li className="menu__item">
+                <a href={buildUrl(`/cookies`, i18n.language)}>{t('footer.cookies')}</a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/website-privacy-policy">{t('footer.privacy')}</a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/terms-and-conditions">{t('footer.terms_conditions')}</a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/welsh-government-modern-slavery-statement">
+                  {t('footer.modern_slavery')}
+                </a>
+              </li>
+              <li className="menu__item">
+                <a href="https://www.gov.wales/alternative-languages">Alternative languages</a>
+              </li>
             </ul>
             <div className="wg-footer-logo"></div>
-            <div>
-              <br />
-              <br />
-            </div>
           </div>
         </footer>
 

--- a/src/consumer/views/cookies.jsx
+++ b/src/consumer/views/cookies.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import Layout from './components/Layout';
+import CookieSettings from '../../shared/views/components/CookieSettings';
 
 export default function Cookies(props) {
   return (
     <Layout {...props}>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds" dangerouslySetInnerHTML={{ __html: props.content }} />
-        <div style={{ position: 'sticky', top: '10px' }} className="govuk-grid-column-one-third">
-          {props.tableOfContents && <h2 className="govuk-heading-s">{props.t('toc')}</h2>}
-          <div dangerouslySetInnerHTML={{ __html: props.tableOfContents }}></div>
-        </div>
-      </div>
+      <CookieSettings {...props} />
     </Layout>
   );
 }

--- a/src/publisher/app.ts
+++ b/src/publisher/app.ts
@@ -23,8 +23,9 @@ import { errorHandler } from '../shared/routes/error-handler';
 import { homepage } from './routes/homepage';
 import { notFound } from '../shared/routes/not-found';
 import { guidance } from './routes/guidance';
-import { cookies } from '../shared/routes/cookie';
+import { cookies } from '../shared/routes/cookies';
 import { admin } from './routes/admin';
+import { cookieBanner } from '../shared/middleware/cookie-banner';
 
 const app: Application = express();
 const config = appConfig();
@@ -47,6 +48,7 @@ app.use(express.json());
 app.use(httpLogger);
 app.use(cookieParser());
 app.use(session);
+app.use(cookieBanner);
 app.use(i18nextMiddleware.handle(i18next));
 app.use(languageSwitcher);
 app.use(initServices);

--- a/src/publisher/views/components/Layout.tsx
+++ b/src/publisher/views/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from 'react';
 import clsx from 'clsx';
 import T from '../../../shared/views/components/T';
 import { Locals, LocalsProvider, useLocals } from '../../../shared/views/context/Locals';
+import CookieBanner from '../../../shared/views/components/CookieBanner';
 
 export type LayoutProps = {
   title?: string;
@@ -99,6 +100,8 @@ const Layout = ({ title, children, backLink, returnLink, formPage }: PropsWithCh
         <a href="#main-content" className="govuk-skip-link" data-module="govuk-skip-link">
           {t('header.navigation.skip_to_content')}
         </a>
+
+        <CookieBanner />
 
         <div className="govuk-phase-banner">
           <div className="govuk-width-container">

--- a/src/publisher/views/components/Layout.tsx
+++ b/src/publisher/views/components/Layout.tsx
@@ -276,7 +276,7 @@ const Layout = ({ title, children, backLink, returnLink, formPage }: PropsWithCh
                 <a href="https://www.gov.wales/copyright-statement">{t('footer.copyright_statement')}</a>
               </li>
               <li className="menu__item">
-                <a href={`/${i18n.language}/cookies`}>{t('footer.cookies')}</a>
+                <a href={buildUrl(`/cookies`, i18n.language)}>{t('footer.cookies')}</a>
               </li>
               <li className="menu__item">
                 <a href="https://www.gov.wales/website-privacy-policy">{t('footer.privacy')}</a>

--- a/src/publisher/views/cookies.jsx
+++ b/src/publisher/views/cookies.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import Layout from './components/Layout';
+import CookieSettings from '../../shared/views/components/CookieSettings';
 
 export default function Cookies(props) {
   return (
     <Layout {...props}>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds" dangerouslySetInnerHTML={{ __html: props.content }} />
-        <div style={{ position: 'sticky', top: '10px' }} className="govuk-grid-column-one-third">
-          {props.tableOfContents && <h2 className="govuk-heading-s">{props.t('toc')}</h2>}
-          <div dangerouslySetInnerHTML={{ __html: props.tableOfContents }}></div>
-        </div>
-      </div>
+      <CookieSettings {...props} />
     </Layout>
   );
 }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -58,6 +58,28 @@
       "users": "Users"
     }
   },
+
+  "cookies": {
+    "banner": {
+      "required": {
+        "summary": "We've saved some files called cookies on your device. These cookies are:",
+        "list": {
+          "essential": "essential for the site to work"
+        }
+      },
+      "optional": {
+        "summary": "We would also like to save some cookies to help:",
+        "list": {
+          "improve": "improve our website by collecting and reporting information on how you use it",
+          "tailor": "tailor communications"
+        }
+      },
+      "buttons": {
+        "accept_all": "Accept all cookies",
+        "change_settings": "Change cookie settings"
+      }
+    }
+  },
   "footer": {
     "top_of_page": "Back to top",
     "contact_us": "Contact us",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -78,6 +78,17 @@
         "accept_all": "Accept all cookies",
         "change_settings": "Change cookie settings"
       }
+    },
+    "settings": {
+      "measuring": {
+        "options": {
+          "reject": "Do not use cookies that measure my website use",
+          "accept": "Use cookies that measure my website use"
+        }
+      },
+      "buttons": {
+        "submit": "Save changes"
+      }
     }
   },
   "footer": {

--- a/src/shared/interfaces/cookie-preferences.ts
+++ b/src/shared/interfaces/cookie-preferences.ts
@@ -1,0 +1,7 @@
+export interface CookiePreferences {
+  showBanner: boolean;
+  acceptAll?: boolean;
+  essential?: boolean;
+  improve?: boolean;
+  tailor?: boolean;
+}

--- a/src/shared/interfaces/cookie-preferences.ts
+++ b/src/shared/interfaces/cookie-preferences.ts
@@ -1,7 +1,5 @@
 export interface CookiePreferences {
   showBanner: boolean;
   acceptAll?: boolean;
-  essential?: boolean;
-  improve?: boolean;
-  tailor?: boolean;
+  measuring?: boolean;
 }

--- a/src/shared/middleware/cookie-banner.ts
+++ b/src/shared/middleware/cookie-banner.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Request, Response } from 'express';
+import { logger } from '../utils/logger';
+import { CookiePreferences } from '../interfaces/cookie-preferences';
+
+export const cookieBanner = (req: Request, res: Response, next: NextFunction) => {
+  const cookiePreferences = req.cookies['cookiePref'] as CookiePreferences;
+  res.locals.showCookieBanner = !cookiePreferences;
+
+  if (res.locals.showCookieBanner) {
+    logger.debug('new visitor or user previously refused cookies - displaying cookie banner');
+  }
+
+  next();
+};

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -39,6 +39,10 @@
     text-decoration: none !important;
   }
 
+  .cookie-banner {
+    padding-top: 20px;
+  }
+
   .govuk-phase-banner a:link:focus {
     color: colours.$white !important;
     background-color: colours.$black !important;

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
-import { NextFunction, Request, Response, Router } from 'express';
+import express, { NextFunction, Request, Response, Router } from 'express';
 import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
@@ -9,26 +9,54 @@ import { marked } from 'marked';
 import { logger } from '../utils/logger';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { docRenderer, createToc, getTitle } from '../services/marked';
+import { CookiePreferences } from '../interfaces/cookie-preferences';
 
 export const cookies = Router();
+
+const bodyParser = express.urlencoded({ extended: true });
 const docsPath = path.join(__dirname, '..', '..', '..', 'docs', 'cookies');
 
-cookies.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  logger.debug('Rendering cookie statement page');
+const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
+  const defaultPref: CookiePreferences = { acceptAll: false, measuring: false, showBanner: true };
+  const cookiePreferences = req.cookies['cookiePref'] || defaultPref;
+
+  if (req.method === 'POST') {
+    logger.debug('Cookie preferences submitted...');
+    const { acceptAll, measuring } = req.body;
+
+    if (acceptAll === 'true') {
+      cookiePreferences.acceptAll = true;
+      cookiePreferences.measuring = true;
+      cookiePreferences.showBanner = false;
+    } else if (measuring) {
+      cookiePreferences.acceptAll = true;
+      cookiePreferences.measuring = measuring === 'accept';
+      cookiePreferences.showBanner = false;
+    }
+
+    res.cookie('cookiePref', cookiePreferences, { maxAge: 31536000000, httpOnly: true });
+    res.redirect(req.get('Referrer') || '/');
+    return;
+  }
+
   let fullDocsPath = path.join(docsPath, 'en');
+
   for (const dir of fs.readdirSync(docsPath)) {
     if (dir === req.language.split('-')[0].toLowerCase()) {
       fullDocsPath = path.join(docsPath, dir);
       break;
     }
   }
+
   const requestedFilePath = path.join(fullDocsPath, 'cookie-statement.md');
   const normalizedFilePath = path.resolve(requestedFilePath);
+
   if (!normalizedFilePath.startsWith(fullDocsPath) && !fs.existsSync(normalizedFilePath)) {
     logger.error(`File does not exist in guidance: ${req.params.file}`);
     next(new NotFoundException());
     return;
   }
+
   const title = await getTitle(normalizedFilePath);
   const mardkwonFile: string = fs.readFileSync(normalizedFilePath, 'utf8');
   const { window } = new JSDOM(`<!DOCTYPE html>`);
@@ -36,5 +64,9 @@ cookies.get('/', async (req: Request, res: Response, next: NextFunction) => {
   const toc = createToc(mardkwonFile);
   marked.use({ renderer: docRenderer });
   const content = domPurify.sanitize(await marked.parse(mardkwonFile));
-  res.render('cookies', { content, tableOfContents: toc, title });
-});
+
+  res.render('cookies', { content, tableOfContents: toc, title, cookiePreferences });
+};
+
+cookies.get('/', bodyParser, cookiePage);
+cookies.post('/', bodyParser, cookiePage);

--- a/src/shared/views/components/CookieBanner.tsx
+++ b/src/shared/views/components/CookieBanner.tsx
@@ -8,9 +8,9 @@ export default function CookieBanner() {
   if (!showCookieBanner) return null;
 
   return (
-    <div id="govwales-shared-cookie-message" className="container-fluid">
+    <div id="cookie-banner" className="cookie-banner container-fluid">
       <p className="govuk-body">
-        <T>cookie_banner.required.summary</T>
+        <T>cookies.banner.required.summary</T>
       </p>
 
       <ul className="govuk-list govuk-list--bullet">

--- a/src/shared/views/components/CookieBanner.tsx
+++ b/src/shared/views/components/CookieBanner.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import T from './T';
+import { useLocals } from '../context/Locals';
+
+export default function CookieBanner() {
+  const { showCookieBanner, buildUrl, i18n } = useLocals();
+
+  if (!showCookieBanner) return null;
+
+  return (
+    <div id="govwales-shared-cookie-message" className="container-fluid">
+      <p className="govuk-body">
+        <T>cookie_banner.required.summary</T>
+      </p>
+
+      <ul className="govuk-list govuk-list--bullet">
+        <li>
+          <T>cookies.banner.required.list.essential</T>
+        </li>
+      </ul>
+
+      <p className="govuk-body">
+        <T>cookies.banner.optional.summary</T>
+      </p>
+
+      <ul className="govuk-list govuk-list--bullet">
+        <li>
+          <T>cookies.banner.optional.list.improve</T>
+        </li>
+        <li>
+          <T>cookies.banner.optional.list.tailor</T>
+        </li>
+      </ul>
+
+      <form id="cookie-banner-form" action={buildUrl('/cookies', i18n.language)} method="post">
+        <input type="hidden" name="acceptAll" value="true" />
+
+        <div className="govuk-button-group">
+          <button id="cookies-accept-all" className="govuk-button govuk-button--secondary">
+            <T>cookies.banner.buttons.accept_all</T>
+          </button>
+          <a
+            id="cookieOptions"
+            className="govuk-button govuk-button--secondary"
+            href={buildUrl('/cookies', i18n.language)}
+          >
+            <T>cookies.banner.buttons.change_settings</T>
+          </a>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/shared/views/components/CookieSettings.tsx
+++ b/src/shared/views/components/CookieSettings.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useLocals } from '../context/Locals';
+import RadioGroup from './RadioGroup';
+import T from './T';
+import { CookiePreferences } from '../../interfaces/cookie-preferences';
+
+type CookieSettingsProps = {
+  content: string;
+  tableOfContents: string;
+  cookiePreferences: CookiePreferences;
+};
+
+export default function CookieSettings(props: CookieSettingsProps) {
+  const { buildUrl, i18n } = useLocals();
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds" dangerouslySetInnerHTML={{ __html: props.content }} />
+        <div style={{ position: 'sticky', top: '10px' }} className="govuk-grid-column-one-third">
+          {props.tableOfContents && <h2 className="govuk-heading-s">{i18n.t('toc')}</h2>}
+          <div dangerouslySetInnerHTML={{ __html: props.tableOfContents }}></div>
+        </div>
+      </div>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <form method="POST" action={buildUrl('/cookies', i18n.language)} className="govuk-form-group">
+            <RadioGroup
+              name="measuring"
+              labelledBy="guidance-cookies-that-measure-website-use"
+              options={[
+                { value: 'reject', label: i18n.t('cookies.settings.measuring.options.reject') },
+                { value: 'accept', label: i18n.t('cookies.settings.measuring.options.accept') }
+              ]}
+              value={
+                props.cookiePreferences.measuring !== undefined
+                  ? props.cookiePreferences.measuring === true
+                    ? 'accept'
+                    : 'reject'
+                  : undefined
+              }
+            />
+            <div className="govuk-button-group">
+              <button type="submit" className="govuk-button">
+                <T>cookies.settings.buttons.submit</T>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Adds a banner to the top of the site informing the user about our use of cookies.

Also replaces the cookies page with new text and a form to control settings.

<img width="1221" height="1458" alt="Screenshot 2025-07-30 at 17 46 28" src="https://github.com/user-attachments/assets/257e22c6-1931-41e1-888a-2eb7da5cca53" />
