### PR TITLE
Add frontend log analysis tool

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ const config = defineConfig([
       'node_modules/**',
       'playwright/**',
       'src/shared/public/**',
+      'tools/analyse-logs/**',
       '**/*.config.{mjs,ts}'
     ]
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is the StatsWales private alpha repository.  This repository is here to allow us to experiment with a number of technologies to prove out a number of hypotheses and establish the technologies we may wish to take in to Beta.",
   "main": "server.js",
   "scripts": {
-    "analyse-logs": "ts-node ./tools/analyse-logs/index.ts",
+    "analyse-logs": "npm --prefix tools/analyse-logs run analyse --",
     "clean": "rimraf dist",
     "css": " sass src/shared/public/scss/app.scss:src/shared/public/css/app.css node_modules/highlight.js/scss/github-dark-dimmed.scss:src/shared/public/css/highlight.css",
     "copy-assets": "ts-node tools/copy-assets",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is the StatsWales private alpha repository.  This repository is here to allow us to experiment with a number of technologies to prove out a number of hypotheses and establish the technologies we may wish to take in to Beta.",
   "main": "server.js",
   "scripts": {
+    "analyse-logs": "ts-node ./tools/analyse-logs/index.ts",
     "clean": "rimraf dist",
     "css": " sass src/shared/public/scss/app.scss:src/shared/public/css/app.css node_modules/highlight.js/scss/github-dark-dimmed.scss:src/shared/public/css/highlight.css",
     "copy-assets": "ts-node tools/copy-assets",

--- a/tools/analyse-logs/duckdb-helper.ts
+++ b/tools/analyse-logs/duckdb-helper.ts
@@ -1,0 +1,32 @@
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+
+let instance: DuckDBInstance | undefined;
+let connection: DuckDBConnection | undefined;
+
+export async function initDuckDB(): Promise<DuckDBConnection> {
+  instance = await DuckDBInstance.create(':memory:', {
+    threads: '4',
+    memory_limit: '512MB'
+  });
+  connection = await instance.connect();
+  return connection;
+}
+
+export async function query(sql: string): Promise<Record<string, unknown>[]> {
+  if (!connection) throw new Error('DuckDB not initialised — call initDuckDB() first');
+  const result = await connection.runAndReadAll(sql);
+  return result.getRowObjectsJson() as Record<string, unknown>[];
+}
+
+export async function run(sql: string): Promise<void> {
+  if (!connection) throw new Error('DuckDB not initialised — call initDuckDB() first');
+  await connection.run(sql);
+}
+
+export async function closeDuckDB(): Promise<void> {
+  if (connection) {
+    connection.disconnectSync();
+    connection = undefined;
+  }
+  instance = undefined;
+}

--- a/tools/analyse-logs/index.ts
+++ b/tools/analyse-logs/index.ts
@@ -1,0 +1,86 @@
+import path from 'node:path';
+
+import { initDuckDB, run, closeDuckDB } from './duckdb-helper';
+import { heading } from './markdown';
+import { overview } from './sections/overview';
+import { errors } from './sections/errors';
+import { performance } from './sections/performance';
+import { statusCodes } from './sections/status-codes';
+import { abuseDetection } from './sections/abuse-detection';
+import { coverageGaps } from './sections/coverage-gaps';
+import { timeOfDay } from './sections/time-of-day';
+
+async function createBaseView(csvPath: string): Promise<void> {
+  const absolutePath = path.resolve(csvPath).replace(/'/g, "''");
+  await run(`
+    CREATE OR REPLACE TEMP TABLE logs AS
+    SELECT
+      json_extract_string("Log_s", '$.level')::INTEGER AS level,
+      json_extract_string("Log_s", '$.time')::BIGINT AS log_time,
+      json_extract_string("Log_s", '$.msg') AS msg,
+      json_extract_string("Log_s", '$.req.method') AS method,
+      replace(json_extract_string("Log_s", '$.req.url'), '&amp;', '&') AS url,
+      json_extract_string("Log_s", '$.res.statusCode')::INTEGER AS status_code,
+      json_extract_string("Log_s", '$.responseTime')::DOUBLE AS response_time,
+      json_extract_string("Log_s", '$.hostname') AS hostname,
+      json_extract_string("Log_s", '$.err.type') AS err_type,
+      json_extract_string("Log_s", '$.err.message') AS err_message,
+      json_extract_string("Log_s", '$.err.stack') AS err_stack,
+      json_extract_string("Log_s", '$.err.code') AS err_code,
+      json_extract("Log_s", '$.req.query') AS query_params,
+      regexp_extract(
+        replace(json_extract_string("Log_s", '$.req.url'), '&amp;', '&'),
+        '^/(en-GB|cy-GB)/', 1
+      ) AS lang,
+      regexp_replace(
+        regexp_replace(
+          regexp_replace(
+            split_part(
+              replace(json_extract_string("Log_s", '$.req.url'), '&amp;', '&'),
+              '?', 1
+            ),
+            '^/(en-GB|cy-GB)', ''
+          ),
+          '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', ':id', 'g'
+        ),
+        '/(filtered|download|data|pivot)/[A-Za-z0-9]{8,}', '/\\1/:filterId', 'g'
+      ) AS route
+    FROM read_csv('${absolutePath}', header=true, ignore_errors=true)
+    WHERE "Log_s" IS NOT NULL AND left(trim("Log_s"), 1) = '{'
+  `);
+}
+
+async function main(): Promise<void> {
+  const csvPath = process.argv[2];
+  if (!csvPath) {
+    process.stderr.write('Usage: npx ts-node index.ts <path-to-csv>\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  await initDuckDB();
+  try {
+    await createBaseView(csvPath);
+
+    const sections = [
+      heading(1, 'Frontend Consumer Log Analysis Report'),
+      `_Generated: ${new Date().toISOString()}_\n`,
+      await overview(),
+      await errors(),
+      await performance(),
+      await statusCodes(),
+      await abuseDetection(),
+      await coverageGaps(),
+      await timeOfDay()
+    ];
+
+    process.stdout.write(sections.join('\n'));
+  } finally {
+    await closeDuckDB();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err}\n`);
+  process.exitCode = 1;
+});

--- a/tools/analyse-logs/markdown.ts
+++ b/tools/analyse-logs/markdown.ts
@@ -1,0 +1,22 @@
+export function heading(level: number, text: string): string {
+  return `${'#'.repeat(level)} ${text}\n`;
+}
+
+export function table(headers: string[], rows: (string | number)[][]): string {
+  if (rows.length === 0) return '_No data._\n';
+  const sep = headers.map(() => '---');
+  const lines = [
+    `| ${headers.join(' | ')} |`,
+    `| ${sep.join(' | ')} |`,
+    ...rows.map((row) => `| ${row.map((c) => String(c ?? '')).join(' | ')} |`)
+  ];
+  return lines.join('\n') + '\n';
+}
+
+export function codeBlock(content: string, lang = ''): string {
+  return `\`\`\`${lang}\n${content}\n\`\`\`\n`;
+}
+
+export function bold(text: string): string {
+  return `**${text}**`;
+}

--- a/tools/analyse-logs/markdown.ts
+++ b/tools/analyse-logs/markdown.ts
@@ -5,6 +5,7 @@ export function heading(level: number, text: string): string {
 function escapeCell(value: string | number | null | undefined): string {
   return String(value ?? '')
     .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|');
 }
 

--- a/tools/analyse-logs/markdown.ts
+++ b/tools/analyse-logs/markdown.ts
@@ -2,13 +2,19 @@ export function heading(level: number, text: string): string {
   return `${'#'.repeat(level)} ${text}\n`;
 }
 
+function escapeCell(value: string | number | null | undefined): string {
+  return String(value ?? '')
+    .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\|/g, '\\|');
+}
+
 export function table(headers: string[], rows: (string | number)[][]): string {
   if (rows.length === 0) return '_No data._\n';
   const sep = headers.map(() => '---');
   const lines = [
-    `| ${headers.join(' | ')} |`,
+    `| ${headers.map((h) => escapeCell(h)).join(' | ')} |`,
     `| ${sep.join(' | ')} |`,
-    ...rows.map((row) => `| ${row.map((c) => String(c ?? '')).join(' | ')} |`)
+    ...rows.map((row) => `| ${row.map((c) => escapeCell(c)).join(' | ')} |`)
   ];
   return lines.join('\n') + '\n';
 }

--- a/tools/analyse-logs/package-lock.json
+++ b/tools/analyse-logs/package-lock.json
@@ -1,0 +1,338 @@
+{
+  "name": "statswales-frontend-analyse-logs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "statswales-frontend-analyse-logs",
+      "dependencies": {
+        "@duckdb/node-api": "^1.5.1-r.1"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "~5.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.1-r.1.tgz",
+      "integrity": "sha512-8U8p44ZL4rJtUrgVaSLm2hOMk3XTwEgs5eJoxYiR6iQXKVEr8vi6z3Vrxhb61g9sgsEZIAmckD7e3zZ1lmPHYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.1-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.1-r.1.tgz",
+      "integrity": "sha512-3vmIlY/ACTLutlMup4F+D2Gzo+kiUoMaIL4TvM4x34cMqnKfsZ+4lMjqfSKYmdcgNGXYXwPwIYaJlvMRhU3Tbg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.1-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.5.1-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.5.1-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.5.1-r.1",
+        "@duckdb/node-bindings-win32-arm64": "1.5.1-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.5.1-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.1-r.1.tgz",
+      "integrity": "sha512-vm0Q/P8/OB/ZDITNTUe80emlg0b7/EcqTPBRu4GmULbt/fFDtkEAjDHDblKZL1yazf7X6JFEabHBGuWL5jmjEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.1-r.1.tgz",
+      "integrity": "sha512-GOKWYbOP1v5jppGjlCaQzvyzVnY8/dGd7UJcnT213uiSMq/mtQk2yvzZCPhq7UdxmqR0TSd+TKttpozd8ANyOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.1-r.1.tgz",
+      "integrity": "sha512-b0tHCtC+GZnD6gJA+ldUwy8FhnugR1Uq0/LjLiusOQOoK5pRXyfiQjgIe/SiKSeE5iEr+FWUXEprSD81HOaaQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.1-r.1.tgz",
+      "integrity": "sha512-AczM4qyMuMXHIa7w1YacIu6FFPpwzUsQSkPUFKsAJzyuRcxAlGEwt+2GnVZSACGQFpKbL9nAkuu3Icq6ttxwag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.1-r.1.tgz",
+      "integrity": "sha512-SrgAiFttkfFXCCAMrmMBWtnBMtEjVaC38XtG6zEdbvmp2RTEPo/dFcvRP75vS/Hm5Iq8Tgiuoq4tIdovwEw5yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.1-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.1-r.1.tgz",
+      "integrity": "sha512-JkL9xvXx9i8ceU1fGJsb9gqgRn30RFi0HyfpuESK2AZInKx5mJn8fvYcj4AQg/Ip9SZ1S4a2Jh5DOFY81koubw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/analyse-logs/package-lock.json
+++ b/tools/analyse-logs/package-lock.json
@@ -9,6 +9,7 @@
         "@duckdb/node-api": "^1.5.1-r.1"
       },
       "devDependencies": {
+        "@types/node": "^25.5.2",
         "ts-node": "^10.9.2",
         "typescript": "~5.9.0"
       }
@@ -184,9 +185,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/tools/analyse-logs/package.json
+++ b/tools/analyse-logs/package.json
@@ -8,6 +8,7 @@
     "@duckdb/node-api": "^1.5.1-r.1"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.0"
   }

--- a/tools/analyse-logs/package.json
+++ b/tools/analyse-logs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "statswales-frontend-analyse-logs",
+  "private": true,
+  "scripts": {
+    "analyse": "ts-node index.ts"
+  },
+  "dependencies": {
+    "@duckdb/node-api": "^1.5.1-r.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "~5.9.0"
+  }
+}

--- a/tools/analyse-logs/sections/abuse-detection.ts
+++ b/tools/analyse-logs/sections/abuse-detection.ts
@@ -1,0 +1,117 @@
+import { query } from '../duckdb-helper';
+import { heading, table, bold } from '../markdown';
+
+export async function abuseDetection(): Promise<string> {
+  const lines: string[] = [heading(2, 'Abuse Detection')];
+
+  const spikes = await query(`
+    WITH per_minute AS (
+      SELECT
+        time_bucket(INTERVAL '1 minute', to_timestamp(log_time / 1000)) AS bucket,
+        count(*) AS cnt
+      FROM logs
+      WHERE url NOT LIKE '%/healthcheck%' OR url IS NULL
+      GROUP BY bucket
+    ),
+    stats AS (
+      SELECT avg(cnt) AS mean, stddev(cnt) AS sd FROM per_minute
+    )
+    SELECT
+      bucket::VARCHAR AS minute,
+      cnt,
+      round((cnt - stats.mean) / NULLIF(stats.sd, 0), 2) AS z_score
+    FROM per_minute, stats
+    WHERE (cnt - stats.mean) / NULLIF(stats.sd, 0) > 3
+    ORDER BY z_score DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, 'Traffic Spikes (z-score > 3, 1-min buckets)'));
+  if (spikes.length === 0) {
+    lines.push('_No traffic spikes detected._\n');
+  } else {
+    lines.push(
+      table(
+        ['Minute', 'Requests', 'Z-Score'],
+        spikes.map((r) => [r.minute as string, Number(r.cnt).toLocaleString(), r.z_score as number])
+      )
+    );
+  }
+
+  const enumeration = await query(`
+    WITH dataset_access AS (
+      SELECT
+        time_bucket(INTERVAL '5 minutes', to_timestamp(log_time / 1000)) AS bucket,
+        regexp_extract(url, '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', 0) AS dataset_id
+      FROM logs
+      WHERE url IS NOT NULL AND url NOT LIKE '%/healthcheck%'
+    )
+    SELECT
+      bucket::VARCHAR AS window,
+      count(DISTINCT dataset_id) AS distinct_datasets,
+      count(*) AS total_requests
+    FROM dataset_access
+    WHERE dataset_id IS NOT NULL AND dataset_id != ''
+    GROUP BY bucket
+    ORDER BY distinct_datasets DESC
+    LIMIT 10
+  `);
+  lines.push(heading(3, 'Dataset Enumeration (distinct IDs per 5-min window)'));
+  lines.push(
+    table(
+      ['Window', 'Distinct Datasets', 'Total Requests'],
+      enumeration.map((r) => [
+        r.window as string,
+        Number(r.distinct_datasets).toLocaleString(),
+        Number(r.total_requests).toLocaleString()
+      ])
+    )
+  );
+
+  const repeated5xx = await query(`
+    SELECT
+      method,
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE status_code BETWEEN 500 AND 599 AND route IS NOT NULL
+    GROUP BY method, route
+    HAVING count(*) >= 3
+    ORDER BY cnt DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, 'Repeated 5xx-Triggering Routes'));
+  if (repeated5xx.length === 0) {
+    lines.push('_No repeated 5xx patterns found._\n');
+  } else {
+    lines.push(
+      table(
+        ['Method', 'Route', 'Count'],
+        repeated5xx.map((r) => [r.method as string, r.route as string, Number(r.cnt).toLocaleString()])
+      )
+    );
+  }
+
+  const longQueries = await query(`
+    SELECT
+      url,
+      length(split_part(url, '?', 2)) AS query_length
+    FROM logs
+    WHERE url IS NOT NULL
+      AND length(split_part(url, '?', 2)) > 200
+    LIMIT 20
+  `);
+  lines.push(heading(3, 'Unusually Long Query Strings (> 200 chars)'));
+  if (longQueries.length === 0) {
+    lines.push('_No unusually long query strings detected._\n');
+  } else {
+    lines.push(`${bold(`${longQueries.length} request(s) with query strings > 200 characters:`)}\n`);
+    lines.push(
+      table(
+        ['URL (truncated)', 'Query Length'],
+        longQueries.map((r) => [(r.url as string).substring(0, 120), r.query_length as number])
+      )
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/coverage-gaps.ts
+++ b/tools/analyse-logs/sections/coverage-gaps.ts
@@ -1,0 +1,85 @@
+import { query } from '../duckdb-helper';
+import { heading, table, bold } from '../markdown';
+
+export async function coverageGaps(): Promise<string> {
+  const lines: string[] = [heading(2, 'Coverage Gaps')];
+
+  const missingInfo = await query(`
+    SELECT
+      count(*) FILTER (WHERE err_stack IS NULL AND level >= 50) AS errors_no_stack,
+      count(*) FILTER (WHERE err_type IS NULL AND level >= 50) AS errors_no_type,
+      count(*) FILTER (WHERE level >= 50) AS total_errors
+    FROM logs
+  `);
+  const row = missingInfo[0];
+  lines.push(`${bold('Total errors:')} ${Number(row.total_errors).toLocaleString()}`);
+  lines.push(`${bold('Errors missing stack trace:')} ${Number(row.errors_no_stack).toLocaleString()}`);
+  lines.push(`${bold('Errors missing error type:')} ${Number(row.errors_no_type).toLocaleString()}\n`);
+
+  const nonHttp = await query(`
+    SELECT
+      COALESCE(msg, 'no message') AS message,
+      count(*) AS cnt
+    FROM logs
+    WHERE method IS NULL AND url IS NULL
+    GROUP BY message
+    ORDER BY cnt DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, 'Non-HTTP Log Entries (no req field)'));
+  lines.push(
+    table(
+      ['Message', 'Count'],
+      nonHttp.map((r) => [(r.message as string).substring(0, 120), Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const warns = await query(`
+    SELECT
+      COALESCE(msg, 'no message') AS message,
+      COALESCE(route, 'n/a') AS route,
+      count(*) AS cnt
+    FROM logs
+    WHERE level = 40
+    GROUP BY message, route
+    ORDER BY cnt DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, 'Warn-Level Messages'));
+  lines.push(
+    table(
+      ['Message', 'Route', 'Count'],
+      warns.map((r) => [(r.message as string).substring(0, 80), r.route as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const noErrors = await query(`
+    WITH all_routes AS (
+      SELECT DISTINCT route
+      FROM logs
+      WHERE route IS NOT NULL AND url NOT LIKE '%/healthcheck%'
+    ),
+    error_routes AS (
+      SELECT DISTINCT route
+      FROM logs
+      WHERE level >= 50 AND route IS NOT NULL
+    )
+    SELECT ar.route, count(*) AS request_count
+    FROM all_routes ar
+    LEFT JOIN error_routes er ON ar.route = er.route
+    INNER JOIN logs l ON l.route = ar.route
+    WHERE er.route IS NULL
+    GROUP BY ar.route
+    ORDER BY request_count DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, 'Routes That Never Produce Errors'));
+  lines.push(
+    table(
+      ['Route', 'Request Count'],
+      noErrors.map((r) => [r.route as string, Number(r.request_count).toLocaleString()])
+    )
+  );
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/errors.ts
+++ b/tools/analyse-logs/sections/errors.ts
@@ -1,0 +1,126 @@
+import { query } from '../duckdb-helper';
+import { heading, table, codeBlock, bold } from '../markdown';
+
+export async function errors(): Promise<string> {
+  const lines: string[] = [heading(2, 'Errors')];
+
+  const grouped = await query(`
+    SELECT
+      COALESCE(err_type, 'unknown') AS error_type,
+      COALESCE(split_part(err_message, chr(10), 1), 'no message') AS first_line,
+      count(*) AS cnt,
+      max(to_timestamp(log_time / 1000))::VARCHAR AS most_recent
+    FROM logs
+    WHERE level >= 50
+    GROUP BY error_type, first_line
+    ORDER BY cnt DESC
+    LIMIT 30
+  `);
+  lines.push(heading(3, 'Errors by Type + Message'));
+  lines.push(
+    table(
+      ['Type', 'Message (first line)', 'Count', 'Most Recent'],
+      grouped.map((r) => [
+        r.error_type as string,
+        (r.first_line as string).substring(0, 120),
+        Number(r.cnt).toLocaleString(),
+        r.most_recent as string
+      ])
+    )
+  );
+
+  const stacks = await query(`
+    SELECT
+      COALESCE(err_type, 'unknown') AS error_type,
+      COALESCE(split_part(err_message, chr(10), 1), 'no message') AS first_line,
+      err_stack
+    FROM logs
+    WHERE level >= 50 AND err_stack IS NOT NULL
+    GROUP BY error_type, first_line, err_stack
+    ORDER BY count(*) DESC
+    LIMIT 5
+  `);
+  if (stacks.length > 0) {
+    lines.push(heading(3, 'Example Stack Traces (top 5 by frequency)'));
+    for (const s of stacks) {
+      lines.push(`**${s.error_type}: ${(s.first_line as string).substring(0, 100)}**\n`);
+      const stackLines = (s.err_stack as string).split('\n').slice(0, 15);
+      lines.push(codeBlock(stackLines.join('\n')));
+    }
+  }
+
+  const routes = await query(`
+    SELECT
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE level >= 50 AND route IS NOT NULL
+    GROUP BY route
+    ORDER BY cnt DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, 'Top Error-Producing Routes'));
+  lines.push(
+    table(
+      ['Route', 'Error Count'],
+      routes.map((r) => [r.route as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const redis = await query(`
+    SELECT
+      COALESCE(err_type, 'unknown') AS error_type,
+      COALESCE(err_code, 'n/a') AS error_code,
+      count(*) AS cnt,
+      min(to_timestamp(log_time / 1000))::VARCHAR AS first_seen,
+      max(to_timestamp(log_time / 1000))::VARCHAR AS last_seen
+    FROM logs
+    WHERE level >= 50
+      AND (err_type LIKE '%Socket%' OR err_type LIKE '%Redis%'
+           OR err_message LIKE '%ECONNRESET%' OR err_message LIKE '%redis%'
+           OR err_code IN ('ECONNRESET', 'ECONNREFUSED'))
+    GROUP BY error_type, error_code
+    ORDER BY cnt DESC
+  `);
+  lines.push(heading(3, 'Redis / Session Errors'));
+  if (redis.length === 0) {
+    lines.push('_No Redis/session errors detected._\n');
+  } else {
+    lines.push(
+      table(
+        ['Type', 'Code', 'Count', 'First Seen', 'Last Seen'],
+        redis.map((r) => [
+          r.error_type as string,
+          r.error_code as string,
+          Number(r.cnt).toLocaleString(),
+          r.first_seen as string,
+          r.last_seen as string
+        ])
+      )
+    );
+  }
+
+  const timeline = await query(`
+    SELECT
+      strftime(to_timestamp(log_time / 1000), '%Y-%m-%d %H:00') AS hour,
+      count(*) AS error_count
+    FROM logs
+    WHERE level >= 50
+    GROUP BY hour
+    ORDER BY hour
+  `);
+  lines.push(heading(3, 'Error Timeline (errors per hour)'));
+  lines.push(
+    table(
+      ['Hour', 'Errors'],
+      timeline.map((r) => [r.hour as string, Number(r.error_count).toLocaleString()])
+    )
+  );
+
+  const noStack = await query(`
+    SELECT count(*) AS cnt FROM logs WHERE level >= 50 AND err_stack IS NULL
+  `);
+  lines.push(`\n${bold('Errors without stack traces:')} ${Number(noStack[0].cnt).toLocaleString()}\n`);
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/errors.ts
+++ b/tools/analyse-logs/sections/errors.ts
@@ -33,17 +33,20 @@ export async function errors(): Promise<string> {
     SELECT
       COALESCE(err_type, 'unknown') AS error_type,
       COALESCE(split_part(err_message, chr(10), 1), 'no message') AS first_line,
-      err_stack
+      err_stack,
+      count(*) AS cnt
     FROM logs
     WHERE level >= 50 AND err_stack IS NOT NULL
     GROUP BY error_type, first_line, err_stack
-    ORDER BY count(*) DESC
+    ORDER BY cnt DESC
     LIMIT 5
   `);
   if (stacks.length > 0) {
     lines.push(heading(3, 'Example Stack Traces (top 5 by frequency)'));
     for (const s of stacks) {
-      lines.push(`**${s.error_type}: ${(s.first_line as string).substring(0, 100)}**\n`);
+      lines.push(
+        `**${s.error_type}: ${(s.first_line as string).substring(0, 100)} (${Number(s.cnt).toLocaleString()})**\n`
+      );
       const stackLines = (s.err_stack as string).split('\n').slice(0, 15);
       lines.push(codeBlock(stackLines.join('\n')));
     }

--- a/tools/analyse-logs/sections/overview.ts
+++ b/tools/analyse-logs/sections/overview.ts
@@ -11,9 +11,13 @@ export async function overview(): Promise<string> {
       count(*) AS total_rows
     FROM logs
   `);
-  const earliest = new Date(Number(timeRange.earliest)).toISOString();
-  const latest = new Date(Number(timeRange.latest)).toISOString();
-  lines.push(`${bold('Time range:')} ${earliest} → ${latest}`);
+  const earliestMs = Number(timeRange.earliest);
+  const latestMs = Number(timeRange.latest);
+  const timeRangeLabel =
+    Number.isFinite(earliestMs) && Number.isFinite(latestMs)
+      ? `${new Date(earliestMs).toISOString()} → ${new Date(latestMs).toISOString()}`
+      : 'n/a';
+  lines.push(`${bold('Time range:')} ${timeRangeLabel}`);
   lines.push(`${bold('Total rows:')} ${Number(timeRange.total_rows).toLocaleString()}\n`);
 
   const healthcheck = await query(`

--- a/tools/analyse-logs/sections/overview.ts
+++ b/tools/analyse-logs/sections/overview.ts
@@ -1,0 +1,104 @@
+import { query } from '../duckdb-helper';
+import { heading, table, bold } from '../markdown';
+
+export async function overview(): Promise<string> {
+  const lines: string[] = [heading(2, 'Overview')];
+
+  const [timeRange] = await query(`
+    SELECT
+      min(log_time) AS earliest,
+      max(log_time) AS latest,
+      count(*) AS total_rows
+    FROM logs
+  `);
+  const earliest = new Date(Number(timeRange.earliest)).toISOString();
+  const latest = new Date(Number(timeRange.latest)).toISOString();
+  lines.push(`${bold('Time range:')} ${earliest} → ${latest}`);
+  lines.push(`${bold('Total rows:')} ${Number(timeRange.total_rows).toLocaleString()}\n`);
+
+  const healthcheck = await query(`
+    SELECT
+      count(*) FILTER (WHERE url LIKE '%/healthcheck%') AS healthcheck,
+      count(*) FILTER (WHERE url NOT LIKE '%/healthcheck%' OR url IS NULL) AS non_healthcheck
+    FROM logs
+  `);
+  lines.push(`${bold('Healthcheck requests:')} ${Number(healthcheck[0].healthcheck).toLocaleString()}`);
+  lines.push(`${bold('Non-healthcheck requests:')} ${Number(healthcheck[0].non_healthcheck).toLocaleString()}\n`);
+
+  const levels = await query(`
+    SELECT
+      CASE level
+        WHEN 10 THEN 'trace'
+        WHEN 20 THEN 'debug'
+        WHEN 30 THEN 'info'
+        WHEN 40 THEN 'warn'
+        WHEN 50 THEN 'error'
+        WHEN 60 THEN 'fatal'
+        ELSE 'unknown (' || COALESCE(CAST(level AS VARCHAR), 'null') || ')'
+      END AS level_name,
+      count(*) AS cnt
+    FROM logs
+    GROUP BY level
+    ORDER BY level
+  `);
+  lines.push(heading(3, 'Log Level Distribution'));
+  lines.push(
+    table(
+      ['Level', 'Count'],
+      levels.map((r) => [r.level_name as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const langDist = await query(`
+    SELECT
+      COALESCE(NULLIF(lang, ''), 'none') AS language,
+      count(*) AS cnt
+    FROM logs
+    WHERE url IS NOT NULL
+    GROUP BY language
+    ORDER BY cnt DESC
+  `);
+  lines.push(heading(3, 'Language Distribution'));
+  lines.push(
+    table(
+      ['Language', 'Count'],
+      langDist.map((r) => [r.language as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const busiest = await query(`
+    SELECT
+      strftime(to_timestamp(log_time / 1000), '%Y-%m-%d %H:00') AS hour,
+      count(*) AS cnt
+    FROM logs
+    WHERE url NOT LIKE '%/healthcheck%' OR url IS NULL
+    GROUP BY hour
+    ORDER BY cnt DESC
+    LIMIT 10
+  `);
+  lines.push(heading(3, 'Top 10 Busiest Hours (excl. healthchecks)'));
+  lines.push(
+    table(
+      ['Hour', 'Requests'],
+      busiest.map((r) => [r.hour as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const hosts = await query(`
+    SELECT hostname, count(*) AS cnt
+    FROM logs
+    WHERE hostname IS NOT NULL
+    GROUP BY hostname
+    ORDER BY cnt DESC
+  `);
+  lines.push(heading(3, 'Container Replicas'));
+  lines.push(`${bold('Unique hostnames:')} ${hosts.length}\n`);
+  lines.push(
+    table(
+      ['Hostname', 'Log Count'],
+      hosts.map((r) => [r.hostname as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/performance.ts
+++ b/tools/analyse-logs/sections/performance.ts
@@ -1,0 +1,87 @@
+import { query } from '../duckdb-helper';
+import { heading, table } from '../markdown';
+
+export async function performance(): Promise<string> {
+  const lines: string[] = [heading(2, 'Performance')];
+
+  const byRoute = await query(`
+    SELECT
+      method,
+      route,
+      count(*) AS cnt,
+      round(quantile_cont(response_time, 0.5)::DOUBLE, 1) AS p50,
+      round(quantile_cont(response_time, 0.95)::DOUBLE, 1) AS p95,
+      round(quantile_cont(response_time, 0.99)::DOUBLE, 1) AS p99
+    FROM logs
+    WHERE response_time IS NOT NULL
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY method, route
+    HAVING count(*) >= 10
+    ORDER BY p95 DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, 'Slowest Routes by p95 (min 10 requests)'));
+  lines.push(
+    table(
+      ['Method', 'Route', 'Count', 'p50 (ms)', 'p95 (ms)', 'p99 (ms)'],
+      byRoute.map((r) => [
+        r.method as string,
+        r.route as string,
+        Number(r.cnt).toLocaleString(),
+        r.p50 as number,
+        r.p95 as number,
+        r.p99 as number
+      ])
+    )
+  );
+
+  const byDataset = await query(`
+    WITH dataset_requests AS (
+      SELECT
+        regexp_extract(url, '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', 0) AS dataset_id,
+        response_time
+      FROM logs
+      WHERE response_time IS NOT NULL AND url IS NOT NULL
+    )
+    SELECT
+      dataset_id,
+      count(*) AS cnt,
+      round(quantile_cont(response_time, 0.5)::DOUBLE, 1) AS p50,
+      round(quantile_cont(response_time, 0.95)::DOUBLE, 1) AS p95
+    FROM dataset_requests
+    WHERE dataset_id IS NOT NULL AND dataset_id != ''
+    GROUP BY dataset_id
+    HAVING count(*) >= 5
+    ORDER BY p95 DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, 'Slowest Datasets by p95 (min 5 requests)'));
+  lines.push(
+    table(
+      ['Dataset ID', 'Count', 'p50 (ms)', 'p95 (ms)'],
+      byDataset.map((r) => [r.dataset_id as string, Number(r.cnt).toLocaleString(), r.p50 as number, r.p95 as number])
+    )
+  );
+
+  const thresholds = await query(`
+    SELECT
+      count(*) FILTER (WHERE response_time > 5000) AS over_5s,
+      count(*) FILTER (WHERE response_time > 10000) AS over_10s,
+      count(*) FILTER (WHERE response_time > 30000) AS over_30s
+    FROM logs
+    WHERE response_time IS NOT NULL
+  `);
+  lines.push(heading(3, 'Slow Request Thresholds'));
+  lines.push(
+    table(
+      ['Threshold', 'Count'],
+      [
+        ['> 5 seconds', Number(thresholds[0].over_5s).toLocaleString()],
+        ['> 10 seconds', Number(thresholds[0].over_10s).toLocaleString()],
+        ['> 30 seconds', Number(thresholds[0].over_30s).toLocaleString()]
+      ]
+    )
+  );
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/status-codes.ts
+++ b/tools/analyse-logs/sections/status-codes.ts
@@ -1,0 +1,97 @@
+import { query } from '../duckdb-helper';
+import { heading, table } from '../markdown';
+
+export async function statusCodes(): Promise<string> {
+  const lines: string[] = [heading(2, 'Status Codes')];
+
+  const summary = await query(`
+    SELECT
+      CASE
+        WHEN status_code BETWEEN 200 AND 299 THEN '2xx'
+        WHEN status_code BETWEEN 300 AND 399 THEN '3xx'
+        WHEN status_code BETWEEN 400 AND 499 THEN '4xx'
+        WHEN status_code BETWEEN 500 AND 599 THEN '5xx'
+        ELSE 'other'
+      END AS category,
+      count(*) AS cnt
+    FROM logs
+    WHERE status_code IS NOT NULL
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY category
+    ORDER BY category
+  `);
+  lines.push(heading(3, 'Status Code Summary (excl. healthchecks)'));
+  lines.push(
+    table(
+      ['Category', 'Count'],
+      summary.map((r) => [r.category as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const redirects = await query(`
+    SELECT
+      status_code,
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE status_code BETWEEN 300 AND 399
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY status_code, route
+    ORDER BY cnt DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, '3xx Redirect Breakdown'));
+  lines.push(
+    table(
+      ['Status', 'Route', 'Count'],
+      redirects.map((r) => [r.status_code as number, r.route as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const fourxx = await query(`
+    SELECT
+      status_code,
+      CASE
+        WHEN status_code IN (401, 403) THEN 'auth'
+        WHEN status_code = 404 THEN 'not found'
+        ELSE 'other 4xx'
+      END AS kind,
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE status_code BETWEEN 400 AND 499
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY status_code, kind, route
+    ORDER BY cnt DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, '4xx Breakdown'));
+  lines.push(
+    table(
+      ['Status', 'Kind', 'Route', 'Count'],
+      fourxx.map((r) => [r.status_code as number, r.kind as string, r.route as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const fivexx = await query(`
+    SELECT
+      status_code,
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE status_code BETWEEN 500 AND 599
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY status_code, route
+    ORDER BY cnt DESC
+    LIMIT 20
+  `);
+  lines.push(heading(3, '5xx Breakdown'));
+  lines.push(
+    table(
+      ['Status', 'Route', 'Count'],
+      fivexx.map((r) => [r.status_code as number, r.route as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/sections/time-of-day.ts
+++ b/tools/analyse-logs/sections/time-of-day.ts
@@ -1,0 +1,78 @@
+import { query } from '../duckdb-helper';
+import { heading, table } from '../markdown';
+
+export async function timeOfDay(): Promise<string> {
+  const lines: string[] = [heading(2, 'Time-of-Day Patterns')];
+
+  const hourly = await query(`
+    SELECT
+      extract(hour FROM to_timestamp(log_time / 1000)) AS hour_utc,
+      count(*) AS total,
+      count(*) FILTER (WHERE level >= 50) AS errors
+    FROM logs
+    WHERE url NOT LIKE '%/healthcheck%' OR url IS NULL
+    GROUP BY hour_utc
+    ORDER BY hour_utc
+  `);
+  lines.push(heading(3, 'Requests by Hour of Day (UTC, excl. healthchecks)'));
+  lines.push(
+    table(
+      ['Hour (UTC)', 'Requests', 'Errors', 'Error %'],
+      hourly.map((r) => {
+        const total = Number(r.total);
+        const errs = Number(r.errors);
+        const pct = total > 0 ? ((errs / total) * 100).toFixed(2) : '0.00';
+        return [`${String(r.hour_utc).padStart(2, '0')}:00`, total.toLocaleString(), errs.toLocaleString(), `${pct}%`];
+      })
+    )
+  );
+
+  const dayOfWeek = await query(`
+    SELECT
+      dayname(to_timestamp(log_time / 1000)) AS day_name,
+      extract(dow FROM to_timestamp(log_time / 1000)) AS dow,
+      CASE
+        WHEN extract(dow FROM to_timestamp(log_time / 1000)) IN (0, 6) THEN 'weekend'
+        ELSE 'weekday'
+      END AS period,
+      count(*) AS cnt
+    FROM logs
+    WHERE url NOT LIKE '%/healthcheck%' OR url IS NULL
+    GROUP BY day_name, dow, period
+    ORDER BY dow
+  `);
+  lines.push(heading(3, 'Requests by Day of Week'));
+  lines.push(
+    table(
+      ['Day', 'Period', 'Requests'],
+      dayOfWeek.map((r) => [r.day_name as string, r.period as string, Number(r.cnt).toLocaleString()])
+    )
+  );
+
+  const offHours = await query(`
+    SELECT
+      method,
+      route,
+      count(*) AS cnt
+    FROM logs
+    WHERE extract(hour FROM to_timestamp(log_time / 1000)) BETWEEN 0 AND 5
+      AND route IS NOT NULL
+      AND url NOT LIKE '%/healthcheck%'
+    GROUP BY method, route
+    ORDER BY cnt DESC
+    LIMIT 15
+  `);
+  lines.push(heading(3, 'Off-Hours Traffic (00:00-06:00 UTC)'));
+  if (offHours.length === 0) {
+    lines.push('_No off-hours traffic detected._\n');
+  } else {
+    lines.push(
+      table(
+        ['Method', 'Route', 'Count'],
+        offHours.map((r) => [r.method as string, r.route as string, Number(r.cnt).toLocaleString()])
+      )
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/tools/analyse-logs/tsconfig.json
+++ b/tools/analyse-logs/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
+    "types": ["node"],
     "strict": true,
     "resolveJsonModule": true,
     "outDir": "dist"

--- a/tools/analyse-logs/tsconfig.json
+++ b/tools/analyse-logs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds a standalone log analysis tool (`tools/analyse-logs/`) that uses DuckDB to parse and analyse frontend consumer logs exported as CSV from Azure
- Generates a markdown report covering: traffic overview, errors, performance (p50/p95/p99), status codes, abuse detection, coverage gaps, and time-of-day patterns
- Self-contained with its own `package.json` and `tsconfig.json` — does not affect the main app build

## Usage

```bash
cd tools/analyse-logs
npm install
npm run analyse -- ../../path-to-log-export.csv
```

## Test plan

- [x] Ran against a 75MB pre-prod log export (~235k rows) and verified report output
- [x] TypeScript compiles cleanly with no IDE diagnostics
