### PR TITLE
Add search box to dev dataset list

### DIFF
--- a/src/consumer/views/view.jsx
+++ b/src/consumer/views/view.jsx
@@ -142,7 +142,7 @@ export default function ConsumerView(props) {
         <form
           method="get"
           action={props.buildUrl(
-            `${props.preview ? '/publish' : ''}/${props.dataset.id}/download`,
+            `${props.preview || props.isDeveloper ? '/publish' : ''}/${props.dataset.id}/download`,
             props.i18n.language
           )}
         >

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -30,11 +30,12 @@ export const listAllDatasets = async (req: Request, res: Response, next: NextFun
   try {
     const page = parseInt(req.query.page_number as string, 10) || 1;
     const limit = parseInt(req.query.page_size as string, 10) || 20;
-    const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getFullDatasetList(page, limit);
+    const search = req.query.search as string | undefined;
+    const results: ResultsetWithCount<DatasetListItemDTO> = await req.pubapi.getFullDatasetList(page, limit, search);
     const { data, count } = results;
     const pagination = getPaginationProps(page, limit, count);
     const flash = res.locals.flash;
-    res.render('developer/list', { data, ...pagination, statusToColour, flash });
+    res.render('developer/list', { data, ...pagination, search, statusToColour, flash });
   } catch (err) {
     next(err);
   }

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -221,9 +221,18 @@ export class PublisherApi {
   }
 
   // should only be used for developer view
-  public async getFullDatasetList(page = 1, limit = 20): Promise<ResultsetWithCount<DatasetListItemDTO>> {
+  public async getFullDatasetList(
+    page = 1,
+    limit = 20,
+    search?: string
+  ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
     logger.debug(`Fetching full dataset list...`);
-    const qs = `${new URLSearchParams({ page: page.toString(), limit: limit.toString() }).toString()}`;
+
+    const searchParams = search
+      ? new URLSearchParams({ page: page.toString(), limit: limit.toString(), search })
+      : new URLSearchParams({ page: page.toString(), limit: limit.toString() });
+
+    const qs = searchParams.toString();
 
     return this.fetch({ url: `developer/dataset?${qs}` }).then(
       (response) => response.json() as unknown as ResultsetWithCount<DatasetListItemDTO>

--- a/src/publisher/views/developer/list.jsx
+++ b/src/publisher/views/developer/list.jsx
@@ -93,8 +93,24 @@ export default function DeveloperList(props) {
       <FlashMessages />
 
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
+        <div className="govuk-grid-column-two-thirds">
           <h1 className="govuk-heading-xl">{title}</h1>
+        </div>
+        <div className="govuk-grid-column-one-third" style={{ textAlign: 'right' }}>
+          <form method="GET">
+            <div className="govuk-form-group govuk-form-group--inline">
+              <input
+                type="text"
+                name="search"
+                className="govuk-input"
+                placeholder={props.t('developer.list.search.placeholder')}
+                defaultValue={props.search || ''}
+              />
+            </div>
+            <button type="submit" className="govuk-button govuk-button-small govuk-!-display-inline">
+              {props.t('developer.list.search.button')}
+            </button>
+          </form>
         </div>
       </div>
 

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1210,6 +1210,10 @@
       "heading": "List Datasets",
       "details": "Details",
       "tasklist": "Task List",
+      "search": {
+        "placeholder": "Search datasets by title",
+        "button": "Search"
+      },
       "error": {
         "no_datasets": "No datasets are currently listed in the database. If you need help, contact a member of the development team."
       },


### PR DESCRIPTION
On some environments the full list of datasets is going to be long, and it would be really handy to be able to just find a dataset by title when trying to debug.

Search might also be useful to publishers but we can prototype it on the dev list first.

<img width="1472" height="1214" alt="Screenshot 2025-08-12 at 11 05 16" src="https://github.com/user-attachments/assets/82938adb-f99f-4e12-a320-d9b03b00ff30" />

<img width="1465" height="824" alt="Screenshot 2025-08-12 at 11 05 07" src="https://github.com/user-attachments/assets/5b10eb07-f432-4828-8849-785e817465fe" />
