### PR TITLE
SW-1054: area code filter is passed as an object not an array

### DIFF
--- a/src/consumer/controllers/consumer.ts
+++ b/src/consumer/controllers/consumer.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 
 import { Request, Response, NextFunction } from 'express';
 import slugify from 'slugify';
-import qs from 'qs';
+import qs, { ParsedQs } from 'qs';
 import { stringify } from 'csv-stringify/sync';
 
 import { DatasetListItemDTO } from '../../shared/dtos/dataset-list-item';
@@ -80,7 +80,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
   const pageNumber = Number.parseInt(query.page_number as string, 10) || 1;
   const pageSize = Number.parseInt(query.page_size as string, 10) || DEFAULT_PAGE_SIZE;
   const sortBy = query.sort_by as unknown as SortByInterface;
-  const selectedFilterOptions = parseFilters(query.filter as Record<string, string[]>);
+  const selectedFilterOptions = parseFilters(query.filter as ParsedQs);
   const shorthandUrl = req.buildUrl(`/shorthand`, req.language);
   const isUnpublished = revision?.unpublished_at || false;
   const isArchived = (dataset.archived_at && dataset.archived_at < new Date().toISOString()) || false;

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream';
 import { randomUUID } from 'node:crypto';
 
 import { NextFunction, Request, Response } from 'express';
+import qs, { ParsedQs } from 'qs';
 import { get, set, sortBy } from 'lodash';
 import { FieldValidationError, matchedData } from 'express-validator';
 import { customAlphabet } from 'nanoid';
@@ -92,7 +93,6 @@ import { TaskDecisionDTO } from '../../shared/dtos/task-decision';
 import { SingleLanguageRevision } from '../../shared/dtos/single-language/revision';
 import { config } from '../../shared/config';
 import { FilterTable } from '../../shared/dtos/filter-table';
-import qs from 'qs';
 import { DEFAULT_PAGE_SIZE } from '../../consumer/controllers/consumer';
 import { SortByInterface } from '../../shared/interfaces/sort-by';
 import { NextUpdateType } from '../../shared/enums/next-update-type';
@@ -559,7 +559,7 @@ export const cubePreview = async (req: Request, res: Response, next: NextFunctio
   const pageNumber = Number.parseInt(query.page_number as string, 10) || 1;
   const pageSize = Number.parseInt(query.page_size as string, 10) || DEFAULT_PAGE_SIZE;
   const sortBy = query.sort_by as unknown as SortByInterface;
-  const filter = parseFilters(query.filter as Record<string, string[]>);
+  const filter = parseFilters(query.filter as ParsedQs);
 
   let errors: ViewError[] | undefined;
   let previewData: ViewDTO | ViewErrDTO | undefined;
@@ -580,7 +580,6 @@ export const cubePreview = async (req: Request, res: Response, next: NextFunctio
     const datasetStatus = getDatasetStatus(datasetDTO);
     const publishingStatus = getPublishingStatus(datasetDTO, revision);
     const datasetTitle = revision?.metadata?.title;
-    const selectedFilterOptions = parseFilters(query.filter as Record<string, string[]>);
 
     pagination = paginationSequence(previewDTO.current_page, previewDTO.total_pages);
     previewMetadata = await getDatasetMetadata(dataset, revision);
@@ -602,7 +601,7 @@ export const cubePreview = async (req: Request, res: Response, next: NextFunctio
         datasetStatus,
         publishingStatus,
         datasetTitle,
-        selectedFilterOptions,
+        selectedFilterOptions: filter,
         shorthandUrl: req.buildUrl(`/shorthand`, req.language)
       });
       return;

--- a/src/shared/utils/parse-filters.ts
+++ b/src/shared/utils/parse-filters.ts
@@ -1,20 +1,25 @@
 import { isObjectLike } from 'lodash';
+import { ParsedQs } from 'qs';
+
 import { FilterInterface } from '../interfaces/filterInterface';
 
-export const parseFilters = (filters?: Record<string, string[]>): FilterInterface[] | undefined => {
+export const parseFilters = (filters: ParsedQs): FilterInterface[] | undefined => {
   if (!filters) return undefined;
 
   return Object.keys(filters).map((columnName: string) => {
-    let values = filters[columnName];
+    const values = filters[columnName];
+    let parsedValues: string[] = [];
+
+    if (!values) return { columnName, values: [] };
 
     if (Array.isArray(values)) {
-      values = values.map((value: string) => decodeURIComponent(value));
+      parsedValues = values.map((value) => decodeURIComponent(value as string));
     } else if (isObjectLike(values)) {
-      values = Object.values(values).map((value) => decodeURIComponent(value as string));
+      parsedValues = Object.values(values).map((value) => (value ? decodeURIComponent(value.toString()) : ''));
     } else {
-      values = [decodeURIComponent(values as string)];
+      parsedValues = [decodeURIComponent(values as string)];
     }
 
-    return { columnName, values };
+    return { columnName, values: parsedValues };
   });
 };


### PR DESCRIPTION
Not sure why / when this changed but the filters were being returned in the format:
```
{
  Measure: [ '1' ],
  Source: [ 'Rivers', 'Sea' ],
  Risk: [ 'Med', 'High' ],
  Type: [ 'Total' ],
  Defence: [ 'Defended' ],
  AreaCode: {
    '0': 'W06000001',
    '1': 'W06000002',
    '2': 'W06000003',
    '3': 'W06000004',
    '4': 'W06000005',
    '5': 'W06000006',
    '6': 'W06000023',
    '7': 'W06000008',
    '8': 'W06000009',
    '9': 'W06000010',
    '10': 'W06000011',
    '11': 'W06000012',
    '12': 'W06000013',
    '13': 'W06000014',
    '14': 'W06000015',
    '15': 'W06000016',
    '16': 'W06000024',
    '17': 'W06000018',
    '18': 'W06000019',
    '19': 'W06000020',
    '20': 'W06000021',
    '21': 'W06000022'
  },
  YearCode: [ '2025' ]
}
```

which was throwing `TypeError: filters[key].map is not a function` when trying to parse the AreaCode filter (an object).

This PR updates the filter parsing to convert all filters to array format, e.g. 
```
[
  'W06000001', 'W06000002',
  'W06000003', 'W06000004',
  'W06000005', 'W06000006',
  'W06000023', 'W06000008',
  'W06000009', 'W06000010',
  'W06000011', 'W06000012',
  'W06000013', 'W06000014',
  'W06000015', 'W06000016',
  'W06000024', 'W06000018',
  'W06000019', 'W06000020',
  'W06000021', 'W06000022'
]
```