### PR TITLE
fix: display period dates in UTC to prevent timezone shifts (SW-1109)

### DIFF
--- a/src/consumer/views/dataset/components/ViewTable.tsx
+++ b/src/consumer/views/dataset/components/ViewTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isValid, parse, parseISO } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 
 import { useLocals } from '../../../../shared/views/context/Locals';
 import Table from '../../../../shared/views/components/Table';
@@ -49,8 +49,10 @@ export default function ViewTable(props: ViewTableProps) {
         }
 
         case col.name === i18n.t('consumer_view.start_date') || col.name === i18n.t('consumer_view.end_date'): {
-          const parsedDate = parseISO(value.split('T')[0]);
-          return isValid(parsedDate) ? dateFormat(parsedDate, 'do MMMM yyyy', { locale: i18n.language }) : value;
+          const parsedDate = new Date(value);
+          return isValid(parsedDate)
+            ? dateFormat(parsedDate, 'do MMMM yyyy', { locale: i18n.language, utc: true })
+            : value;
         }
 
         default:

--- a/src/publisher/views/components/DimensionPreviewTable.tsx
+++ b/src/publisher/views/components/DimensionPreviewTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { parseISO } from 'date-fns';
 
 import Table from '../../../shared/views/components/Table';
 import { ColumnHeader, ViewDTO } from '../../../shared/dtos/view-dto';
@@ -47,7 +46,7 @@ export default function DimensionPreviewTable(props: DimensionPreviewTableProps)
       switch (heading.name) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(parseISO(value.split('T')[0]), 'do MMMM yyyy');
+          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true });
         }
       }
       return value;

--- a/src/publisher/views/components/DimensionPreviewTable.tsx
+++ b/src/publisher/views/components/DimensionPreviewTable.tsx
@@ -46,7 +46,7 @@ export default function DimensionPreviewTable(props: DimensionPreviewTableProps)
       switch (heading.name) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true });
+          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true, locale: i18n.language });
         }
       }
       return value;

--- a/src/publisher/views/components/MeasurePreviewTable.tsx
+++ b/src/publisher/views/components/MeasurePreviewTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { parseISO } from 'date-fns';
 
 import Table from '../../../shared/views/components/Table';
 import { ViewDTO } from '../../../shared/dtos/view-dto';
@@ -22,7 +21,7 @@ export default function MeasurePreviewTable(props: MeasurePreviewTableProps) {
       switch (col.name.toLowerCase()) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(parseISO(value.split('T')[0]), 'do MMMM yyyy');
+          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true });
         }
         case 'date_type': {
           return <T>publish.measure_review.year_type.{value}</T>;

--- a/src/publisher/views/components/MeasurePreviewTable.tsx
+++ b/src/publisher/views/components/MeasurePreviewTable.tsx
@@ -21,7 +21,7 @@ export default function MeasurePreviewTable(props: MeasurePreviewTableProps) {
       switch (col.name.toLowerCase()) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true });
+          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true, locale: i18n.language });
         }
         case 'date_type': {
           return <T>publish.measure_review.year_type.{value}</T>;

--- a/src/publisher/views/publish/date-chooser.jsx
+++ b/src/publisher/views/publish/date-chooser.jsx
@@ -37,7 +37,7 @@ export default function DateChooser(props) {
         case 'end_date':
           return dateFormat(new Date(value), 'do MMMM yyyy', {
             locale: props.i18n.language,
-            timeZone: 'Europe/London'
+            utc: true
           });
       }
       return value;

--- a/src/publisher/views/publish/period-match-failure.jsx
+++ b/src/publisher/views/publish/period-match-failure.jsx
@@ -66,14 +66,14 @@ export default function PeriodMatchFailure(props) {
       <h2 className="govuk-heading-l">{props.t('publish.period_match_failure.subheading')}</h2>
 
       <ul className="govuk-list govuk-list--bullet">
-        {props.extension.nonMatchingValues.length === 0 ? (
-          <li className="govuk-list--bullet">{props.t('publish.period_match_failure.no_matches')}</li>
-        ) : (
+        {props.extension.nonMatchingValues?.length ? (
           props.extension.nonMatchingValues.map((value, idx) => (
             <li className="govuk-list--bullet" key={idx}>
               {value}
             </li>
           ))
+        ) : (
+          <li className="govuk-list--bullet">{props.t('publish.period_match_failure.no_matches')}</li>
         )}
       </ul>
 

--- a/src/shared/utils/dataset-metadata.ts
+++ b/src/shared/utils/dataset-metadata.ts
@@ -100,9 +100,11 @@ export const metadataToCSV = (metadata: PreviewMetadata, locale: Locale): string
       t('dataset_view.key_information.time_covered'),
       t('dataset_view.key_information.time_period', {
         start: metadata.keyInfo.timePeriod.start
-          ? dateFormat(metadata.keyInfo.timePeriod.start, 'MMMM yyyy', { locale })
+          ? dateFormat(metadata.keyInfo.timePeriod.start, 'MMMM yyyy', { locale, utc: true })
           : '',
-        end: metadata.keyInfo.timePeriod.end ? dateFormat(metadata.keyInfo.timePeriod.end, 'MMMM yyyy', { locale }) : ''
+        end: metadata.keyInfo.timePeriod.end
+          ? dateFormat(metadata.keyInfo.timePeriod.end, 'MMMM yyyy', { locale, utc: true })
+          : ''
       })
     ]);
   }

--- a/src/shared/utils/date-format.ts
+++ b/src/shared/utils/date-format.ts
@@ -7,10 +7,11 @@ import { Locale } from '../enums/locale';
 // override date-fns locale option with our own Locale enum so we don't have to convert it everywhere we use this function
 interface DateFormatOptions extends Omit<FormatOptions, 'locale'> {
   locale?: Locale | string;
+  utc?: boolean;
 }
 
 export const dateFormat = (date: DateArg<Date> & {}, formatStr: string, options?: DateFormatOptions): string => {
-  const tzDate = new TZDate(date as Date, 'Europe/London');
+  const tzDate = new TZDate(date as Date, options?.utc ? 'UTC' : 'Europe/London');
 
   const formatOptions: FormatOptions = {
     ...options,

--- a/src/shared/views/components/dataset/KeyInfo.jsx
+++ b/src/shared/views/components/dataset/KeyInfo.jsx
@@ -14,8 +14,8 @@ function PeriodCovered({ timePeriod, locale }) {
       </dt>
       <dd className="govuk-summary-list__value">
         <T
-          start={dateFormat(timePeriod.start, 'MMMM yyyy', { locale })}
-          end={dateFormat(timePeriod.end, 'MMMM yyyy', { locale })}
+          start={dateFormat(timePeriod.start, 'MMMM yyyy', { locale, utc: true })}
+          end={dateFormat(timePeriod.end, 'MMMM yyyy', { locale, utc: true })}
         >
           dataset_view.key_information.time_period
         </T>

--- a/tests-e2e/consumer/dataset-view.spec.ts
+++ b/tests-e2e/consumer/dataset-view.spec.ts
@@ -40,6 +40,9 @@ test.describe('Dataset View', () => {
     await expect(page.getByRole('heading', { name: 'Main information' })).toBeVisible();
     // Realistic dataset has a Financial year date dimension — time period should be visible
     await expect(page.locator('#time-period')).toBeVisible();
+    // Financial year coverage should show correct months (not shifted by timezone)
+    await expect(page.locator('#time-period')).toContainText('April 2013');
+    await expect(page.locator('#time-period')).toContainText('March 2024');
   });
 
   test('Custom year dataset About tab does not show time period', async ({ browser }) => {

--- a/tests-e2e/publish/helpers/publishing-steps.ts
+++ b/tests-e2e/publish/helpers/publishing-steps.ts
@@ -131,6 +131,7 @@ export type DimensionConfig = {
   dimensionName: string;
   optionSelections: string[];
   filename?: string;
+  previewChecks?: string[];
 };
 
 export async function configureDimension(page: Page, datasetId: string, dimensionConfig: DimensionConfig) {
@@ -139,6 +140,13 @@ export async function configureDimension(page: Page, datasetId: string, dimensio
   for (const option of dimensionConfig.optionSelections) {
     await page.getByLabel(option).first().click({ force: true });
     await page.getByRole('button', { name: 'Continue' }).click();
+  }
+
+  if (dimensionConfig.previewChecks) {
+    const firstRow = page.locator('table tbody tr').first();
+    for (const text of dimensionConfig.previewChecks) {
+      await expect(firstRow).toContainText(text);
+    }
   }
 
   await page.getByRole('button', { name: 'Continue' }).click();

--- a/tests-e2e/publish/publish-dataset.spec.ts
+++ b/tests-e2e/publish/publish-dataset.spec.ts
@@ -80,7 +80,8 @@ test.describe('Publish dataset', () => {
       await configureDimension(page, datasetId, {
         originalColName: 'YearCode',
         dimensionName: columnAssignments.find((c) => c.column === 'YearCode')!.name!,
-        optionSelections: ['Dates', 'Periods', 'Financial', 'YYYYYY', 'Years']
+        optionSelections: ['Dates', 'Periods', 'Financial', 'YYYYYY', 'Years'],
+        previewChecks: ['1st April 2013', '31st March 2014']
       });
 
       await configureLookupDimension(page, datasetId, {
@@ -134,6 +135,9 @@ test.describe('Publish dataset', () => {
       await expect(previewPage.getByText('Main information', { exact: true })).toBeVisible();
       await expect(previewPage.getByText('Overview', { exact: true })).toBeVisible();
       await expect(previewPage.getByText('Published by', { exact: true })).toBeVisible();
+      // Financial year coverage: April 2013 to March 2024
+      await expect(previewPage.locator('#time-period')).toContainText('April 2013');
+      await expect(previewPage.locator('#time-period')).toContainText('March 2024');
       await expect(previewPage.getByText(metadata.summary, { exact: true })).toBeVisible();
       await expect(previewPage.getByText(metadata.collection, { exact: true })).toBeVisible();
       await expect(previewPage.getByText(metadata.quality, { exact: true })).toBeVisible();

--- a/tools/replay-dataset-types.ts
+++ b/tools/replay-dataset-types.ts
@@ -11,7 +11,6 @@ export interface DebugDimensionConfig {
 
 export interface DebugDatasetConfig {
   title: string;
-  groupName: string;
   dataFile: string; // CSV filename relative to dataset dir
   columnAssignments: ColumnAssignment[];
   measure: { filename: string }; // CSV filename relative to dataset dir

--- a/tools/replay-dataset.ts
+++ b/tools/replay-dataset.ts
@@ -157,7 +157,7 @@ async function main() {
     // Phase 1: Create dataset
     console.log('Starting new dataset...');
     await startNewDataset(page);
-    await selectUserGroup(page, cfg.groupName);
+    await selectUserGroup(page, 'E2E tests');
     const datasetId = await provideDatasetTitle(page, cfg.title);
     console.log(`Dataset created: ${datasetId}`);
 


### PR DESCRIPTION
## Summary

Frontend companion to Marvell-Consulting/statswales-backend#640 — fixes SW-1109 timezone bug in financial year date display.

**Changes:**
- Added `utc?: boolean` option to `dateFormat()` — when set, formats dates in UTC instead of Europe/London, preventing BST shifts on abstract period boundary dates
- Applied `utc: true` to all coverage/period date formatting: About tab, metadata CSV download, dimension preview tables, measure preview, consumer data view, and date-chooser
- Removed unused `parseISO` imports and the `split('T')[0]` workaround in preview tables
- Added e2e test assertions for financial year dates:
  - Publisher dimension preview: checks first row shows "1st April 2013" / "31st March 2014"
  - Publisher preview About tab: checks time period shows "April 2013" / "March 2024"
  - Consumer About tab: same coverage period check
- Added generic `previewChecks` option to `configureDimension` helper for reusable preview table assertions

## Test plan

- [ ] Frontend unit tests pass (172 tests)
- [ ] Publisher dimension setup shows correct dates for financial years
- [ ] Consumer About tab shows "April 2013 to March 2024" for realistic dataset
- [ ] Metadata CSV download shows correct time period
- [ ] Other dates (e.g. "Last updated") still display correctly in London time
- [ ] E2E publish and consumer tests pass
