### PR TITLE
SW-1146: use correct enctype for forms with express.urlencoded

### DIFF
--- a/src/publisher/views/admin/user-create.jsx
+++ b/src/publisher/views/admin/user-create.jsx
@@ -13,7 +13,7 @@ export default function UserCreate(props) {
 
           <ErrorHandler />
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <div className="govuk-form-group">
               <input
                 className={clsx('govuk-input', {

--- a/src/publisher/views/admin/user-group-email.jsx
+++ b/src/publisher/views/admin/user-group-email.jsx
@@ -17,7 +17,7 @@ export default function UserGroupEmail(props) {
 
           <ErrorHandler />
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <div className="govuk-form-group">
               <label className="govuk-label" htmlFor="email_cy">
                 {props.t('admin.group.email.form.email_cy.label')}

--- a/src/publisher/views/admin/user-group-name.jsx
+++ b/src/publisher/views/admin/user-group-name.jsx
@@ -14,7 +14,7 @@ export default function UserGroupName(props) {
           <h1 className="govuk-heading-xl">{title}</h1>
           <ErrorHandler />
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <div className="govuk-form-group">
               <label className="govuk-label" htmlFor="name_cy">
                 {props.t('admin.group.name.form.name_cy.label')}

--- a/src/publisher/views/admin/user-group-org.jsx
+++ b/src/publisher/views/admin/user-group-org.jsx
@@ -15,7 +15,7 @@ export default function UserGroupOrg(props) {
             </h1>
             <ErrorHandler />
 
-            <form encType="multipart/form-data" method="post">
+            <form method="post">
               <RadioGroup
                 name="organisation_id"
                 labelledBy="organisation"

--- a/src/publisher/views/admin/user-group-status.jsx
+++ b/src/publisher/views/admin/user-group-status.jsx
@@ -16,7 +16,7 @@ export default function UserGroupStatus(props) {
 
           <p className="govuk-body">{props.t(`admin.group.${props.action}.description`)}</p>
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <button type="submit" className="govuk-button" data-module="govuk-button">
               {props.t('buttons.continue')}
             </button>{' '}

--- a/src/publisher/views/admin/user-roles.jsx
+++ b/src/publisher/views/admin/user-roles.jsx
@@ -15,7 +15,7 @@ export default function UserRoles(props) {
 
           <ErrorHandler />
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <div className="govuk-form-group">
               <fieldset className="govuk-fieldset">
                 <h2 className="govuk-heading-l">{props.t('admin.user.roles.service.heading')}</h2>

--- a/src/publisher/views/admin/user-status.jsx
+++ b/src/publisher/views/admin/user-status.jsx
@@ -16,7 +16,7 @@ export default function UserStatus(props) {
 
           <p className="govuk-body">{props.t(`admin.user.${props.action}.description`)}</p>
 
-          <form encType="multipart/form-data" method="post">
+          <form method="post">
             <button type="submit" className="govuk-button" data-module="govuk-button">
               {props.t('buttons.continue')}
             </button>{' '}


### PR DESCRIPTION
Something has changed recently that broke the body parsing on the admin forms.

The enctype attribute has always been incorrectly set to `multipart/form-data` which is for file uploads, not the default for post requests which is `application/x-www-form-urlencoded`.

This should fix the admin form submissions.