### PR TITLE
Run validation tests inside files sequentially

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,14 +13,14 @@ import 'dotenv/config';
  */
 export default defineConfig({
   testDir: './tests-e2e',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
+  /* Whether to run tests inside files in parallel (default is to run separate files in parallel but not the tests within the same file) */
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Fail fast on CI */
-  maxFailures: 1,
+  maxFailures: process.env.CI ? 1 : 3,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Dir for test artifacts such as screenshots, videos, traces, etc. */

--- a/tests-e2e/publish/archive-dataset.spec.ts
+++ b/tests-e2e/publish/archive-dataset.spec.ts
@@ -8,8 +8,6 @@ import { publishMinimalDataset } from './helpers/publishing-steps';
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Archive dataset', () => {
-  test.describe.configure({ mode: 'default' }); // run tests in this file sequentially
-
   const title = `archive-dataset.spec - ${nanoid(5)}`;
   let datasetId: string;
 

--- a/tests-e2e/publish/move-dataset.spec.ts
+++ b/tests-e2e/publish/move-dataset.spec.ts
@@ -8,8 +8,6 @@ import { startNewDataset, selectUserGroup, provideDatasetTitle } from './helpers
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Move dataset between groups', () => {
-  test.describe.configure({ mode: 'default' }); // run tests in this file sequentially
-
   const title = `move-dataset.spec - ${nanoid(5)}`;
   let datasetId: string;
 

--- a/tests-e2e/publish/publish-dataset.spec.ts
+++ b/tests-e2e/publish/publish-dataset.spec.ts
@@ -37,8 +37,6 @@ import { config } from '../../src/shared/config';
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Publish dataset', () => {
-  test.describe.configure({ mode: 'default' }); // run tests in this file sequentially
-
   const title = `publish-dataset.spec - ${nanoid(5)}`;
   const nextUpdate = add(new Date(), { years: 1 });
   let datasetId: string;

--- a/tests-e2e/publish/unpublish-dataset.spec.ts
+++ b/tests-e2e/publish/unpublish-dataset.spec.ts
@@ -10,8 +10,6 @@ import { publishMinimalDataset } from './helpers/publishing-steps';
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Unpublish dataset', () => {
-  test.describe.configure({ mode: 'default' }); // run tests in this file sequentially
-
   const title = `unpublish-dataset.spec - ${nanoid(5)}`;
   let datasetId: string;
 

--- a/tests-e2e/publish/update-dataset.spec.ts
+++ b/tests-e2e/publish/update-dataset.spec.ts
@@ -15,8 +15,6 @@ import {
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Update dataset', () => {
-  test.describe.configure({ mode: 'default' }); // run tests in this file sequentially
-
   const title = `update-dataset.spec - ${nanoid(5)}`;
   let datasetId: string;
 

--- a/tests-e2e/publish/validation/assign-sources.spec.ts
+++ b/tests-e2e/publish/validation/assign-sources.spec.ts
@@ -11,14 +11,6 @@ test.describe('Sources page', () => {
   const title = `assign-sources.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/sources`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -50,5 +42,13 @@ test.describe('Sources page', () => {
     test.fixme('Displays an error if more than one value source is selected', async () => {});
     test.fixme('Displays an error if more than one notes source is selected', async () => {});
     test.fixme('Displays an error if more than one measure source is selected', async () => {});
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/sources`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
+    });
   });
 });

--- a/tests-e2e/publish/validation/data-upload.spec.ts
+++ b/tests-e2e/publish/validation/data-upload.spec.ts
@@ -13,14 +13,6 @@ test.describe('Upload page', () => {
   const title = `data-upload.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/upload`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -62,6 +54,14 @@ test.describe('Upload page', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/upload`);
         await expect(page.getByText('errors.unknown_error')).toBeVisible(); // TODO: fix this error message
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/upload`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/dataset-title.spec.ts
+++ b/tests-e2e/publish/validation/dataset-title.spec.ts
@@ -6,14 +6,6 @@ import { users } from '../../fixtures/logins';
 const baseUrl = config.frontend.publisher.url;
 
 test.describe('Title page', () => {
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/title`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -46,6 +38,14 @@ test.describe('Title page', () => {
         expect(page.url()).toContain(`${baseUrl}/en-GB/publish/title`);
         await expect(page.getByText('Enter the title of this dataset')).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/title`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-collection.spec.ts
+++ b/tests-e2e/publish/validation/meta-collection.spec.ts
@@ -11,14 +11,6 @@ test.describe('Metadata - Data collection', () => {
   const title = `meta-collection.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/collection`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -58,6 +50,14 @@ test.describe('Metadata - Data collection', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/collection`);
         await expect(page.getByText('Enter how the data was collected or calculated')).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/collection`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-designation.spec.ts
+++ b/tests-e2e/publish/validation/meta-designation.spec.ts
@@ -11,14 +11,6 @@ test.describe('Metadata - Designation', () => {
   const title = `meta-designation.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/designation`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -47,6 +39,14 @@ test.describe('Metadata - Designation', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/designation`);
         await expect(page.getByText('Select how this dataset is designated').first()).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/designation`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-providers.spec.ts
+++ b/tests-e2e/publish/validation/meta-providers.spec.ts
@@ -7,8 +7,6 @@ import { startNewDataset, selectUserGroup, provideDatasetTitle } from '../helper
 
 const baseUrl = config.frontend.publisher.url;
 
-test.describe.configure({ mode: 'serial' }); // tests in this file must be performed in order to avoid test failures
-
 test.describe('Metadata - Data providers', () => {
   const title = `meta-providers.spec - ${nanoid(5)}`;
   let datasetId: string;
@@ -52,14 +50,6 @@ test.describe('Metadata - Data providers', () => {
       await page.getByRole('link', { name: 'Remove' }).first().click();
     }
   }
-
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/providers`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
 
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
@@ -256,6 +246,14 @@ test.describe('Metadata - Data providers', () => {
         await expect(page.getByRole('cell', { name: 'Sport Wales' })).toBeVisible();
         await expect(page.getByRole('cell', { name: 'Geographical information' })).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/providers`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-quality.spec.ts
+++ b/tests-e2e/publish/validation/meta-quality.spec.ts
@@ -11,14 +11,6 @@ test.describe('Metadata Quality', () => {
   const title = `meta-quality.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/quality`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -79,6 +71,14 @@ test.describe('Metadata Quality', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/quality`);
         await expect(page.getByText('Enter what rounding has been applied to the data values').first()).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/quality`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-related.spec.ts
+++ b/tests-e2e/publish/validation/meta-related.spec.ts
@@ -7,8 +7,6 @@ import { startNewDataset, selectUserGroup, provideDatasetTitle } from '../helper
 
 const baseUrl = config.frontend.publisher.url;
 
-test.describe.configure({ mode: 'serial' }); // tests in this file must be performed in order to avoid test failures
-
 test.describe('Metadata Related Links', () => {
   const title = `meta-related.spec - ${nanoid(5)}`;
   let datasetId: string;
@@ -18,14 +16,6 @@ test.describe('Metadata Related Links', () => {
       await page.getByRole('link', { name: 'Remove' }).first().click();
     }
   }
-
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/related`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
 
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
@@ -90,6 +80,14 @@ test.describe('Metadata Related Links', () => {
         await page.getByRole('button', { name: 'Continue' }).click();
         await expect(page.getByText('Select yes if you need to add a link to another report')).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/related`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-summary.spec.ts
+++ b/tests-e2e/publish/validation/meta-summary.spec.ts
@@ -11,14 +11,6 @@ test.describe('Metadata Summary', () => {
   const title = `meta-summary.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/summary`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -62,6 +54,14 @@ test.describe('Metadata Summary', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/summary`);
         await expect(page.getByText('Enter the summary of this dataset')).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/summary`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-title.spec.ts
+++ b/tests-e2e/publish/validation/meta-title.spec.ts
@@ -11,18 +11,6 @@ test.describe('Metadata Title', () => {
   const title = `meta-title.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.beforeEach(async ({ page }) => {
-    await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/title`);
-  });
-
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/title`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -64,6 +52,14 @@ test.describe('Metadata Title', () => {
         await expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/title`);
         await expect(page.getByText('Enter the title of this dataset')).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/title`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });

--- a/tests-e2e/publish/validation/meta-topics.spec.ts
+++ b/tests-e2e/publish/validation/meta-topics.spec.ts
@@ -11,14 +11,6 @@ test.describe('Metadata Topics', () => {
   const title = `meta-topics.spec - ${nanoid(5)}`;
   let datasetId: string;
 
-  test.describe('Not authed', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-    test('Redirects to login page when not authenticated', async ({ page }) => {
-      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/topics`);
-      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
-    });
-  });
-
   test.describe('Authed as a publisher', () => {
     test.use({ storageState: users.publisher.path });
 
@@ -50,6 +42,14 @@ test.describe('Metadata Topics', () => {
         expect(page.url()).toBe(`${baseUrl}/en-GB/publish/${datasetId}/topics`);
         await expect(page.getByText('Select which topics are relevant to this dataset').first()).toBeVisible();
       });
+    });
+  });
+
+  test.describe('Not authed', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test('Redirects to login page when not authenticated', async ({ page }) => {
+      await page.goto(`${baseUrl}/en-GB/publish/${datasetId}/topics`);
+      expect(page.url()).toBe(`${baseUrl}/en-GB/auth/login`);
     });
   });
 });


### PR DESCRIPTION
The validation tests were creating a new dataset per-test which is excessive - reusing the existing dataset per file is marginally quicker and less noisy.