### PR TITLE
Don't show cookie banner on return from login

### DIFF
--- a/src/shared/middleware/translation.ts
+++ b/src/shared/middleware/translation.ts
@@ -26,7 +26,8 @@ i18next
       caches: ['cookie'],
       cookieDomain,
       cookieSecure: config.session.secure,
-      cookieHttpOnly: true
+      cookieHttpOnly: true,
+      cookieSameSite: 'lax'
     },
     backend: {
       loadPath: `${__dirname}/../i18n/{{lng}}.json`

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -47,7 +47,7 @@ const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
     res.cookie('cookiePref', cookiePreferences, {
       maxAge: 31536000000, // 1 year
       httpOnly: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
       secure: config.session.secure
     });
 


### PR DESCRIPTION
I was seeing an issue where on first return from login, the cookie banner displayed despite the cookiePref cookie being set to hide the banner.

On further inspection, this was because Chrome filters out `SameSite=Strict` cookies from requests made from other domains (such as a redirect from the backend after auth).

<img width="383" height="206" alt="Screenshot 2025-08-14 at 10 43 27" src="https://github.com/user-attachments/assets/03ad9ff0-cbb7-461f-98ad-09029f1765cb" />

The banner would disappear again once you started navigating the frontend, as Chrome sent the cookie with those requests.

The solution is to use "Lax" rather than "Strict" for SameSite as it allows cookies to be sent on GET requests from other domains whilst retaining protection against POST requests as a CSRF measure.

As an added bonus, this was also preventing the language cookie from being read after returning from login, and the same fix on that allows the language selection to persist across the login journey.
