### PR TITLE
SW-1223: Fix unhandled RangeError in date parsing

### DIFF
--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -34,7 +34,7 @@ export default function ViewTable(props: ViewTableProps) {
 
         case col.name === i18n.t('consumer_view.start_date') || col.name === i18n.t('consumer_view.end_date'): {
           const parsedDate = parseISO(value.split('T')[0]);
-          return dateFormat(parsedDate, 'do MMMM yyyy', { locale: i18n.language });
+          return isValid(parsedDate) ? dateFormat(parsedDate, 'do MMMM yyyy', { locale: i18n.language }) : value;
         }
 
         default:

--- a/src/shared/utils/dataset-metadata.ts
+++ b/src/shared/utils/dataset-metadata.ts
@@ -64,7 +64,7 @@ export const metadataToCSV = (metadata: PreviewMetadata, locale: Locale): string
   if (metadata.keyInfo.nextUpdateAt) {
     const { update_type } = metadata.keyInfo.nextUpdateAt;
     const { day, month, year } = metadata.keyInfo.nextUpdateAt.date || {};
-    const date = parse(`${day || '01'} ${month} ${year}`, 'dd MM yyyy', new Date());
+    const date = parse(`${day || '01'} ${month || '01'} ${year}`, 'dd MM yyyy', new Date());
 
     switch (update_type) {
       case NextUpdateType.None:
@@ -79,10 +79,12 @@ export const metadataToCSV = (metadata: PreviewMetadata, locale: Locale): string
       case NextUpdateType.Update:
         if (!isValid(date)) {
           lines.push([t('dataset_view.key_information.next_update'), '']);
-        } else if (day) {
+        } else if (day && month && year) {
           lines.push([t('dataset_view.key_information.next_update'), dateFormat(date, 'd MMMM yyyy', { locale })]);
-        } else {
+        } else if (month && year) {
           lines.push([t('dataset_view.key_information.next_update'), dateFormat(date, 'MMMM yyyy', { locale })]);
+        } else {
+          lines.push([t('dataset_view.key_information.next_update'), dateFormat(date, 'yyyy', { locale })]);
         }
         break;
     }

--- a/src/shared/utils/dataset-metadata.ts
+++ b/src/shared/utils/dataset-metadata.ts
@@ -8,7 +8,7 @@ import { i18next } from '../middleware/translation';
 import { Locale } from '../enums/locale';
 import { dateFormat } from './date-format';
 import { NextUpdateType } from '../enums/next-update-type';
-import { parse } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 
 export const getDatasetMetadata = async (
   dataset: SingleLanguageDataset,
@@ -77,7 +77,9 @@ export const metadataToCSV = (metadata: PreviewMetadata, locale: Locale): string
         ]);
         break;
       case NextUpdateType.Update:
-        if (day) {
+        if (!isValid(date)) {
+          lines.push([t('dataset_view.key_information.next_update'), '']);
+        } else if (day) {
           lines.push([t('dataset_view.key_information.next_update'), dateFormat(date, 'd MMMM yyyy', { locale })]);
         } else {
           lines.push([t('dataset_view.key_information.next_update'), dateFormat(date, 'MMMM yyyy', { locale })]);

--- a/src/shared/views/components/dataset/NextUpdate.tsx
+++ b/src/shared/views/components/dataset/NextUpdate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import T from '../T';
-import { parse } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 
 import { dateFormat } from '../../../utils/date-format';
 import { NextUpdateType } from '../../../enums/next-update-type';
@@ -30,7 +30,9 @@ const getNextUpdate = (nextUpdateAt?: NextUpdateAt, locale?: string) => {
       const { day, month, year } = nextUpdateAt.date || {};
       const date = parse(`${day || '01'} ${month || '01'} ${year}`, 'dd MM yyyy', new Date());
 
-      if (day && month && year) {
+      if (!isValid(date)) {
+        return <T>dataset_view.key_information.next_update_missing</T>;
+      } else if (day && month && year) {
         return dateFormat(date, 'd MMMM yyyy', { locale });
       } else if (month && year) {
         return dateFormat(date, 'MMMM yyyy', { locale });

--- a/tests/utils/dataset-metadata.test.ts
+++ b/tests/utils/dataset-metadata.test.ts
@@ -210,4 +210,34 @@ describe('metadataToCSV', () => {
     expect(nextUpdateRow).toBeDefined();
     expect(nextUpdateRow![1]).toBe('');
   });
+
+  it('formats year-only next update correctly', async () => {
+    const revision = makeRevision({
+      update_frequency: {
+        update_type: NextUpdateType.Update,
+        date: { day: undefined, month: undefined, year: '2027' }
+      }
+    });
+    const metadata = await getDatasetMetadata(makeDataset(), revision, false);
+    const csv = metadataToCSV(metadata, Locale.EnglishGb);
+
+    const nextUpdateRow = csv.find((row) => row[0] === i18next.t('dataset_view.key_information.next_update'));
+    expect(nextUpdateRow).toBeDefined();
+    expect(nextUpdateRow![1]).toBe('2027');
+  });
+
+  it('formats month-and-year next update correctly', async () => {
+    const revision = makeRevision({
+      update_frequency: {
+        update_type: NextUpdateType.Update,
+        date: { day: undefined, month: '06', year: '2027' }
+      }
+    });
+    const metadata = await getDatasetMetadata(makeDataset(), revision, false);
+    const csv = metadataToCSV(metadata, Locale.EnglishGb);
+
+    const nextUpdateRow = csv.find((row) => row[0] === i18next.t('dataset_view.key_information.next_update'));
+    expect(nextUpdateRow).toBeDefined();
+    expect(nextUpdateRow![1]).toBe('June 2027');
+  });
 });

--- a/tests/utils/dataset-metadata.test.ts
+++ b/tests/utils/dataset-metadata.test.ts
@@ -3,6 +3,7 @@ import { SingleLanguageDataset } from '../../src/shared/dtos/single-language/dat
 import { SingleLanguageRevision } from '../../src/shared/dtos/single-language/revision';
 import { Designation } from '../../src/shared/enums/designation';
 import { Locale } from '../../src/shared/enums/locale';
+import { NextUpdateType } from '../../src/shared/enums/next-update-type';
 import { i18next } from '../../src/shared/middleware/translation';
 
 const makeRevision = (overrides: Record<string, unknown> = {}): SingleLanguageRevision =>
@@ -191,5 +192,22 @@ describe('metadataToCSV', () => {
     expect(timePeriodRow).toBeDefined();
     // The row value should contain formatted date text
     expect(timePeriodRow![1]).toBeTruthy();
+  });
+
+  it('does not throw when next update has invalid date components', async () => {
+    const revision = makeRevision({
+      update_frequency: {
+        update_type: NextUpdateType.Update,
+        date: { day: undefined, month: undefined, year: undefined }
+      }
+    });
+    const metadata = await getDatasetMetadata(makeDataset(), revision, false);
+
+    expect(() => metadataToCSV(metadata, Locale.EnglishGb)).not.toThrow();
+
+    const csv = metadataToCSV(metadata, Locale.EnglishGb);
+    const nextUpdateRow = csv.find((row) => row[0] === i18next.t('dataset_view.key_information.next_update'));
+    expect(nextUpdateRow).toBeDefined();
+    expect(nextUpdateRow![1]).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- Add `isValid` checks to three date-parsing locations that were throwing `RangeError: Invalid time value` when receiving malformed or missing date components (21 errors on 2026-04-02)
- `ViewTable.tsx`: validate `parseISO` result before formatting start/end date columns — falls back to the raw string value
- `dataset-metadata.ts`: validate `parse` result in `metadataToCSV` next-update handling — falls back to empty string
- `NextUpdate.tsx`: validate `parse` result before formatting — falls back to the "next update missing" translation

## Test plan

- [x] New test: `metadataToCSV` with undefined date components does not throw and produces empty string
- [ ] Verify consumer dataset pages render correctly with valid date data
- [ ] Verify pages degrade gracefully when date components are missing/malformed
