### PR TITLE
SW-1049: add dataset pagination to topic pages

### DIFF
--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -5,6 +5,7 @@ import Layout from './components/Layout';
 import Hero from './components/Hero';
 import T from '../../shared/views/components/T';
 import { useLocals } from '../../shared/views/context/Locals';
+import Pagination from '../../shared/views/components/Pagination';
 
 function Breadcrumbs({ parentTopics, selectedTopic }) {
   const { buildUrl, i18n } = useLocals();
@@ -154,7 +155,12 @@ export default function TopicList(props) {
 
           {props.childTopics?.length > 0 && <ChildTopics {...props} />}
 
-          {props.datasets?.length > 0 && <Datasets {...props} />}
+          {props.datasets?.length > 0 && (
+            <>
+              <Datasets {...props} />
+              <Pagination {...props} />
+            </>
+          )}
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
Adds missing pagination to the dataset lists on topic pages in the consumer view.