### PR TITLE
SW-589: user group deactivate / reactivate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/src/publisher/controllers/admin.ts
+++ b/src/publisher/controllers/admin.ts
@@ -119,7 +119,7 @@ export const groupStatus = async (req: Request, res: Response) => {
   const groupName = group.metadata?.find((m) => lang.includes(m.language!))?.name || '---';
   let errors: ViewError[] = [];
 
-  const action = group.status === UserStatus.Active ? UserGroupAction.Deactivate : UserGroupAction.Reactivate;
+  const action = group.status === UserGroupStatus.Active ? UserGroupAction.Deactivate : UserGroupAction.Reactivate;
 
   try {
     if (req.method === 'POST') {

--- a/src/publisher/controllers/admin.ts
+++ b/src/publisher/controllers/admin.ts
@@ -135,7 +135,7 @@ export const groupStatus = async (req: Request, res: Response) => {
     }
   } catch (err) {
     if (err instanceof ApiException) {
-      logger.error(err, 'there was a problem updating the user status');
+      logger.error(err, 'there was a problem updating the user group status');
       errors = [{ field: 'api', message: { key: 'errors.try_later' } }];
     }
   }

--- a/src/publisher/routes/admin.ts
+++ b/src/publisher/routes/admin.ts
@@ -13,7 +13,8 @@ import {
   createUser,
   editUserRoles,
   viewUser,
-  userStatus
+  userStatus,
+  groupStatus
 } from '../controllers/admin';
 import { ensureAdmin } from '../middleware/ensure-admin';
 import { flashMessages } from '../../shared/middleware/flash';
@@ -45,6 +46,9 @@ admin.post('/group/:userGroupId/organisation', fetchUserGroup, upload.none(), pr
 
 admin.get('/group/:userGroupId/email', fetchUserGroup, provideGroupEmail);
 admin.post('/group/:userGroupId/email', fetchUserGroup, upload.none(), provideGroupEmail);
+
+admin.get('/group/:userGroupId/status', fetchUserGroup, groupStatus);
+admin.post('/group/:userGroupId/status', fetchUserGroup, upload.none(), groupStatus);
 
 admin.use('/user', (req: Request, res: Response, next: NextFunction) => {
   res.locals.activePage = 'users';

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -46,6 +46,7 @@ import { FilterInterface } from '../../shared/interfaces/filterInterface';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
 import { UnknownException } from '../../shared/exceptions/unknown.exception';
 import { TaskAction } from '../../shared/enums/task-action';
+import { UserGroupStatus } from '../../shared/enums/user-group-status';
 
 const config = appConfig();
 
@@ -721,9 +722,11 @@ export class PublisherApi {
     );
   }
 
-  public async getAllUserGroups(): Promise<UserGroupDTO[]> {
-    logger.debug(`Fetching all user groups...`);
-    return this.fetch({ url: `admin/group` }).then((response) => response.json() as unknown as UserGroupDTO[]);
+  public async getAllUserGroups(status?: UserGroupStatus): Promise<UserGroupDTO[]> {
+    logger.debug(`Fetching all user groups with status: ${status || 'any'}...`);
+    const qs = status ? `?${new URLSearchParams({ status }).toString()}` : '';
+
+    return this.fetch({ url: `admin/group${qs}` }).then((response) => response.json() as unknown as UserGroupDTO[]);
   }
 
   public async getUserGroup(groupId: string): Promise<UserGroupDTO> {
@@ -741,6 +744,14 @@ export class PublisherApi {
   public async updateUserGroup(group: UserGroupDTO): Promise<UserGroupDTO> {
     logger.debug(`Updating user group`);
     return this.fetch({ url: `admin/group/${group.id}`, method: HttpMethod.Patch, json: group }).then(
+      (response) => response.json() as unknown as UserGroupDTO
+    );
+  }
+
+  public async updateUserGroupStatus(groupId: string, status: UserGroupStatus): Promise<UserGroupDTO> {
+    logger.debug(`Updating user group status to ${status}...`);
+    const json = { status };
+    return this.fetch({ url: `admin/group/${groupId}/status`, method: HttpMethod.Patch, json }).then(
       (response) => response.json() as unknown as UserGroupDTO
     );
   }

--- a/src/publisher/views/admin/user-group-status.jsx
+++ b/src/publisher/views/admin/user-group-status.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Layout from '../components/Layout';
+import FlashMessages from '../../../shared/views/components/FlashMessages';
+import ErrorHandler from '../components/ErrorHandler';
+
+export default function UserGroupStatus(props) {
+  const title = props.t(`admin.group.${props.action}.heading`, { groupName: props.groupName });
+  return (
+    <Layout {...props} formPage title={title}>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <FlashMessages />
+          <ErrorHandler />
+
+          <h1 className="govuk-heading-xl">{title}</h1>
+
+          <p className="govuk-body">{props.t(`admin.group.${props.action}.description`)}</p>
+
+          <form encType="multipart/form-data" method="post">
+            <button type="submit" className="govuk-button" data-module="govuk-button">
+              {props.t('buttons.continue')}
+            </button>{' '}
+            <a
+              href={props.buildUrl(`/admin/group`, props.i18n.language)}
+              className="govuk-button govuk-button--secondary"
+              data-module="govuk-button"
+            >
+              {props.t('buttons.cancel')}
+            </a>
+          </form>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/publisher/views/admin/user-group-view.jsx
+++ b/src/publisher/views/admin/user-group-view.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import Table from '../../../shared/views/components/Table';
+import FlashMessages from '../../../shared/views/components/FlashMessages';
 
 export default function UserGroupView(props) {
   const columns = [
@@ -31,12 +32,22 @@ export default function UserGroupView(props) {
   const title = props.group?.name;
   return (
     <Layout {...props} title={title}>
+      <FlashMessages />
+
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1 className="govuk-heading-xl">{title}</h1>
 
           <h2 className="govuk-heading-l">{props.t('admin.group.view.details.heading')}</h2>
           <dl className="govuk-summary-list">
+            <div className="govuk-summary-list__row">
+              <dt className="govuk-summary-list__key">{props.t('admin.group.view.details.status')}</dt>
+              <dd className="govuk-summary-list__value">
+                <strong className={`govuk-tag govuk-tag--${props.statusToColour(props.group.status)}`}>
+                  {props.t(`admin.group.badge.status.${props.group.status}`)}
+                </strong>
+              </dd>
+            </div>
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">{props.t('admin.group.view.details.organisation.heading')}</dt>
               <dd className="govuk-summary-list__value">
@@ -50,10 +61,6 @@ export default function UserGroupView(props) {
               </dd>
             </div>
           </dl>
-
-          <a href={props.buildUrl(`/admin/group/${props.group.id}/name`, props.i18n.language)} className="govuk-link">
-            {props.t('admin.group.view.buttons.edit')}
-          </a>
         </div>
       </div>
 
@@ -81,8 +88,26 @@ export default function UserGroupView(props) {
           {!props.group?.datasets || props.group.datasets.length === 0 ? (
             <p>{props.t('admin.group.view.datasets.none')}</p>
           ) : (
-            <p>{props.t('admin.group.view.datasets.some', { count: props.datsetCount })}</p>
+            <p>{props.t('admin.group.view.datasets.some', { count: props.datasetCount })}</p>
           )}
+        </div>
+      </div>
+
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <h2 className="govuk-heading-l">{props.t('admin.group.view.actions.heading')}</h2>
+
+          <div className="actions">
+            <ul className="govuk-list">
+              {props.actions?.map((action, index) => (
+                <li key={index}>
+                  <a className="govuk-link govuk-link--no-underline" href={action.url}>
+                    {props.t(`admin.group.view.actions.${action.key}.label`)}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </Layout>

--- a/src/shared/dtos/single-language/user-group.ts
+++ b/src/shared/dtos/single-language/user-group.ts
@@ -10,4 +10,5 @@ export interface SingleLanguageUserGroup {
   datasets?: DatasetDTO[];
   created_at?: string;
   updated_at?: string;
+  status?: string;
 }

--- a/src/shared/dtos/user/user-group.ts
+++ b/src/shared/dtos/user/user-group.ts
@@ -16,4 +16,5 @@ export interface UserGroupDTO {
   metadata?: UserGroupMetadataDTO[];
   created_at?: string;
   updated_at?: string;
+  status?: string;
 }

--- a/src/shared/enums/user-group-action.ts
+++ b/src/shared/enums/user-group-action.ts
@@ -1,0 +1,5 @@
+export enum UserGroupAction {
+  Edit = 'edit',
+  Deactivate = 'deactivate',
+  Reactivate = 'reactivate'
+}

--- a/src/shared/enums/user-group-status.ts
+++ b/src/shared/enums/user-group-status.ts
@@ -1,0 +1,4 @@
+export enum UserGroupStatus {
+  Active = 'active',
+  Inactive = 'inactive'
+}

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1699,7 +1699,8 @@
           "email": {
             "heading": "Contact email",
             "not_set": "Not set"
-          }
+          },
+          "status": "Status"
         },
         "users": {
           "heading": "Users",
@@ -1714,8 +1715,20 @@
           "heading": "Datasets",
           "dataset": "There is {{count}} dataset",
           "dataset_other": "There are {{count}} datasets",
-          "some": "$t(admin.group.view.datasets.dataset, {\"count\": {{count}} }) assigned to this group",
+          "some": "$t(admin.group.view.datasets.dataset, {\"count\": {{count}} }) assigned to this group. If you need to deactivate the group, you must first move these datasets to another group.",
           "none": "No datasets assigned to this group"
+        },
+        "actions": {
+          "heading": "Actions",
+          "edit": {
+            "label": "Change group details"
+          },
+         "deactivate": {
+            "label": "Deactivate group"
+          },
+          "reactivate": {
+            "label": "Reactivate group"
+          }
         },
         "buttons": {
           "edit": "Change group details"
@@ -1779,6 +1792,28 @@
         "success": {
           "create": "Group created successfully",
           "update": "Group updated successfully"
+        }
+      },
+      "deactivate": {
+        "heading": "Are you sure you want to deactivate {{groupName}}?",
+        "description": "Any associated users will be removed from this group and it will no longer be assignable to users or datasets.",
+        "success": "{{groupName}} deactivated",
+        "error": {
+          "saving": "Group could not be deactivated. Try again later."
+        }
+      },
+      "reactivate": {
+        "heading": "Are you sure you want to reactivate {{groupName}}?",
+        "description": "This group will be assignable to datasets and users.",
+        "success": "{{groupName}} reactivated",
+        "error": {
+          "saving": "Group could not be reactivated. Try again later."
+        }
+      },
+      "badge": {
+        "status": {
+          "active": "Active",
+          "inactive": "Deactivated"
         }
       }
     },

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1723,7 +1723,7 @@
           "edit": {
             "label": "Change group details"
           },
-         "deactivate": {
+          "deactivate": {
             "label": "Deactivate group"
           },
           "reactivate": {

--- a/src/shared/utils/single-lang-user-group.ts
+++ b/src/shared/utils/single-lang-user-group.ts
@@ -10,6 +10,7 @@ export const singleLangUserGroup = (group: UserGroupDTO, lang: string): SingleLa
     ...pick(group, ['id', 'users', 'datasets', 'created_at', 'updated_at']),
     name: meta?.name,
     email: meta?.email,
-    organisation: group.organisation?.name
+    organisation: group.organisation?.name,
+    status: group.status
   };
 };


### PR DESCRIPTION
Adds the UI for deactivating user groups. Only groups with no assigned datasets can be deactivated. All users will be removed from the group, and will not be automatically re-added on reactivation.


<img width="1446" height="1202" alt="Screenshot 2025-09-19 at 15 58 18" src="https://github.com/user-attachments/assets/ea859682-661e-4e40-b65d-b15c242d107a" />
<img width="1437" height="1149" alt="Screenshot 2025-09-19 at 15 58 45" src="https://github.com/user-attachments/assets/9a0a5270-9b38-4d45-9921-99ae3deaaf5d" />
