### PR TITLE
SW-853: display error page when lookup table contains empty rows

### DIFF
--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -843,9 +843,19 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
           return;
         }
 
+        if (error.status === 500 && body?.errors?.[0]?.message?.key?.includes('lookup_table_loading_failed')) {
+          const failurePreview = body as ViewErrDTO;
+          res.render('publish/dimension-match-failure', {
+            ...failurePreview,
+            patchRequest: { dimension_type: DimensionType.LookupTable },
+            dimension
+          });
+          return;
+        }
+
         logger.error(error, 'Something went wrong other than not matching');
         res.status(500);
-        errors = [{ field: 'unknown', message: { key: 'errors.csv.unknown' } }];
+        errors = [{ field: 'unknown', message: { key: 'errors.dimension_validation.unknown_error' } }];
         throw new Error();
       }
     } catch (err: any) {

--- a/src/publisher/views/publish/dimension-match-failure.jsx
+++ b/src/publisher/views/publish/dimension-match-failure.jsx
@@ -16,13 +16,13 @@ export default function DimensionMatchFailure(props) {
 
       {props.patchRequest.dimension_type === 'lookup_table' ? (
         <>
-          { props.extension?.totalNonMatching &&
+          {props.extension?.totalNonMatching && (
             <p className="govuk-body">
               {props.t('publish.dimension_match_failure.lookup_information', {
                 failureCount: props.extension.totalNonMatching
               })}
             </p>
-          }
+          )}
           <p className="govuk-body">{props.t('publish.dimension_match_failure.you_should_check')}</p>
           <ul className="govuk-list govuk-list--bullet">
             <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.formatting')}</li>

--- a/src/publisher/views/publish/dimension-match-failure.jsx
+++ b/src/publisher/views/publish/dimension-match-failure.jsx
@@ -16,14 +16,17 @@ export default function DimensionMatchFailure(props) {
 
       {props.patchRequest.dimension_type === 'lookup_table' ? (
         <>
-          <p className="govuk-body">
-            {props.t('publish.dimension_match_failure.lookup_information', {
-              failureCount: props.extension.totalNonMatching
-            })}
-          </p>
+          { props.extension?.totalNonMatching &&
+            <p className="govuk-body">
+              {props.t('publish.dimension_match_failure.lookup_information', {
+                failureCount: props.extension.totalNonMatching
+              })}
+            </p>
+          }
           <p className="govuk-body">{props.t('publish.dimension_match_failure.you_should_check')}</p>
           <ul className="govuk-list govuk-list--bullet">
             <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.formatting')}</li>
+            <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.empty_rows')}</li>
             <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.choices')}</li>
           </ul>
         </>

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -533,6 +533,7 @@
       "ref_information": "{{failureCount, number}} instances of reference codes in the data table could not be found in the selected standardised reference data.",
       "you_should_check_ref": "You should check you selected the correct data table and reference data. You should also check the data table:",
       "formatting": "contain the correct reference codes",
+      "empty_rows": "do not contain any empty rows",
       "choices": "do not contain any trailing spaces after any values",
       "ref_formatting": "contains the correct reference codes",
       "ref_choices": "does not contain any trailing spaces after any values",


### PR DESCRIPTION
Previously we were just showing a not very helpful "errors.csv.unknown" untranslated message when a lookup table contained empty rows.

We now trigger the `dimension-match-failure` error page and I've added an additional item to the "you should check" list.

<img width="1437" height="982" alt="Screenshot 2025-08-05 at 13 02 55" src="https://github.com/user-attachments/assets/95ea9d39-55b5-45ef-9f05-b6274115fc61" />
