### PR TITLE
Fix broken container boot if CONSUMER_WELSH_URL not set

### DIFF
--- a/src/shared/middleware/translation.ts
+++ b/src/shared/middleware/translation.ts
@@ -20,8 +20,10 @@ const domainDetector = {
         return 'cy-GB';
       }
     }
-    if (req.hostname?.includes(new URL(url).hostname)) {
-      return 'en-GB';
+    if (url && URL.canParse(url)) {
+      if (req.hostname?.includes(new URL(url).hostname)) {
+        return 'en-GB';
+      }
     }
   }
 };


### PR DESCRIPTION
Azure passes a placeholder if the env var isn't set - this was causing the if condition to trigger but the URL wasn't valid which caused an exception preventing the FE from booting up.

