### PR TITLE
SW-989: Render markdown as html in translation previews

### DIFF
--- a/src/publisher/views/components/TranslationsPreviewTable.tsx
+++ b/src/publisher/views/components/TranslationsPreviewTable.tsx
@@ -37,7 +37,8 @@ export default function TranslationsPreviewTable({ isImport, translations }: Tra
         )
       ) : (
         <T>translations.export.table.value</T>
-      )
+      ),
+      format: (value: string) => <div dangerouslySetInnerHTML={{ __html: value }} />
     },
     ...(isImport
       ? [
@@ -47,7 +48,8 @@ export default function TranslationsPreviewTable({ isImport, translations }: Tra
               <T>translations.import.table.welsh</T>
             ) : (
               <T>translations.import.table.english</T>
-            )
+            ),
+            format: (value: string) => <div dangerouslySetInnerHTML={{ __html: value }} />
           }
         ]
       : [


### PR DESCRIPTION
The metadata fields allow the user to provide markdown which is then rendered as HTML in the published dataset.

This PR updates the translation previews to render the markdown as it would appear on the dataset about page.

<img width="1448" height="868" alt="Screenshot 2025-08-11 at 17 13 11" src="https://github.com/user-attachments/assets/7ad4ca7d-cdf8-434e-87a8-93d227d1614a" />
