### PR TITLE
SW-916 remove translation of year type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ yarn.lock
 
 # ignore IDE settings
 .vscode/
+.nova/
 playwright/.auth

--- a/src/publisher/views/components/DimensionPreviewTable.tsx
+++ b/src/publisher/views/components/DimensionPreviewTable.tsx
@@ -46,9 +46,6 @@ export default function DimensionPreviewTable(props: DimensionPreviewTableProps)
         case 'end_date': {
           return dateFormat(parseISO(value.split('T')[0]), 'do MMMM yyyy');
         }
-        case 'date_type': {
-          return <T>publish.time_dimension_review.year_type.{value}</T>;
-        }
       }
       return value;
     },


### PR DESCRIPTION
Year types are now translated directly in the cube build process and when the date dimension is created on the backend.  This cleans up the preview of date dimensions by no longer having erronious `publish.time_dimension_review.year_type.` in the preview.