### PR TITLE
Better config import

### DIFF
--- a/src/consumer/app.ts
+++ b/src/consumer/app.ts
@@ -4,7 +4,6 @@ import express, { Application } from 'express';
 import cookieParser from 'cookie-parser';
 import expressReactViews from 'express-react-views';
 
-import { appConfig } from '../shared/config';
 import { checkConfig } from '../shared/config/check-config';
 import { httpLogger, logger } from '../shared/utils/logger';
 import { strictTransport } from '../shared/middleware/strict-transport';
@@ -25,10 +24,7 @@ import session from '../shared/middleware/session';
 import { staticPages } from '../shared/routes/static-pages';
 
 const app: Application = express();
-const config = appConfig();
 checkConfig();
-
-logger.info(`App config loaded for '${config.env}' env`);
 
 app.disable('x-powered-by');
 app.set('trust proxy', 1);

--- a/src/consumer/controllers/consumer.ts
+++ b/src/consumer/controllers/consumer.ts
@@ -15,15 +15,13 @@ import { FileFormat } from '../../shared/enums/file-format';
 import { getDownloadHeaders } from '../../shared/utils/download-headers';
 import { logger } from '../../shared/utils/logger';
 import { Locale } from '../../shared/enums/locale';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
 import { TopicDTO } from '../../shared/dtos/topic';
 import { parseFilters } from '../../shared/utils/parse-filters';
 import { FilterTable } from '../../shared/dtos/filter-table';
 import { ViewDTO } from '../../shared/dtos/view-dto';
 import { PreviewMetadata } from '../../shared/interfaces/preview-metadata';
-
-const config = appConfig();
 
 export const DEFAULT_PAGE_SIZE = 100;
 

--- a/src/consumer/middleware/services.ts
+++ b/src/consumer/middleware/services.ts
@@ -2,15 +2,13 @@ import { NextFunction, Request, Response } from 'express';
 import { DateArg, format, parseISO } from 'date-fns';
 import { enGB, cy } from 'date-fns/locale';
 
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { Locale } from '../../shared/enums/locale';
 
 import { localeUrl } from '../../shared/middleware/language-switcher';
 import { statusToColour } from '../../shared/utils/status-to-colour';
 import { TZDate } from '@date-fns/tz';
 import { ConsumerApi } from '../services/consumer-api';
-
-const config = appConfig();
 
 export const dateFormat = (date: DateArg<Date> & {}, formatStr: string, options?: any): string => {
   const tzDate = new TZDate(date as Date, 'Europe/London');

--- a/src/consumer/routes/consumer.ts
+++ b/src/consumer/routes/consumer.ts
@@ -9,10 +9,8 @@ import {
   downloadPublishedMetadata
 } from '../controllers/consumer';
 import { fetchPublishedDataset } from '../middleware/fetch-dataset';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { logger } from '../../shared/utils/logger';
-
-const config = appConfig();
 
 export const consumer = Router();
 

--- a/src/consumer/routes/feedback.ts
+++ b/src/consumer/routes/feedback.ts
@@ -6,11 +6,9 @@ import { i18next } from '../../shared/middleware/translation';
 import { flashMessages } from '../../shared/middleware/flash';
 import { ViewError } from '../../shared/dtos/view-error';
 import { getErrors, improveValidator, satisfactionValidator } from '../../shared/validators';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { logger } from '../../shared/utils/logger';
 import { AppEnv } from '../../shared/config/env.enum';
-
-const config = appConfig();
 
 export const feedback = Router();
 

--- a/src/consumer/server.ts
+++ b/src/consumer/server.ts
@@ -1,10 +1,10 @@
 import 'dotenv/config';
 
-import { appConfig } from '../shared/config';
+import { config } from '../shared/config';
 import app from './app';
 import { logger } from '../shared/utils/logger';
 
-const PORT = appConfig().frontend.consumer.port;
+const PORT = config.frontend.consumer.port;
 
 app.listen(PORT, () => {
   logger.info(`Consumer frontend is running on port ${PORT}`);

--- a/src/consumer/services/consumer-api.ts
+++ b/src/consumer/services/consumer-api.ts
@@ -3,7 +3,7 @@ import { performance } from 'node:perf_hooks';
 
 import { logger as parentLogger } from '../../shared/utils/logger';
 import { DatasetDTO } from '../../shared/dtos/dataset';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { HttpMethod } from '../../shared/enums/http-method';
 import { ApiException } from '../../shared/exceptions/api.exception';
 import { Locale } from '../../shared/enums/locale';
@@ -16,8 +16,6 @@ import { FilterInterface } from '../../shared/interfaces/filterInterface';
 import { FilterTable } from '../../shared/dtos/filter-table';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
 import { UnknownException } from '../../shared/exceptions/unknown.exception';
-
-const config = appConfig();
 
 const logger = parentLogger.child({ service: 'consumer-api' });
 

--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -4,9 +4,9 @@ import T from '../../../shared/views/components/T';
 import { Locals, LocalsProvider, useLocals } from '../../../shared/views/context/Locals';
 import CookieBanner from '../../../shared/views/components/CookieBanner';
 import { AppEnv } from '../../../shared/config/env.enum';
-import { appConfig } from '../../../shared/config';
+import { config } from '../../../shared/config';
 
-const configConsumer = appConfig().frontend.consumer;
+const configConsumer = config.frontend.consumer;
 
 const CanonicalUrls = () => {
   const { buildUrl, protocol, hostname, url } = useLocals();

--- a/src/publisher/app.ts
+++ b/src/publisher/app.ts
@@ -4,7 +4,6 @@ import express, { Application } from 'express';
 import cookieParser from 'cookie-parser';
 import expressReactViews from 'express-react-views';
 
-import { appConfig } from '../shared/config';
 import { checkConfig } from '../shared/config/check-config';
 import { httpLogger, logger } from '../shared/utils/logger';
 import { strictTransport } from '../shared/middleware/strict-transport';
@@ -30,10 +29,7 @@ import { history } from '../shared/middleware/history';
 import { staticPages } from '../shared/routes/static-pages';
 
 const app: Application = express();
-const config = appConfig();
 checkConfig();
-
-logger.info(`App config loaded for '${config.env}' env`);
 
 app.disable('x-powered-by');
 app.set('trust proxy', 1);

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -90,7 +90,7 @@ import { UserDTO } from '../../shared/dtos/user/user';
 import { TaskDTO } from '../../shared/dtos/task';
 import { TaskDecisionDTO } from '../../shared/dtos/task-decision';
 import { SingleLanguageRevision } from '../../shared/dtos/single-language/revision';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { FilterTable } from '../../shared/dtos/filter-table';
 import qs from 'qs';
 import { DEFAULT_PAGE_SIZE } from '../../consumer/controllers/consumer';
@@ -2257,7 +2257,6 @@ export const provideUpdateFrequency = async (req: Request, res: Response) => {
 export const provideDataProviders = async (req: Request, res: Response, next: NextFunction) => {
   const deleteId = req.query.delete;
   const editId = req.query.edit;
-  const config = appConfig();
   const supportEmail = req.language.includes('en') ? config.email.support.en : config.email.support.cy;
   let availableProviders: ProviderDTO[] = [];
   let dataProviders: RevisionProviderDTO[] = [];

--- a/src/publisher/middleware/ensure-authenticated.ts
+++ b/src/publisher/middleware/ensure-authenticated.ts
@@ -3,10 +3,8 @@ import JWT from 'jsonwebtoken';
 
 import { JWTPayloadWithUser } from '../../shared/interfaces/jwt-payload-with-user';
 import { logger } from '../../shared/utils/logger';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { GlobalRole } from '../../shared/enums/global-role';
-
-const config = appConfig();
 
 export const ensureAuthenticated = (req: Request, res: Response, next: NextFunction) => {
   logger.debug(`Checking if user is authenticated for route ${req.originalUrl}...`);

--- a/src/publisher/middleware/services.ts
+++ b/src/publisher/middleware/services.ts
@@ -2,15 +2,13 @@ import { NextFunction, Request, Response } from 'express';
 import { DateArg, format, parseISO } from 'date-fns';
 import { enGB, cy } from 'date-fns/locale';
 
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { Locale } from '../../shared/enums/locale';
 import { PublisherApi } from '../services/publisher-api';
 
 import { localeUrl } from '../../shared/middleware/language-switcher';
 import { statusToColour } from '../../shared/utils/status-to-colour';
 import { TZDate } from '@date-fns/tz';
-
-const config = appConfig();
 
 const dateFormat = (date: DateArg<Date> & {}, formatStr: string, options?: any): string => {
   const tzDate = new TZDate(date as Date, 'Europe/London');

--- a/src/publisher/routes/auth.ts
+++ b/src/publisher/routes/auth.ts
@@ -3,12 +3,11 @@ import JWT from 'jsonwebtoken';
 
 import { logger } from '../../shared/utils/logger';
 import { JWTPayloadWithUser } from '../../shared/interfaces/jwt-payload-with-user';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { ViewError } from '../../shared/dtos/view-error';
 
 export const auth = Router();
 
-const config = appConfig();
 const cookieDomain = new URL(config.auth.jwt.cookieDomain).hostname;
 logger.debug(`JWT cookie domain is '${cookieDomain}'`);
 

--- a/src/publisher/server.ts
+++ b/src/publisher/server.ts
@@ -1,10 +1,10 @@
 import 'dotenv/config';
 
-import { appConfig } from '../shared/config';
+import { config } from '../shared/config';
 import app from './app';
 import { logger } from '../shared/utils/logger';
 
-const PORT = appConfig().frontend.publisher.port;
+const PORT = config.frontend.publisher.port;
 
 app.listen(PORT, () => {
   logger.info(`Publisher frontend is running on port ${PORT}`);

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -7,7 +7,7 @@ import { RevisionMetadataDTO } from '../../shared/dtos/revision-metadata';
 import { DataTableDto } from '../../shared/dtos/data-table';
 import { SourceAssignmentDTO } from '../../shared/dtos/source-assignment-dto';
 import { logger as parentLogger } from '../../shared/utils/logger';
-import { appConfig } from '../../shared/config';
+import { config } from '../../shared/config';
 import { HttpMethod } from '../../shared/enums/http-method';
 import { ApiException } from '../../shared/exceptions/api.exception';
 import { ViewException } from '../../shared/exceptions/view.exception';
@@ -48,8 +48,6 @@ import { UnknownException } from '../../shared/exceptions/unknown.exception';
 import { TaskAction } from '../../shared/enums/task-action';
 import { UserGroupStatus } from '../../shared/enums/user-group-status';
 import { DashboardStats } from '../../shared/interfaces/dashboard-stats';
-
-const config = appConfig();
 
 const logger = parentLogger.child({ service: 'publisher-api' });
 

--- a/src/publisher/views/publish/overview/ActionsTab.tsx
+++ b/src/publisher/views/publish/overview/ActionsTab.tsx
@@ -3,13 +3,11 @@ import React from 'react';
 import { TaskDTO } from '../../../../shared/dtos/task';
 import T from '../../../../shared/views/components/T';
 import { useLocals } from '../../../../shared/views/context/Locals';
-import { appConfig } from '../../../../shared/config';
+import { config } from '../../../../shared/config';
 import { TaskAction } from '../../../../shared/enums/task-action';
 import { TaskStatus } from '../../../../shared/enums/task-status';
 import { DatasetStatus } from '../../../../shared/enums/dataset-status';
 import { PublishingStatus } from '../../../../shared/enums/publishing-status';
-
-const config = appConfig();
 
 type ActionLinkProps = {
   path?: string;

--- a/src/publisher/views/publish/overview/overview.jsx
+++ b/src/publisher/views/publish/overview/overview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { appConfig } from '../../../../shared/config';
+import { config } from '../../../../shared/config';
 import Layout from '../../components/Layout';
 import FlashMessages from '../../../../shared/views/components/FlashMessages';
 import ErrorHandler from '../../components/ErrorHandler';
@@ -9,8 +9,6 @@ import Tabs from '../../../../shared/views/components/Tabs';
 import T from '../../../../shared/views/components/T';
 import { ActionsTab } from './ActionsTab';
 import { HistoryTab } from './HistoryTab';
-
-const config = appConfig();
 
 export default function Overview(props) {
   const openPublishTask = props.openTasks.find((task) => task.action === 'publish');

--- a/src/shared/config/check-config.ts
+++ b/src/shared/config/check-config.ts
@@ -3,17 +3,17 @@ import { walkObject, UnknownObject } from '../utils/walk-object';
 
 import { optionalProperties } from './app-config.interface';
 
-import { appConfig } from '.';
+import { config } from '.';
 
 export const checkConfig = () => {
-  const config = appConfig() as unknown as UnknownObject;
+  logger.debug(`Checking app config for '${config.env}' env...`);
 
-  logger.info(`Checking app config for '${config.env}' env...`);
-
-  walkObject(config, ({ key, value, location, isLeaf }) => {
+  walkObject(config as unknown as UnknownObject, ({ key, value, location, isLeaf }) => {
     if (isLeaf && !optionalProperties.includes(key) && value === undefined) {
       const configPath = location.join('.');
       throw new Error(`${configPath} is invalid or missing, stopping server`);
     }
   });
+
+  logger.info(`App config loaded for '${config.env}' env`);
 };

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -10,7 +10,7 @@ import { AppConfig } from './app-config.interface';
 // this is loosely based on the config strategy from
 // https://www.raulmelo.me/en/blog/best-practices-for-handling-per-environment-config-js-ts-applications
 
-export const appConfig = (): AppConfig => {
+const getConfig = (): AppConfig => {
   const currentEnv = process.env.APP_ENV as AppEnv;
 
   switch (currentEnv) {
@@ -31,3 +31,5 @@ export const appConfig = (): AppConfig => {
       throw new Error(`Invalid APP_ENV "${currentEnv}"`);
   }
 };
+
+export const config = getConfig();

--- a/src/shared/middleware/rate-limiter.ts
+++ b/src/shared/middleware/rate-limiter.ts
@@ -1,9 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 
-import { appConfig } from '../config';
-
-const config = appConfig();
+import { config } from '../config';
 
 const bypass = (re: Request, res: Response, next: NextFunction) => next();
 

--- a/src/shared/middleware/session.ts
+++ b/src/shared/middleware/session.ts
@@ -3,10 +3,8 @@ import session, { MemoryStore, Store } from 'express-session';
 import { createClient } from 'redis';
 
 import { logger } from '../utils/logger';
-import { appConfig } from '../config';
+import { config } from '../config';
 import { SessionStore } from '../config/session-store.enum';
-
-const config = appConfig();
 
 let store: Store;
 

--- a/src/shared/middleware/strict-transport.ts
+++ b/src/shared/middleware/strict-transport.ts
@@ -1,10 +1,8 @@
 import { Request, Response, NextFunction, Router } from 'express';
 import helmet from 'helmet';
 
-import { appConfig } from '../config';
+import { config } from '../config';
 import { AppEnv } from '../config/env.enum';
-
-const config = appConfig();
 
 const bypass = (re: Request, res: Response, next: NextFunction) => next();
 

--- a/src/shared/middleware/translation.ts
+++ b/src/shared/middleware/translation.ts
@@ -4,9 +4,8 @@ import i18next from 'i18next';
 import Backend from 'i18next-fs-backend';
 import i18nextMiddleware, { LanguageDetector } from 'i18next-http-middleware';
 
-import { appConfig } from '../config';
+import { config } from '../config';
 
-const config = appConfig();
 const ignoreRoutes = ['/public', '/css', '/assets', '/healthcheck'];
 const TRANSLATIONS = config.language.availableTranslations;
 const SUPPORTED_LOCALES = config.language.supportedLocales;

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -11,11 +11,9 @@ import { logger } from '../utils/logger';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { docRenderer, createToc, getTitle } from '../services/marked';
 import { CookiePreferences } from '../interfaces/cookie-preferences';
-import { appConfig } from '../config';
+import { config } from '../config';
 import { flashMessages } from '../middleware/flash';
 import { RequestHistory } from '../interfaces/request-history';
-
-const config = appConfig();
 
 export const cookies = Router();
 

--- a/src/shared/routes/error-handler.ts
+++ b/src/shared/routes/error-handler.ts
@@ -1,9 +1,8 @@
 import { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
 
-import { appConfig } from '../config';
+import { config } from '../config';
 import { logger } from '../utils/logger';
 
-const config = appConfig();
 const cookieDomain = new URL(config.auth.jwt.cookieDomain).hostname;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -2,9 +2,7 @@ import pino from 'pino';
 import pinoHttp from 'pino-http';
 import pick from 'lodash/pick';
 
-import { appConfig } from '../config';
-
-const config = appConfig();
+import { config } from '../config';
 
 export const logger = pino({
   level: config.logger.level

--- a/tests-e2e/publish/1-start.spec.ts
+++ b/tests-e2e/publish/1-start.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 import { users } from '../fixtures/logins';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Not authed', () => {

--- a/tests-e2e/publish/2-title.spec.ts
+++ b/tests-e2e/publish/2-title.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { TitlePage } from './pages/title-page';
 import { users } from '../fixtures/logins';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Title page', () => {

--- a/tests-e2e/publish/3-upload.spec.ts
+++ b/tests-e2e/publish/3-upload.spec.ts
@@ -2,13 +2,12 @@ import path from 'node:path';
 
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { UploadPage } from './pages/upload-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Upload page', () => {

--- a/tests-e2e/publish/4-preview.spec.ts
+++ b/tests-e2e/publish/4-preview.spec.ts
@@ -2,14 +2,13 @@ import path from 'node:path';
 
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { PreviewPage } from './pages/preview-page';
 import { UploadPage } from './pages/upload-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 // TODO: fix and re-enable this test

--- a/tests-e2e/publish/5-sources.spec.ts
+++ b/tests-e2e/publish/5-sources.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { SourcesPage } from './pages/sources-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Sources page', () => {

--- a/tests-e2e/publish/helpers/create-empty-dataset.ts
+++ b/tests-e2e/publish/helpers/create-empty-dataset.ts
@@ -1,9 +1,8 @@
 import { Page } from '@playwright/test';
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 import { TitlePage } from '../pages/title-page';
 import { escapeRegExp } from 'lodash';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export async function createEmptyDataset(page: Page, title: string) {

--- a/tests-e2e/publish/meta-collection.spec.ts
+++ b/tests-e2e/publish/meta-collection.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { CollectionPage } from './pages/collection-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Data Collection', () => {

--- a/tests-e2e/publish/meta-designation.spec.ts
+++ b/tests-e2e/publish/meta-designation.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { DesignationPage } from './pages/designation-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Designation', () => {

--- a/tests-e2e/publish/meta-providers.spec.ts
+++ b/tests-e2e/publish/meta-providers.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { ProviderPage } from './pages/provider-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe.configure({ mode: 'serial' }); // tests in this file must be performed in order to avoid test failures

--- a/tests-e2e/publish/meta-quality.spec.ts
+++ b/tests-e2e/publish/meta-quality.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { QualityPage } from './pages/quality-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Quality', () => {

--- a/tests-e2e/publish/meta-related.spec.ts
+++ b/tests-e2e/publish/meta-related.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { RelatedLinksPage } from './pages/related-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe.configure({ mode: 'serial' }); // tests in this file must be performed in order to avoid test failures

--- a/tests-e2e/publish/meta-summary.spec.ts
+++ b/tests-e2e/publish/meta-summary.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { SummaryPage } from './pages/summary-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Summary', () => {

--- a/tests-e2e/publish/meta-title.spec.ts
+++ b/tests-e2e/publish/meta-title.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { TitlePage } from './pages/title-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Title', () => {

--- a/tests-e2e/publish/meta-topics.spec.ts
+++ b/tests-e2e/publish/meta-topics.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import { TopicsPage } from './pages/topics-page';
 import { users } from '../fixtures/logins';
 import { createEmptyDataset } from './helpers/create-empty-dataset';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Metadata Topics', () => {

--- a/tests-e2e/publish/move-groups.spec.ts
+++ b/tests-e2e/publish/move-groups.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 import { users } from '../fixtures/logins';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Move dataset between groups', () => {

--- a/tests-e2e/publish/pages/collection-page.ts
+++ b/tests-e2e/publish/pages/collection-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class CollectionPage {

--- a/tests-e2e/publish/pages/designation-page.ts
+++ b/tests-e2e/publish/pages/designation-page.ts
@@ -1,8 +1,7 @@
 import type { Page } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class DesignationPage {

--- a/tests-e2e/publish/pages/preview-page.ts
+++ b/tests-e2e/publish/pages/preview-page.ts
@@ -1,8 +1,7 @@
 import type { Page } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class PreviewPage {

--- a/tests-e2e/publish/pages/provider-page.ts
+++ b/tests-e2e/publish/pages/provider-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class ProviderPage {

--- a/tests-e2e/publish/pages/quality-page.ts
+++ b/tests-e2e/publish/pages/quality-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class QualityPage {

--- a/tests-e2e/publish/pages/related-page.ts
+++ b/tests-e2e/publish/pages/related-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class RelatedLinksPage {

--- a/tests-e2e/publish/pages/sources-page.ts
+++ b/tests-e2e/publish/pages/sources-page.ts
@@ -1,8 +1,7 @@
 import type { Page } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class SourcesPage {

--- a/tests-e2e/publish/pages/summary-page.ts
+++ b/tests-e2e/publish/pages/summary-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class SummaryPage {

--- a/tests-e2e/publish/pages/title-page.ts
+++ b/tests-e2e/publish/pages/title-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class TitlePage {

--- a/tests-e2e/publish/pages/topics-page.ts
+++ b/tests-e2e/publish/pages/topics-page.ts
@@ -1,8 +1,7 @@
 import type { Page } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class TopicsPage {

--- a/tests-e2e/publish/pages/upload-page.ts
+++ b/tests-e2e/publish/pages/upload-page.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator } from '@playwright/test';
 
-import { appConfig } from '../../../src/shared/config';
+import { config } from '../../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 export class UploadPage {

--- a/tests-e2e/required/happy-path.spec.ts
+++ b/tests-e2e/required/happy-path.spec.ts
@@ -8,9 +8,8 @@ import { TZDate } from '@date-fns/tz';
 import { add } from 'date-fns';
 
 import { users } from '../fixtures/logins';
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Happy path', () => {

--- a/tests-e2e/required/homepage.spec.ts
+++ b/tests-e2e/required/homepage.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 import { users } from '../fixtures/logins';
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
-const config = appConfig();
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Not authed', () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -4,13 +4,12 @@ import { parse as parseCookies } from 'set-cookie-parser';
 
 import { i18next } from '../src/shared/middleware/translation';
 import app from '../src/publisher/app';
-import { appConfig } from '../src/shared/config';
+import { config } from '../src/shared/config';
 import { Locale } from '../src/shared/enums/locale';
 
 import { mockBackend } from './mocks/backend';
 
 describe('Authentication', () => {
-  const config = appConfig();
   const t = i18next.t;
 
   beforeAll(() => {

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -6,7 +6,7 @@ import { parse as parseCookies } from 'set-cookie-parser';
 import { i18next } from '../src/shared/middleware/translation';
 import app from '../src/publisher/app';
 import { Locale } from '../src/shared/enums/locale';
-import { appConfig } from '../src/shared/config';
+import { config } from '../src/shared/config';
 
 import { mockBackend } from './mocks/backend';
 
@@ -15,7 +15,6 @@ jest.mock('../src/publisher/middleware/ensure-authenticated', () => ({
 }));
 
 describe('Error handling', () => {
-  const config = appConfig();
   const t = i18next.t;
 
   beforeAll(() => {

--- a/tests/mocks/backend.ts
+++ b/tests/mocks/backend.ts
@@ -2,7 +2,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 
 import { DatasetListItemDTO } from '../../src/shared/dtos/dataset-list-item';
-import { appConfig } from '../../src/shared/config';
+import { config } from '../../src/shared/config';
 
 import {
   datasets,
@@ -131,7 +131,7 @@ export const mockBackend = setupServer(
   }),
 
   http.get('http://localhost:3001/auth/providers', () => {
-    const enabled = appConfig().auth.providers;
+    const enabled = config.auth.providers;
     return HttpResponse.json({ enabled });
   })
 );

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { appConfig } from '../src/shared/config';
+import { config } from '../src/shared/config';
 import { HttpMethod } from '../src/shared/enums/http-method';
 import { Locale } from '../src/shared/enums/locale';
 import { SourceType } from '../src/shared/enums/source-type';
@@ -16,7 +16,6 @@ describe('PublisherApi', () => {
   let fetchSpy: jest.SpyInstance;
   let mockResponse: Promise<Response>;
 
-  const config = appConfig();
   const baseUrl = config.backend.url;
   const token = 'thisissomemadeupjwt';
 


### PR DESCRIPTION
Just tidying up something that has been nagging me for a while... 

Just create the config once and then import it where needed, instead of calling `appConfig()` everywhere.

The main change is https://github.com/Marvell-Consulting/statswales-frontend/pull/489/files#diff-329dac7d95d2a828f92da09e2a59e3957201c8ce7d98a55ae52ce058ef654f75R35 and everything else is just importing that object.

Will do the same on backend shortly.