### PR TITLE
SW-1222: Send rate limit bypass token to backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5242,14 +5242,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -12040,10 +12040,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/src/consumer/services/consumer-api.ts
+++ b/src/consumer/services/consumer-api.ts
@@ -55,6 +55,7 @@ export class ConsumerApi {
     /* eslint-disable @typescript-eslint/naming-convention */
     const head = {
       'Accept-Language': lang,
+      ...(config.backend.rateLimitBypassToken ? { 'x-rate-limit-bypass': config.backend.rateLimitBypassToken } : {}),
       ...(json ? { 'Content-Type': 'application/json; charset=UTF-8' } : {}),
       ...headers
     };

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -97,6 +97,8 @@ export class PublisherApi {
       'Accept-Language': lang,
       ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
       // eslint-disable-next-line @typescript-eslint/naming-convention
+      ...(config.backend.rateLimitBypassToken ? { 'x-rate-limit-bypass': config.backend.rateLimitBypassToken } : {}),
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ...(json ? { 'Content-Type': 'application/json; charset=UTF-8' } : {}),
       ...headers
     };

--- a/src/shared/config/app-config.interface.ts
+++ b/src/shared/config/app-config.interface.ts
@@ -32,6 +32,7 @@ export interface AppConfig {
   backend: {
     port: number;
     url: string;
+    rateLimitBypassToken?: string;
   };
   language: {
     availableTranslations: Locale[];
@@ -68,4 +69,4 @@ export interface AppConfig {
 
 // list any optional properties here so we can ignore missing values when we check the config on boot
 // it would be nice to get them directly from the interface, but interfaces are compile-time only
-export const optionalProperties = ['redisUrl', 'redisPassword', 'basic', 'welshUrl'];
+export const optionalProperties = ['redisUrl', 'redisPassword', 'basic', 'welshUrl', 'rateLimitBypassToken'];

--- a/src/shared/config/envs/default.ts
+++ b/src/shared/config/envs/default.ts
@@ -33,7 +33,8 @@ export const getDefaultConfig = (): AppConfig => {
     },
     backend: {
       port: parseInt(process.env.BACKEND_PORT || '3000', 10),
-      url: process.env.BACKEND_URL!
+      url: process.env.BACKEND_URL!,
+      rateLimitBypassToken: process.env.RATE_LIMIT_BYPASS_TOKEN
     },
     language: {
       availableTranslations: [Locale.English, Locale.Welsh],

--- a/tests/consumer-api.test.ts
+++ b/tests/consumer-api.test.ts
@@ -1,0 +1,94 @@
+import { config } from '../src/shared/config';
+import { HttpMethod } from '../src/shared/enums/http-method';
+import { ApiException } from '../src/shared/exceptions/api.exception';
+import { UnknownException } from '../src/shared/exceptions/unknown.exception';
+import { ConsumerApi } from '../src/consumer/services/consumer-api';
+
+describe('ConsumerApi', () => {
+  let consumerApi: ConsumerApi;
+  let fetchSpy: jest.SpyInstance;
+  let mockResponse: Promise<Response>;
+
+  const baseUrl = config.backend.url;
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const headers = { 'Accept-Language': 'en' };
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(() => mockResponse);
+    consumerApi = new ConsumerApi();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Rate limit bypass', () => {
+    const bypassToken = 'test-bypass-token';
+
+    afterEach(() => {
+      delete (config.backend as Record<string, unknown>).rateLimitBypassToken;
+    });
+
+    it('should include x-rate-limit-bypass header when bypass token is configured', async () => {
+      config.backend.rateLimitBypassToken = bypassToken;
+      mockResponse = Promise.resolve(new Response(null, { status: 200 }));
+
+      await consumerApi.ping();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/healthcheck?lang=en`,
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          headers: { ...headers, 'x-rate-limit-bypass': bypassToken }
+        })
+      );
+    });
+
+    it('should not include x-rate-limit-bypass header when bypass token is not configured', async () => {
+      mockResponse = Promise.resolve(new Response(null, { status: 200 }));
+
+      await consumerApi.ping();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/healthcheck?lang=en`,
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'x-rate-limit-bypass': expect.anything()
+          })
+        })
+      );
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw an UnknownException when the backend is unreachable', async () => {
+      mockResponse = Promise.reject(new Error('Service Unavailable'));
+      await expect(consumerApi.fetch({ url: 'example.com/api' })).rejects.toThrow(
+        new UnknownException('Service Unavailable')
+      );
+    });
+
+    it('should throw an ApiException when the backend returns a 500', async () => {
+      mockResponse = Promise.resolve(new Response(null, { status: 500, statusText: 'Internal Server Error' }));
+      await expect(consumerApi.fetch({ url: 'example.com/api' })).rejects.toThrow(
+        new ApiException('Internal Server Error', 500)
+      );
+    });
+  });
+
+  describe('ping', () => {
+    it('should return true when the backend is reachable', async () => {
+      mockResponse = Promise.resolve(new Response(null, { status: 200 }));
+
+      const ping = await consumerApi.ping();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/healthcheck?lang=en`,
+        expect.objectContaining({ method: HttpMethod.Get, headers })
+      );
+      expect(ping).toBe(true);
+    });
+  });
+});

--- a/tests/consumer-api.test.ts
+++ b/tests/consumer-api.test.ts
@@ -25,9 +25,14 @@ describe('ConsumerApi', () => {
 
   describe('Rate limit bypass', () => {
     const bypassToken = 'test-bypass-token';
+    const originalToken = config.backend.rateLimitBypassToken;
 
-    afterEach(() => {
+    beforeEach(() => {
       delete (config.backend as Record<string, unknown>).rateLimitBypassToken;
+    });
+
+    afterAll(() => {
+      config.backend.rateLimitBypassToken = originalToken;
     });
 
     it('should include x-rate-limit-bypass header when bypass token is configured', async () => {

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -48,6 +48,45 @@ describe('PublisherApi', () => {
     });
   });
 
+  describe('Rate limit bypass', () => {
+    const bypassToken = 'test-bypass-token';
+
+    afterEach(() => {
+      delete (config.backend as Record<string, unknown>).rateLimitBypassToken;
+    });
+
+    it('should include x-rate-limit-bypass header when bypass token is configured', async () => {
+      config.backend.rateLimitBypassToken = bypassToken;
+      mockResponse = Promise.resolve(new Response(null, { status: 200 }));
+
+      await statsWalesApi.ping();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/healthcheck?lang=en`,
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          headers: { ...headers, 'x-rate-limit-bypass': bypassToken }
+        })
+      );
+    });
+
+    it('should not include x-rate-limit-bypass header when bypass token is not configured', async () => {
+      mockResponse = Promise.resolve(new Response(null, { status: 200 }));
+
+      await statsWalesApi.ping();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/healthcheck?lang=en`,
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'x-rate-limit-bypass': expect.anything()
+          })
+        })
+      );
+    });
+  });
+
   describe('Error handling', () => {
     it('should throw an UnknownException when the backend is unreachable', async () => {
       mockResponse = Promise.reject(new Error('Service Unavailable'));

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -50,9 +50,14 @@ describe('PublisherApi', () => {
 
   describe('Rate limit bypass', () => {
     const bypassToken = 'test-bypass-token';
+    const originalToken = config.backend.rateLimitBypassToken;
 
-    afterEach(() => {
+    beforeEach(() => {
       delete (config.backend as Record<string, unknown>).rateLimitBypassToken;
+    });
+
+    afterAll(() => {
+      config.backend.rateLimitBypassToken = originalToken;
     });
 
     it('should include x-rate-limit-bypass header when bypass token is configured', async () => {


### PR DESCRIPTION
## Summary

- Adds `RATE_LIMIT_BYPASS_TOKEN` to the frontend config and sends it as the `x-rate-limit-bypass` header on every request to the backend from both PublisherApi and ConsumerApi
- When the env var is not set (e.g. local dev), the header is simply omitted
- Adds unit tests for the bypass header behaviour in both API clients, including a new `consumer-api.test.ts` test file

## Test plan

- [x] Unit tests pass (`npm run check`)
- [ ] Verify in staging that the frontend can communicate with the backend without being rate-limited when the token is configured
- [ ] Verify that requests without the token are still subject to rate limiting
