### PR TITLE
SW-696: accept all cookies improvement

### DIFF
--- a/src/shared/middleware/history.ts
+++ b/src/shared/middleware/history.ts
@@ -1,12 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
 import { RequestHistory } from '../interfaces/request-history';
 
+const isRelativeUrl = (url: string): boolean => {
+  return url.startsWith('/') && !url.includes('://');
+};
+
 // records the last 10 URLs visited by the user
 export const history = (req: Request, res: Response, next: NextFunction) => {
   const history: RequestHistory[] = req.session?.history || [];
   const currentUrl = req.originalUrl;
 
-  if (currentUrl !== history[0]?.url) {
+  if (currentUrl !== history[0]?.url && isRelativeUrl(currentUrl)) {
     // Add the current URL to the beginning of the history array
     history.unshift({
       url: currentUrl,

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -50,9 +50,9 @@ const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
       secure: config.session.secure
     });
 
-    req.session.flash = [{ key: `cookies.referrer`, value: referrer }];
+    req.session.flash = [`cookies.settings.saved.heading`];
     req.session.save();
-    res.redirect(req.buildUrl('/cookies', req.language));
+    res.redirect(acceptAll === 'true' ? referrer : req.buildUrl('/cookies', req.language));
     return;
   }
 


### PR DESCRIPTION
Feedback from team review - 

If user "accepts all" from the cookie banner without visiting the cookie settings page, automatically return them to the original url after saving.