### PR TITLE
Fix use of canonical urls 

### DIFF
--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -6,7 +6,7 @@ import { AppEnv } from '../../../shared/config/env.enum';
 
 const CanonicalUrls = () => {
   const { buildUrl, protocol, hostname, url } = useLocals();
-  const [pathname] = url.split('?');
+  const pathname = new URL(url, `${protocol}://${hostname}`).pathname;
   const currentUrl = `${protocol}://${hostname}${pathname}`;
   const englishUrl = buildUrl(pathname, 'en-GB');
   const welshUrl = buildUrl(pathname, 'cy-GB');


### PR DESCRIPTION
Use base dataset url as canonical url stripping filters etc.

Only display welsh lan alternative if FRONTEND_WELSH_URL is set as an env var.