### PR TITLE
SW-1216 Right Align Numbers in the table views

### DIFF
--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -62,7 +62,7 @@ export default function ViewTable(props: ViewTableProps) {
         : isNumericColumn(col, index)
           ? 'govuk-table__header--numeric'
           : '',
-    cellClassName: (value: string) => {
+    cellClassName: (value: string | undefined) => {
       if (col.source_type === FactTableColumnType.LineNumber) return 'line-number';
       if (isNumericValue(value)) return 'govuk-table__cell--numeric';
       return undefined;

--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -19,7 +19,7 @@ export type ViewTableProps = NoteCodesLegendProps & {
 // Matches humanized numbers (commas as thousand separators), optional decimal,
 // optional whitespace padding, and optional postfix codes like [x] or [z].
 const isNumericValue = (value: string | undefined): boolean =>
-  /^\s*-?[\d,]+(\.\d+)?(\s*\[\w+\])*\s*$/.test(value ?? '');
+  /^\s*-?(?:\d+|\d{1,3}(?:,\d{3})+)(\.\d+)?(\s*\[\w+\])*\s*$/.test(value ?? '');
 
 export default function ViewTable(props: ViewTableProps) {
   const { i18n } = useLocals();

--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -16,8 +16,23 @@ export type ViewTableProps = NoteCodesLegendProps & {
   isPivot?: boolean;
 };
 
+// Matches humanized numbers (commas as thousand separators), optional decimal,
+// optional whitespace padding, and optional postfix codes like [x] or [z].
+const isNumericValue = (value: string | undefined): boolean =>
+  /^\s*-?[\d,]+(\.\d+)?(\s*\[\w+\])*\s*$/.test(value ?? '');
+
 export default function ViewTable(props: ViewTableProps) {
   const { i18n } = useLocals();
+
+  // A column is numeric if it is typed as DataValues, or — for untyped/unknown columns
+  // (e.g. pivoted columns whose headers come from dimension values) — if the first
+  // non-empty cell in that column looks like a number.
+  const isNumericColumn = (col: ColumnHeader, colIndex: number): boolean => {
+    if (col.source_type === FactTableColumnType.DataValues) return true;
+    if (col.source_type && col.source_type !== FactTableColumnType.Unknown) return false;
+    const firstValue = props.data?.slice(0, 5).find((row) => row[colIndex])?.[colIndex];
+    return firstValue !== undefined && isNumericValue(firstValue);
+  };
 
   const columns = props.headers?.map((col, index) => ({
     key: index,
@@ -41,8 +56,17 @@ export default function ViewTable(props: ViewTableProps) {
           return value;
       }
     },
-    className: col.source_type === FactTableColumnType.LineNumber ? 'line-number' : '',
-    cellClassName: col.source_type === FactTableColumnType.LineNumber ? 'line-number' : ''
+    className:
+      col.source_type === FactTableColumnType.LineNumber
+        ? 'line-number'
+        : isNumericColumn(col, index)
+          ? 'govuk-table__header--numeric'
+          : '',
+    cellClassName: (value: string) => {
+      if (col.source_type === FactTableColumnType.LineNumber) return 'line-number';
+      if (isNumericValue(value)) return 'govuk-table__cell--numeric';
+      return undefined;
+    }
   }));
 
   return (

--- a/src/shared/views/components/Table.tsx
+++ b/src/shared/views/components/Table.tsx
@@ -9,7 +9,8 @@ import { omit, size } from 'lodash';
 type ColumnBase<T> = {
   key: (keyof T & string) | number;
   className?: string;
-  cellClassName?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cellClassName?: string | ((value: any, row: T) => string | undefined);
   style?: CSSProperties;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   format?: (value: any, row: T) => ReactNode;
@@ -193,13 +194,19 @@ export default function Table<T>({
                 <tr key={index} className="govuk-table__row">
                   {columns.map((col, index) => {
                     const isObject = typeof col === 'object';
+                    const cellValue = isObject ? row[col.key as keyof typeof row] : row[col as keyof typeof row];
+                    const cellClass = isObject
+                      ? typeof col.cellClassName === 'function'
+                        ? col.cellClassName(cellValue, row)
+                        : col.cellClassName
+                      : undefined;
                     return (
-                      <td key={index} className={clsx('govuk-table__cell', isObject && col.cellClassName)}>
+                      <td key={index} className={clsx('govuk-table__cell', cellClass)}>
                         {isObject
                           ? col.format
-                            ? col.format(row[col.key as keyof typeof row], row)
-                            : (row[col.key as keyof typeof row] as ReactNode)
-                          : (row[col as keyof typeof row] as ReactNode)}
+                            ? col.format(cellValue, row)
+                            : (cellValue as ReactNode)
+                          : (cellValue as ReactNode)}
                       </td>
                     );
                   })}

--- a/tests-e2e/consumer/dataset-view.spec.ts
+++ b/tests-e2e/consumer/dataset-view.spec.ts
@@ -53,6 +53,22 @@ test.describe('Dataset View', () => {
     await page.close();
   });
 
+  test('Numeric columns and cells are right-aligned in the data table', async ({ page }) => {
+    await page.goto(datasetUrl);
+
+    // At least one header should carry the numeric alignment class
+    const numericHeaders = page.locator('#data_table th.govuk-table__header--numeric');
+    await expect(numericHeaders.first()).toBeVisible();
+
+    // At least one data cell should carry the numeric alignment class
+    const numericCells = page.locator('#data_table td.govuk-table__cell--numeric');
+    await expect(numericCells.first()).toBeVisible();
+
+    // The CSS class must actually produce right-aligned text
+    const textAlign = await numericCells.first().evaluate((el) => window.getComputedStyle(el).textAlign);
+    expect(textAlign).toBe('right');
+  });
+
   test('Can switch to Welsh on dataset view', async ({ page }) => {
     await page.goto(datasetUrl);
     await page.getByText('Cymraeg').click();


### PR DESCRIPTION
Numbers were left aligned the same as all other data types.  The request was made for all numbers to be right aligned but this has to take into account numbers can be humanized (UK English) and can contain optional notes codes in the format of `[x]`.  Updates the codes to test for numbers according to this format and add an alignment class to the cells to right align the values.

Here's the summary of what was changed:

  ---
  src/shared/views/components/Table.tsx
  - cellClassName type widened from string to string | ((value: any, row: T) => string | undefined) — backwards-compatible; existing static string usages (e.g. DimensionPreviewTable.tsx) are unchanged
  - Cell rendering now evaluates the function form: computes cellValue once and passes it to both the class function and the format function

  src/consumer/views/dataset/components/ViewTable.tsx
  - Added isNumericValue — regex that matches humanized numbers: digits+commas, optional decimal, optional [x]-style postfix codes, optional whitespace padding
  - Added isNumericColumn — applies govuk-table__header--numeric to the column header when:
    - source_type === DataValues (normal tables), OR
    - source_type is absent/Unknown and the first non-empty cell looks numeric (catches pivot columns whose headers come from dimension values)
    - Explicitly skips other typed columns (Dimension, Time, NoteCodes, etc.)
  - cellClassName is now a per-cell function: applies govuk-table__cell--numeric to any cell whose value matches isNumericValue, so cells with dashes, empty values, or "N/A" are left-aligned while real numbers are right-aligned