### PR TITLE
Add frontend support for period endings and rolling periods

### DIFF
--- a/docs/guidance/en/Data-preparation-‐-New-datasets.md
+++ b/docs/guidance/en/Data-preparation-‐-New-datasets.md
@@ -177,9 +177,25 @@ Your dataset can contain data for multiple time periods. For example, monthly va
 
 You **must use consistent year formatting** for all time periods present in the dataset. For example if you use ‘YYYY’ for years, you could use ‘YYYYQx’ for quarters and 'YYYYMM' for months.
 
-##### Non-standard periods
+#### Rolling or overlapping periods of time
 
-There may be rare circumstances where these standardised formats are not appropriate for the data in your dataset. For example, if periods are non-continuous and cover only parts of specific years. In these cases you should [prepare your own lookup tables](#guidance-lookup-tables).
+There may be circumstances where the periods of time in your dataset overlap. For example, where your data values represent cumulative values up to a specific date, such as the amount for the year ending 30th June, then the amount for year ending 31st July, and so on. In these cases you should use the following formatting:
+
+- a prefix of either YE, QE, ME or WE for year ending, quarter ending, month ending or week ending
+- then any of the specific date formats described in the '[Specific points in time](#guidance-specific-points-in-time)' section
+
+Examples:
+
+| Format in data table | Example      | How it will appear on website |
+| :------------------- | :----------- | :---------------------------- |
+| YEYYYY-MM-DD         | YE2022-03-31 | Year ending 31 March 2022     |
+| QEYYYY-MM-DD         | QE2022-05-30 | Quarter ending 30 May 2022    |
+| MEDD-MM-YYYY         | ME15-03-2022 | Month ending 15 March 2022    |
+| WEDD-MM-YYYY         | WE25-03-2022 | Week ending 25 March 2022     |
+
+#### Non-standard periods
+
+There may be very rare circumstances where these standardised formats are not appropriate for the data in your dataset. In these cases you should [prepare your own lookup tables](#guidance-lookup-tables).
 
 <!-- In these cases you should [prepare your own date lookup tables](#guidance-date-lookup-tables).
 

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -1189,6 +1189,7 @@ export const fetchTimeDimensionPreview = async (req: Request, res: Response, nex
         case 'time_period':
           res.redirect(req.buildUrl(`/publish/${req.params.datasetId}/dates/${dimension.id}/period`, req.language));
           break;
+        case 'rolling_point':
         case 'time_point':
           res.redirect(
             req.buildUrl(`/publish/${req.params.datasetId}/dates/${dimension.id}/point-in-time`, req.language)
@@ -1704,6 +1705,7 @@ export const periodReview = async (req: Request, res: Response, next: NextFuncti
     }
 
     const dataPreview = await req.pubapi.getDimensionPreview(res.locals.dataset.id, dimension.id);
+    logger.debug(JSON.stringify(dataPreview, null, 2));
 
     if (errors) {
       res.status(errors.status || 500);

--- a/src/publisher/views/publish/date-chooser.jsx
+++ b/src/publisher/views/publish/date-chooser.jsx
@@ -3,6 +3,7 @@ import Layout from '../components/Layout';
 import ErrorHandler from '../components/ErrorHandler';
 import Table from '../../../shared/views/components/Table';
 import RadioGroup from '../../../shared/views/components/RadioGroup';
+import { formatInTimeZone } from 'date-fns-tz';
 
 export default function DateChooser(props) {
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
@@ -34,7 +35,10 @@ export default function DateChooser(props) {
           }
         case 'start_date':
         case 'end_date':
-          return props.dateFormat(props.parseISO(value.split('T')[0]), 'do MMMM yyyy', { locale: props.i18n.language });
+          return props.dateFormat(new Date(value), 'do MMMM yyyy', {
+            locale: props.i18n.language,
+            timeZone: 'Europe/London'
+          });
       }
       return value;
     }
@@ -104,6 +108,11 @@ export default function DateChooser(props) {
                         value: 'time_period',
                         label: props.t('publish.time_dimension_chooser.chooser.period'),
                         hint: props.t('publish.time_dimension_chooser.chooser.period-hint')
+                      },
+                      {
+                        value: 'rolling_point',
+                        label: props.t('publish.time_dimension_chooser.chooser.rolling'),
+                        hint: props.t('publish.time_dimension_chooser.chooser.rolling-hint')
                       },
                       {
                         value: 'time_point',

--- a/src/publisher/views/publish/specific-date-chooser.jsx
+++ b/src/publisher/views/publish/specific-date-chooser.jsx
@@ -41,7 +41,7 @@ export default function SpecificDateChooser(props) {
                   hint: <T example="14-10-2024">publish.point_in_time.example</T>
                 },
                 {
-                  value: '-yyyy-MM-dd',
+                  value: 'yyyy-MM-dd',
                   label: 'YYYY-MM-DD',
                   hint: <T example="2024-10-14">publish.point_in_time.example</T>
                 },

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -331,7 +331,9 @@
         "period": "Periods",
         "period-hint": "For example, months or years for which data values apply to",
         "point": "Specific points",
-        "point-hint": "For example, specific dates when data values were collected"
+        "point-hint": "For example, specific dates when data values were collected",
+        "rolling": "Rolling or overlapping periods of time",
+        "rolling-hint": "For example, cumulative yearly values every 3 months"
       }
     },
     "number_chooser": {


### PR DESCRIPTION
Adds support to the frontend for rolling style periods based around a prefix on a specific date.  Support is added for Year Ending, Quarter Ending, Month Ending and Week Ending.

Updates guidance with details of the new format and fixes a timezone issue where dates comes through as UTC but aren't being zoned correctly to Europe/London