### PR TITLE
SW-956: Escape dimension values in filters

### DIFF
--- a/src/consumer/controllers/consumer.ts
+++ b/src/consumer/controllers/consumer.ts
@@ -19,6 +19,9 @@ import { appConfig } from '../../shared/config';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
 import { TopicDTO } from '../../shared/dtos/topic';
 import { parseFilters } from '../../shared/utils/parse-filters';
+import { FilterTable } from '../../shared/dtos/filter-table';
+import { ViewDTO } from '../../shared/dtos/view-dto';
+import { PreviewMetadata } from '../../shared/interfaces/preview-metadata';
 
 const config = appConfig();
 
@@ -82,16 +85,13 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
     return;
   }
 
-  const datasetMetadata = await getDatasetMetadata(dataset, revision);
-  const preview = await req.conapi.getPublishedDatasetView(
-    dataset.id,
-    pageSize,
-    pageNumber,
-    sortBy,
-    selectedFilterOptions
-  );
+  const [datasetMetadata, preview, filters]: [PreviewMetadata, ViewDTO, FilterTable[]] = await Promise.all([
+    getDatasetMetadata(dataset, revision),
+    req.conapi.getPublishedDatasetView(dataset.id, pageSize, pageNumber, sortBy, selectedFilterOptions),
+    req.conapi.getPublishedDatasetFilters(dataset.id)
+  ]);
+
   pagination = generateSequenceForNumber(preview.current_page, preview.total_pages);
-  const filters = await req.conapi.getPublishedDatasetFilters(dataset.id);
 
   res.render('view', { ...preview, datasetMetadata, pagination, filters, selectedFilterOptions });
 };

--- a/src/consumer/services/consumer-api.ts
+++ b/src/consumer/services/consumer-api.ts
@@ -131,10 +131,10 @@ export class ConsumerApi {
     );
   }
 
-  public async getPublishedDatasetFilters(datasetId: string): Promise<FilterTable> {
+  public async getPublishedDatasetFilters(datasetId: string): Promise<FilterTable[]> {
     logger.debug(`Fetching published view of dataset: ${datasetId}`);
     return this.fetch({ url: `v1/${datasetId}/view/filters` }).then(
-      (response) => response.json() as unknown as FilterTable
+      (response) => response.json() as unknown as FilterTable[]
     );
   }
 

--- a/src/shared/utils/parse-filters.ts
+++ b/src/shared/utils/parse-filters.ts
@@ -1,0 +1,10 @@
+import { FilterInterface } from '../interfaces/filterInterface';
+
+export const parseFilters = (filters?: Record<string, string[]>): FilterInterface[] | undefined => {
+  if (!filters) return undefined;
+
+  return Object.keys(filters).map((key: string) => ({
+    columnName: key,
+    values: filters[key].map((value: string) => decodeURIComponent(value))
+  }));
+};

--- a/src/shared/views/components/Filters.tsx
+++ b/src/shared/views/components/Filters.tsx
@@ -16,7 +16,7 @@ const normalizeFilters = (options: FilterTable['values']): CheckboxOptions[] => 
   return options.map((opt) => {
     return {
       label: opt.description,
-      value: opt.description,
+      value: encodeURIComponent(opt.description), // this is used in checkbox input name
       children: opt.children ? normalizeFilters(opt.children) : undefined
     };
   });


### PR DESCRIPTION
This fixes an issue with cube preview / consumer view when dimension values contain non-alphanumeric characters such as `[`, `]`, etc.

These values need escaping/encoding as they're used in the checkbox input name and can cause issues with parsing the form data correctly.

There is also a slight performance improvement by fetching the data and available filters in parallel instead of sequentially.

