### PR TITLE
SW-1085 Get start and end dates from the revision over the dataset

### DIFF
--- a/src/shared/dtos/revision.ts
+++ b/src/shared/dtos/revision.ts
@@ -29,6 +29,6 @@ export interface RevisionDTO {
   related_links?: RelatedLinkDTO[];
   providers?: RevisionProviderDTO[];
   topics?: TopicDTO[];
-  coverage_start_date?: Date;
-  coverage_end_date?: Date;
+  coverage_start_date?: string;
+  coverage_end_date?: string;
 }

--- a/src/shared/dtos/single-language/revision.ts
+++ b/src/shared/dtos/single-language/revision.ts
@@ -27,6 +27,6 @@ export interface SingleLanguageRevision {
   related_links?: RelatedLinkDTO[];
   providers?: RevisionProviderDTO[];
   topics?: TopicDTO[];
-  coverage_start_date?: Date;
-  coverage_end_date?: Date;
+  coverage_start_date?: string;
+  coverage_end_date?: string;
 }

--- a/src/shared/utils/dataset-metadata.ts
+++ b/src/shared/utils/dataset-metadata.ts
@@ -21,8 +21,8 @@ export const getDatasetMetadata = async (
 
   const { rounding_applied, designation, related_links, providers, metadata } = revision;
   const { summary, quality, collection, rounding_description } = metadata;
-  const startDate = revision.coverage_start_date ? revision.coverage_start_date.toISOString() : dataset.start_date;
-  const endDate = revision.coverage_end_date ? revision.coverage_end_date.toISOString() : dataset.end_date;
+  const startDate = revision.coverage_start_date ? revision.coverage_start_date : dataset.start_date;
+  const endDate = revision.coverage_end_date ? revision.coverage_end_date : dataset.end_date;
 
   const preview: PreviewMetadata = {
     title: revision.metadata.title,


### PR DESCRIPTION
The revision now carries the start and end dates for the coverage details of the published dataset.  For legacy pruposes we try to fallback to the datasets start and end dates.