### PR TITLE
Re-add pivoting feature flag 

### DIFF
--- a/src/consumer/views/components/DatasetList.tsx
+++ b/src/consumer/views/components/DatasetList.tsx
@@ -21,7 +21,7 @@ export default function Datasets({ datasets }: DatasetsProps) {
         <li className="index-list__item" key={dataset.id}>
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
+            href={buildUrl(`/${dataset.id}`, i18n.language)}
           >
             {dataset.title}
           </a>

--- a/src/consumer/views/components/SearchResults.tsx
+++ b/src/consumer/views/components/SearchResults.tsx
@@ -7,13 +7,17 @@ import { dateFormat } from '../../../shared/utils/date-format';
 import { DatasetStatus } from '../../../shared/enums/dataset-status';
 import T from '../../../shared/views/components/T';
 import { SearchResultDTO } from '../../../shared/dtos/search-result';
+import { isFeatureEnabled } from '../../../shared/utils/feature-flags';
+import { FeatureFlag } from '../../../shared/enums/feature-flag';
 
 interface SearchResultsProps {
   results: SearchResultDTO[];
 }
 
 export default function SearchResults({ results }: SearchResultsProps) {
-  const { buildUrl, i18n } = useLocals();
+  const { buildUrl, i18n, protocol, hostname, url, featureFlags } = useLocals();
+  const urlObj = new URL(url, `${protocol}://${hostname}`);
+  const showPivot = isFeatureEnabled(urlObj.searchParams, FeatureFlag.PivotFlow, featureFlags);
 
   const renderTitle = (dataset: SearchResultDTO) => {
     if (dataset.match_title && dataset.match_title.includes('<mark>')) {
@@ -39,7 +43,7 @@ export default function SearchResults({ results }: SearchResultsProps) {
         >
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
+            href={buildUrl(`/${dataset.id}${showPivot ? '/start' : ''}`, i18n.language)}
           >
             {renderTitle(dataset)}
           </a>

--- a/src/consumer/views/list.jsx
+++ b/src/consumer/views/list.jsx
@@ -28,7 +28,7 @@ export default function ConsumerList(props) {
           <ul className="govuk-list">
             {props.data.map((dataset, index) => (
               <li key={index} className="index-list__item">
-                <a href={props.buildUrl(`/${dataset.id}/start`, props.i18n.language)}>
+                <a href={props.buildUrl(`/${dataset.id}`, props.i18n.language)}>
                   <h3 className="govuk-heading-xs govuk-!-margin-bottom-0">{dataset.title}</h3>
                 </a>
                 <div className="index-list__meta">

--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { clsx } from 'clsx';
+import { URL } from 'node:url';
 
 import Layout from './components/Layout';
 import Hero from './components/Hero';
@@ -9,6 +10,8 @@ import { useLocals } from '../../shared/views/context/Locals';
 import Pagination from '../../shared/views/components/Pagination';
 import { statusToColour } from '../../shared/utils/status-to-colour';
 import { dateFormat } from '../../shared/utils/date-format';
+import { isFeatureEnabled } from '../../shared/utils/feature-flags';
+import { FeatureFlag } from '../../shared/enums/feature-flag';
 
 function ChildTopics({ childTopics }) {
   const { buildUrl, i18n } = useLocals();
@@ -30,7 +33,9 @@ function ChildTopics({ childTopics }) {
 }
 
 function Datasets({ datasets }) {
-  const { buildUrl, i18n } = useLocals();
+  const { buildUrl, i18n, protocol, hostname, url, featureFlags } = useLocals();
+  const urlObj = new URL(url, `${protocol}://${hostname}`);
+  const showPivot = isFeatureEnabled(urlObj.searchParams, FeatureFlag.PivotFlow, featureFlags);
 
   return (
     <ul className="govuk-list">
@@ -38,7 +43,7 @@ function Datasets({ datasets }) {
         <li className="index-list__item" key={dataset.id}>
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
+            href={buildUrl(`/${dataset.id}${showPivot ? '/start' : ''}`, i18n.language)}
           >
             {dataset.title}
           </a>

--- a/src/shared/enums/feature-flag.ts
+++ b/src/shared/enums/feature-flag.ts
@@ -1,3 +1,4 @@
 export enum FeatureFlag {
-  Example = 'example' // don't use - enum needs at least one value otherwise we get ts errors in isFeatureEnabled()
+  Example = 'example', // don't use - enum needs at least one value otherwise we get ts errors in isFeatureEnabled()
+  PivotFlow = 'pivot'
 }

--- a/tests/consumer-api.test.ts
+++ b/tests/consumer-api.test.ts
@@ -91,7 +91,7 @@ describe('ConsumerApi', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/healthcheck?lang=en`,
-        expect.objectContaining({ method: HttpMethod.Get, headers })
+        expect.objectContaining({ method: HttpMethod.Get, headers: expect.objectContaining(headers) })
       );
       expect(ping).toBe(true);
     });

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -42,7 +42,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/healthcheck?lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers: { ...headers, Authorization: `Bearer ${token}` }
+          headers: expect.objectContaining({ ...headers, Authorization: `Bearer ${token}` })
         })
       );
     });
@@ -146,7 +146,7 @@ describe('PublisherApi', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/data-table/raw?lang=en`,
-        expect.objectContaining({ method: HttpMethod.Get, headers })
+        expect.objectContaining({ method: HttpMethod.Get, headers: expect.objectContaining(headers) })
       );
       expect(fileStream).toBe(stream);
     });
@@ -167,7 +167,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/sources?lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(factTableColumnDto).toEqual(dataTable);
@@ -187,7 +187,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}?lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(datasetDTO).toEqual(dataset);
@@ -207,7 +207,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/view?page_number=1&page_size=10&lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(viewDTO).toEqual(view);
@@ -243,7 +243,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/data-table/preview?page_number=1&page_size=10&lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(viewDTO).toEqual(view);
@@ -278,7 +278,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset?lang=en`,
         expect.objectContaining({
           method: HttpMethod.Post,
-          headers,
+          headers: expect.objectContaining(headers),
           body
         })
       );
@@ -330,7 +330,7 @@ describe('PublisherApi', () => {
         expect.objectContaining({
           method: HttpMethod.Patch,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          headers: { ...headers, 'Content-Type': 'application/json; charset=UTF-8' },
+          headers: expect.objectContaining({ ...headers, 'Content-Type': 'application/json; charset=UTF-8' }),
           body: JSON.stringify(sourceAssignment)
         })
       );
@@ -355,7 +355,7 @@ describe('PublisherApi', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/fact-table?lang=en`,
-        expect.objectContaining({ method: HttpMethod.Post, headers, body })
+        expect.objectContaining({ method: HttpMethod.Post, headers: expect.objectContaining(headers), body })
       );
       expect(datasetDTO).toEqual(dataset);
     });
@@ -393,7 +393,7 @@ describe('PublisherApi', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/healthcheck?lang=en`,
-        expect.objectContaining({ method: HttpMethod.Get, headers })
+        expect.objectContaining({ method: HttpMethod.Get, headers: expect.objectContaining(headers) })
       );
       expect(ping).toBe(true);
     });
@@ -405,7 +405,7 @@ describe('PublisherApi', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         `${baseUrl}/healthcheck?lang=en`,
-        expect.objectContaining({ method: HttpMethod.Get, headers })
+        expect.objectContaining({ method: HttpMethod.Get, headers: expect.objectContaining(headers) })
       );
     });
   });
@@ -426,7 +426,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/tasks?lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(taskDTOs).toEqual(tasks);
@@ -444,7 +444,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/tasks?open=true&lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(taskDTOs).toEqual(tasks);
@@ -462,7 +462,7 @@ describe('PublisherApi', () => {
         `${baseUrl}/dataset/${datasetId}/tasks?open=false&lang=en`,
         expect.objectContaining({
           method: HttpMethod.Get,
-          headers
+          headers: expect.objectContaining(headers)
         })
       );
       expect(taskDTOs).toEqual(tasks);


### PR DESCRIPTION
## Summary

- Re-adds the `PivotFlow` feature flag that was removed in #625, gating the `/start` pivot flow behind the `pivot` flag again while the bug is investigated
- Fixes API test assertions (`publisher-api.test.ts`, `consumer-api.test.ts`) to use `expect.objectContaining` for headers, so tests pass locally when `RATE_LIMIT_BYPASS_TOKEN` is set in the environment

## Test plan

- [x] All 172 tests pass locally (including with `RATE_LIMIT_BYPASS_TOKEN` set)
- [x] `npm run check` passes (prettier, lint, test, build)
- [ ] Verify dataset links go to `/{id}` without the flag and `/{id}/start` with `?feature=pivot`
