### PR TITLE
Remove pivot feature flag

### DIFF
--- a/src/consumer/views/components/DatasetList.tsx
+++ b/src/consumer/views/components/DatasetList.tsx
@@ -21,7 +21,7 @@ export default function Datasets({ datasets }: DatasetsProps) {
         <li className="index-list__item" key={dataset.id}>
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}`, i18n.language)}
+            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
           >
             {dataset.title}
           </a>

--- a/src/consumer/views/components/SearchResults.tsx
+++ b/src/consumer/views/components/SearchResults.tsx
@@ -7,17 +7,13 @@ import { dateFormat } from '../../../shared/utils/date-format';
 import { DatasetStatus } from '../../../shared/enums/dataset-status';
 import T from '../../../shared/views/components/T';
 import { SearchResultDTO } from '../../../shared/dtos/search-result';
-import { isFeatureEnabled } from '../../../shared/utils/feature-flags';
-import { FeatureFlag } from '../../../shared/enums/feature-flag';
 
 interface SearchResultsProps {
   results: SearchResultDTO[];
 }
 
 export default function SearchResults({ results }: SearchResultsProps) {
-  const { buildUrl, i18n, protocol, hostname, url, featureFlags } = useLocals();
-  const urlObj = new URL(url, `${protocol}://${hostname}`);
-  const showPivot = isFeatureEnabled(urlObj.searchParams, FeatureFlag.PivotFlow, featureFlags);
+  const { buildUrl, i18n } = useLocals();
 
   const renderTitle = (dataset: SearchResultDTO) => {
     if (dataset.match_title && dataset.match_title.includes('<mark>')) {
@@ -43,7 +39,7 @@ export default function SearchResults({ results }: SearchResultsProps) {
         >
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}${showPivot ? '/start' : ''}`, i18n.language)}
+            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
           >
             {renderTitle(dataset)}
           </a>

--- a/src/consumer/views/dataset/components/DataTab.tsx
+++ b/src/consumer/views/dataset/components/DataTab.tsx
@@ -12,8 +12,6 @@ import { RowsPerPage } from '../../../../shared/views/components/RowsPerPage';
 import { SortByInterface, serializeSortBy } from '../../../../shared/interfaces/sort-by';
 import { PivotControls } from './pivot/PivotControls';
 import { DataControls } from './pivot/DataControls';
-import { isFeatureEnabled } from '../../../../shared/utils/feature-flags';
-import { FeatureFlag } from '../../../../shared/enums/feature-flag';
 
 type DataTabProps = NoteCodesLegendProps &
   PaginationProps &
@@ -33,9 +31,7 @@ type DataTabProps = NoteCodesLegendProps &
   };
 
 export default function DataTab(props: DataTabProps) {
-  const { buildUrl, i18n, protocol, hostname, url, featureFlags } = useLocals();
-  const urlObj = new URL(url, `${protocol}://${hostname}`);
-  const showPivot = isFeatureEnabled(urlObj.searchParams, FeatureFlag.PivotFlow, featureFlags);
+  const { buildUrl, i18n } = useLocals();
   const pivotSelected = !!props.columns && !!props.rows;
 
   let formUrl = buildUrl(`/${props.dataset.id}/filtered`, i18n.language);
@@ -83,7 +79,6 @@ export default function DataTab(props: DataTabProps) {
 
               {!props.preview &&
                 !props.isDevPreview &&
-                showPivot &&
                 (pivotSelected ? <PivotControls {...props} /> : <DataControls {...props} />)}
 
               <div className="govuk-!-padding-top-5 govuk-!-margin-bottom-2">

--- a/src/consumer/views/list.jsx
+++ b/src/consumer/views/list.jsx
@@ -28,7 +28,7 @@ export default function ConsumerList(props) {
           <ul className="govuk-list">
             {props.data.map((dataset, index) => (
               <li key={index} className="index-list__item">
-                <a href={props.buildUrl(`/${dataset.id}`, props.i18n.language)}>
+                <a href={props.buildUrl(`/${dataset.id}/start`, props.i18n.language)}>
                   <h3 className="govuk-heading-xs govuk-!-margin-bottom-0">{dataset.title}</h3>
                 </a>
                 <div className="index-list__meta">

--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { clsx } from 'clsx';
-import { URL } from 'node:url';
 
 import Layout from './components/Layout';
 import Hero from './components/Hero';
@@ -10,8 +9,6 @@ import { useLocals } from '../../shared/views/context/Locals';
 import Pagination from '../../shared/views/components/Pagination';
 import { statusToColour } from '../../shared/utils/status-to-colour';
 import { dateFormat } from '../../shared/utils/date-format';
-import { isFeatureEnabled } from '../../shared/utils/feature-flags';
-import { FeatureFlag } from '../../shared/enums/feature-flag';
 
 function ChildTopics({ childTopics }) {
   const { buildUrl, i18n } = useLocals();
@@ -33,9 +30,7 @@ function ChildTopics({ childTopics }) {
 }
 
 function Datasets({ datasets }) {
-  const { buildUrl, i18n, protocol, hostname, url, featureFlags } = useLocals();
-  const urlObj = new URL(url, `${protocol}://${hostname}`);
-  const showPivot = isFeatureEnabled(urlObj.searchParams, FeatureFlag.PivotFlow, featureFlags);
+  const { buildUrl, i18n } = useLocals();
 
   return (
     <ul className="govuk-list">
@@ -43,7 +38,7 @@ function Datasets({ datasets }) {
         <li className="index-list__item" key={dataset.id}>
           <a
             className="govuk-heading-s govuk-!-margin-bottom-0 govuk-link inline"
-            href={buildUrl(`/${dataset.id}${showPivot ? '/start' : ''}`, i18n.language)}
+            href={buildUrl(`/${dataset.id}/start`, i18n.language)}
           >
             {dataset.title}
           </a>

--- a/src/shared/enums/feature-flag.ts
+++ b/src/shared/enums/feature-flag.ts
@@ -1,4 +1,3 @@
 export enum FeatureFlag {
-  Example = 'example', // don't use - enum needs at least one value otherwise we get ts errors in isFeatureEnabled()
-  PivotFlow = 'pivot'
+  Example = 'example' // don't use - enum needs at least one value otherwise we get ts errors in isFeatureEnabled()
 }


### PR DESCRIPTION
## Summary

- Removes the `PivotFlow` feature flag so the pivot feature is available to all users by default
- Dataset links in search results and topic lists now always point to the `/start` landing page
- Pivot controls on the data tab are always shown for non-preview views
- Reverses the gating added in #633 and #634 now that QA testing is complete

## Test plan

- [ ] Verify dataset links go to `/{id}/start` on topic lists and search results
- [ ] Verify pivot controls (start over / create own table) appear on the data tab
- [ ] Verify the full pivot flow works end-to-end without `?feature=pivot` in the URL
