### PR TITLE
SW-1216 Add missing edge case

### DIFF
--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -18,8 +18,9 @@ export type ViewTableProps = NoteCodesLegendProps & {
 
 // Matches humanized numbers (commas as thousand separators), optional decimal,
 // optional whitespace padding, and optional postfix codes like [x] or [z].
+// Also matches standalone note codes with no numeric value (e.g. [x], [x][z]).
 const isNumericValue = (value: string | undefined): boolean =>
-  /^\s*-?(?:\d+|\d{1,3}(?:,\d{3})+)(\.\d+)?(\s*\[\w+\])*\s*$/.test(value ?? '');
+  /^\s*(?:-?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:\s*\[\w+\])*|(?:\[\w+\]\s*)+)\s*$/.test(value ?? '');
 
 export default function ViewTable(props: ViewTableProps) {
   const { i18n } = useLocals();


### PR DESCRIPTION
There's an edge case when you can have no value and just a note code. This also need to be right aligned to make the other values in the column.

This updates the regex to cover this edgecase