### PR TITLE
Liveness should only prove the process/event loop is healthy

### DIFF
--- a/src/shared/routes/healthcheck.ts
+++ b/src/shared/routes/healthcheck.ts
@@ -37,4 +37,6 @@ const stillAlive = async (req: Request, res: Response) => {
 };
 
 healthcheck.get('/ready', stillAlive);
-healthcheck.get('/live', stillAlive);
+healthcheck.get('/live', (_req: Request, res: Response) => {
+  res.json({ message: 'success' });
+});


### PR DESCRIPTION
no external deps. Keep /ready for dependency checks.