### PR TITLE
SW-774: use a different subheading if subtopic

### DIFF
--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -119,7 +119,7 @@ export default function TopicList(props) {
             <>
               <Breadcrumbs {...props} />
               <h2 className="topic-subhead">
-                <T>consumer.topic_list.topic</T>
+                <T>{ props.parentTopics.length > 0 ? 'consumer.topic_list.sub_topic' : 'consumer.topic_list.topic' }</T>
               </h2>
               <h1 className="govuk-heading-xl">{title}</h1>
             </>

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1734,6 +1734,7 @@
       "heading": "Find statistics and data about Wales",
       "topics": "Topics",
       "topic": "Topic",
+      "sub_topic": "Sub-topic",
       "api": "Browse by topic or <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"{{url}}\">get API access (opens in new tab)</a>.",
       "dataset": {
         "first_published": "First published: {{published}}"


### PR DESCRIPTION
Changes the subheading for topics depending on if the topic has parent(s).

<img width="701" height="532" alt="Screenshot 2025-08-26 at 16 55 02" src="https://github.com/user-attachments/assets/465165e5-1382-4cf7-9454-ac2bf04a25cf" />
<img width="823" height="523" alt="Screenshot 2025-08-26 at 16 55 06" src="https://github.com/user-attachments/assets/abb5b165-9521-4aae-9a29-7d5d18d68c1b" />
