### PR TITLE
SW-482: Note code shorthand docs

### DIFF
--- a/docs/static-pages/shorthand.cy.md
+++ b/docs/static-pages/shorthand.cy.md
@@ -1,6 +1,6 @@
 # Shorthand for labelling data values
 
-Some tables on StatsWales use symbols, also know as shorthand, to provide extra detail about specific data values.
+Some tables on StatsWales use symbols, also known as shorthand, to provide extra detail about specific data values.
 These are as follows:
 
 | Shorthand | Meaning                                          | Use                                                                                                                             |

--- a/docs/static-pages/shorthand.cy.md
+++ b/docs/static-pages/shorthand.cy.md
@@ -1,0 +1,24 @@
+# Shorthand for labelling data values
+
+Some tables on StatsWales use symbols, also know as shorthand, to provide extra detail about specific data values.
+These are as follows:
+
+| Shorthand | Meaning                                          | Use                                                                                                                             |
+| :-------- | :----------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| **a**     | Average                                          | The data value is an average of other values                                                                                    |
+| **b**     | Break in time series                             | There is a break in the data series that means that data before the break cannot be directly compared with data after the break |
+| **c**     | Confidential information                         | The data value has been suppressed for confidentiality purposes                                                                 |
+| **e**     | Estimated                                        | The data value is an estimated value                                                                                            |
+| **f**     | Forecast                                         | The data value is a calculated future value instead of an observed value                                                        |
+| **k**     | Low figure                                       | The data value is a low figure that appears as a zero when rounded                                                              |
+| **ns**    | Not statistically significant                    | It's not possible to determine if the data value is reliable or not                                                             |
+| **p**     | Provisional                                      | The data value is yet to be finalised, or is expected to be revised                                                             |
+| **r**     | Revised                                          | The data value has been revised since it was first published                                                                    |
+| **s**     | Statistically significant at 0.05 or 5% level    | There's a less than 5% chance the data value is unreliable                                                                      |
+| **ss**    | Statistically significant at 0.01 or 1% level    | There's a less than 1% chance the data value is unreliable                                                                      |
+| **sss**   | Statistically significant at 0.001 or 0.1% level | There's a less than 0.1% chance the data value is unreliable                                                                    |
+| **t**     | Total                                            | The data value is a total of other values                                                                                       |
+| **u**     | Low reliability                                  | The data value is of low statistical quality                                                                                    |
+| **w**     | None recorded in survey                          | No data value is estimated to be in this combination of variables                                                               |
+| **x**     | Not available                                    | The data value is unavailable for unknown or other reasons                                                                      |
+| **z**     | Not applicable                                   | There is no possible data value for this combination of variables                                                               |

--- a/docs/static-pages/shorthand.en.md
+++ b/docs/static-pages/shorthand.en.md
@@ -1,6 +1,6 @@
 # Shorthand for labelling data values
 
-Some tables on StatsWales use symbols, also know as shorthand, to provide extra detail about specific data values.
+Some tables on StatsWales use symbols, also known as shorthand, to provide extra detail about specific data values.
 These are as follows:
 
 | Shorthand | Meaning                                          | Use                                                                                                                             |

--- a/docs/static-pages/shorthand.en.md
+++ b/docs/static-pages/shorthand.en.md
@@ -1,0 +1,24 @@
+# Shorthand for labelling data values
+
+Some tables on StatsWales use symbols, also know as shorthand, to provide extra detail about specific data values.
+These are as follows:
+
+| Shorthand | Meaning                                          | Use                                                                                                                             |
+| :-------- | :----------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| **a**     | Average                                          | The data value is an average of other values                                                                                    |
+| **b**     | Break in time series                             | There is a break in the data series that means that data before the break cannot be directly compared with data after the break |
+| **c**     | Confidential information                         | The data value has been suppressed for confidentiality purposes                                                                 |
+| **e**     | Estimated                                        | The data value is an estimated value                                                                                            |
+| **f**     | Forecast                                         | The data value is a calculated future value instead of an observed value                                                        |
+| **k**     | Low figure                                       | The data value is a low figure that appears as a zero when rounded                                                              |
+| **ns**    | Not statistically significant                    | It's not possible to determine if the data value is reliable or not                                                             |
+| **p**     | Provisional                                      | The data value is yet to be finalised, or is expected to be revised                                                             |
+| **r**     | Revised                                          | The data value has been revised since it was first published                                                                    |
+| **s**     | Statistically significant at 0.05 or 5% level    | There's a less than 5% chance the data value is unreliable                                                                      |
+| **ss**    | Statistically significant at 0.01 or 1% level    | There's a less than 1% chance the data value is unreliable                                                                      |
+| **sss**   | Statistically significant at 0.001 or 0.1% level | There's a less than 0.1% chance the data value is unreliable                                                                    |
+| **t**     | Total                                            | The data value is a total of other values                                                                                       |
+| **u**     | Low reliability                                  | The data value is of low statistical quality                                                                                    |
+| **w**     | None recorded in survey                          | No data value is estimated to be in this combination of variables                                                               |
+| **x**     | Not available                                    | The data value is unavailable for unknown or other reasons                                                                      |
+| **z**     | Not applicable                                   | There is no possible data value for this combination of variables                                                               |

--- a/src/consumer/controllers/consumer.ts
+++ b/src/consumer/controllers/consumer.ts
@@ -79,6 +79,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
   let pagination: (string | number)[] = [];
   const sortBy = query.sort_by as unknown as SortByInterface;
   const selectedFilterOptions = parseFilters(query.filter as Record<string, string[]>);
+  const shorthandUrl = req.buildUrl(`/shorthand`, req.language);
 
   if (!dataset.live || !revision) {
     next(new NotFoundException('no published revision found'));
@@ -93,7 +94,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
 
   pagination = generateSequenceForNumber(preview.current_page, preview.total_pages);
 
-  res.render('view', { ...preview, datasetMetadata, pagination, filters, selectedFilterOptions });
+  res.render('view', { ...preview, datasetMetadata, pagination, filters, selectedFilterOptions, shorthandUrl });
 };
 
 export const downloadPublishedMetadata = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/consumer/views/view.jsx
+++ b/src/consumer/views/view.jsx
@@ -28,9 +28,33 @@ export default function ConsumerView(props) {
   const parsedQuery = qs.parse(query);
   const sortBy = parsedQuery.sort_by;
 
+  const NoteCodesLegend = () => {
+    if (!props.note_codes || props.note_codes.length === 0) return null;
+
+    return (
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-full">
+          <p className="govuk-body standard-shorthand">
+            <span
+              dangerouslySetInnerHTML={{
+                __html: props.t('dataset_view.notes.shorthand', { shorthand_url: props.shorthandUrl })
+              }}
+            ></span>
+            {props.note_codes.map((code, idx) => (
+              <span key={code} className="govuk-body">
+                {` [${code}] = ${props.t(`dataset_view.notes.${code}`).toLowerCase()}${idx < props.note_codes.length - 1 ? ',' : '.'}`}
+              </span>
+            ))}
+          </p>
+        </div>
+      </div>
+    );
+  };
+
   const DataPanel = (
     <div className="govuk-width-container">
       <div className="govuk-main-wrapper govuk-!-padding-top-0">
+        <NoteCodesLegend />
         <div className="govuk-grid-row govuk-!-margin-bottom-0">
           {/* Disabled for consumer testing */}
           {/*<div className="govuk-grid-column-one-half">*/}

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -583,7 +583,8 @@ export const cubePreview = async (req: Request, res: Response, next: NextFunctio
         errors,
         datasetStatus,
         publishingStatus,
-        datasetTitle
+        datasetTitle,
+        shorthandUrl: req.buildUrl(`/shorthand`, req.language)
       });
       return;
     }

--- a/src/shared/dtos/view-dto.ts
+++ b/src/shared/dtos/view-dto.ts
@@ -36,4 +36,5 @@ export interface ViewDTO {
   total_pages: number;
   headers: ColumnHeader[];
   data: string[][];
+  note_codes?: string[];
 }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1746,5 +1746,8 @@
   },
   "accessibility": {
     "title": "Accessibility statement for StatsWales"
+  },
+  "shorthand": {
+    "title": "Shorthand for labelling data values"
   }
 }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -198,6 +198,7 @@
     },
     "notes": {
       "heading": "Data notes",
+      "shorthand": "<a class=\"govuk-link\" href=\"{{shorthand_url}}\" target=\"_blank\">Standard shorthand</a> is used in this table:",
       "revisions": "Revisions",
       "data_value_shorthand": "Data value shorthand",
       "rounding": "Rounding applied",

--- a/src/shared/routes/static-pages.ts
+++ b/src/shared/routes/static-pages.ts
@@ -16,28 +16,33 @@ const docsPath = path.join(__dirname, '..', '..', '..', 'docs', 'static-pages');
 
 export const staticPages = Router();
 
-staticPages.get('/accessibility', async (req: Request, res: Response, next: NextFunction) => {
-  const lang = req.language.split('-')[0]?.toLowerCase() || 'en';
-  const requestedFilePath = path.join(docsPath, `accessibility.${lang}.md`);
-  const normalizedFilePath = path.resolve(requestedFilePath);
+const staticPageHandler = (pageName: string) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const lang = req.language.split('-')[0]?.toLowerCase() || 'en';
+    const requestedFilePath = path.join(docsPath, `${pageName}.${lang}.md`);
+    const normalizedFilePath = path.resolve(requestedFilePath);
 
-  if (!normalizedFilePath.startsWith(docsPath) || !fs.existsSync(normalizedFilePath)) {
-    logger.error('Could not find accessibility docs file');
-    next(new NotFoundException());
-    return;
-  }
+    if (!normalizedFilePath.startsWith(docsPath) || !fs.existsSync(normalizedFilePath)) {
+      logger.error(`Could not load ${normalizedFilePath}`);
+      next(new NotFoundException());
+      return;
+    }
 
-  try {
-    const title = t('accessibility.title', { lng: req.language });
-    const markdownFile: string = await readFile(normalizedFilePath, 'utf8');
-    const { window } = new JSDOM(`<!DOCTYPE html>`);
-    const domPurify = DOMPurify(window);
-    const tableOfContents = createToc(markdownFile);
-    marked.use({ renderer: docRenderer });
-    const content = domPurify.sanitize(await marked.parse(markdownFile));
-    res.render('static-page', { content, tableOfContents, title });
-  } catch (err) {
-    logger.error(err, 'Could not render accessibility page');
-    next(new NotFoundException());
-  }
-});
+    try {
+      const title = t(`${pageName}.title`, { lng: req.language });
+      const markdownFile: string = await readFile(normalizedFilePath, 'utf8');
+      const { window } = new JSDOM(`<!DOCTYPE html>`);
+      const domPurify = DOMPurify(window);
+      const tableOfContents = createToc(markdownFile);
+      marked.use({ renderer: docRenderer });
+      const content = domPurify.sanitize(await marked.parse(markdownFile));
+      res.render('static-page', { content, tableOfContents, title });
+    } catch (err) {
+      logger.error(err, `Could not render ${pageName} page`);
+      next(new NotFoundException());
+    }
+  };
+};
+
+staticPages.get('/accessibility', staticPageHandler('accessibility'));
+staticPages.get('/shorthand', staticPageHandler('shorthand'));


### PR DESCRIPTION
Adds a legend at the top of the cube preview/consumer view that displays the note codes and their definitions, along with a link to a table with the full set of codes.

<img width="1504" height="977" alt="Screenshot 2025-08-15 at 14 51 49" src="https://github.com/user-attachments/assets/d899a3c1-0faa-4db7-be8d-8b5391ef5505" />


<img width="1445" height="1260" alt="Screenshot 2025-08-15 at 14 53 37" src="https://github.com/user-attachments/assets/5fcc8045-7360-4958-95aa-11703f61793e" />


