### PR TITLE
SW-1220: stop swallowing server errors as 404s in consumer fetch-dataset

### DIFF
--- a/src/consumer/middleware/fetch-dataset.ts
+++ b/src/consumer/middleware/fetch-dataset.ts
@@ -19,7 +19,12 @@ export const fetchPublishedDataset = async (req: Request, res: Response, next: N
       res.redirect(301, req.buildUrl(`/${dataset.replaced_by.dataset_id}`, req.language));
       return;
     }
-  } catch (_err) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (err: any) {
+    if (err.status >= 500) {
+      next(err);
+      return;
+    }
     next(new NotFoundException('errors.dataset_missing'));
     return;
   }

--- a/src/consumer/middleware/fetch-dataset.ts
+++ b/src/consumer/middleware/fetch-dataset.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { ApiException } from '../../shared/exceptions/api.exception';
 import { NotFoundException } from '../../shared/exceptions/not-found.exception';
 import { hasError, datasetIdValidator } from '../../shared/validators';
 
@@ -19,13 +20,12 @@ export const fetchPublishedDataset = async (req: Request, res: Response, next: N
       res.redirect(301, req.buildUrl(`/${dataset.replaced_by.dataset_id}`, req.language));
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
-    if (err.status >= 500) {
-      next(err);
+  } catch (err) {
+    if (err instanceof ApiException && err.status >= 400 && err.status < 500) {
+      next(new NotFoundException('errors.dataset_missing'));
       return;
     }
-    next(new NotFoundException('errors.dataset_missing'));
+    next(err);
     return;
   }
 

--- a/tests/consumer-fetch-dataset-middleware.test.ts
+++ b/tests/consumer-fetch-dataset-middleware.test.ts
@@ -1,0 +1,98 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { fetchPublishedDataset } from '../src/consumer/middleware/fetch-dataset';
+import { ApiException } from '../src/shared/exceptions/api.exception';
+import { NotFoundException } from '../src/shared/exceptions/not-found.exception';
+import { UnknownException } from '../src/shared/exceptions/unknown.exception';
+
+const validDatasetId = '5caeb8ed-ea64-4a58-8cf0-b728308833e5';
+
+const mockReq = (datasetId: string, getPublishedDataset: jest.Mock) =>
+  ({ params: { datasetId }, query: {}, body: {}, conapi: { getPublishedDataset } }) as unknown as Request;
+
+const mockRes = () => ({ locals: {}, redirect: jest.fn() }) as unknown as Response;
+
+describe('fetchPublishedDataset middleware', () => {
+  it('should set res.locals and call next on success', async () => {
+    const dataset = { id: validDatasetId, title: 'Test Dataset' };
+    const getPublishedDataset = jest.fn().mockResolvedValue(dataset);
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(res.locals.datasetId).toBe(validDatasetId);
+    expect(res.locals.dataset).toBe(dataset);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('should return NotFoundException for an invalid dataset ID', async () => {
+    const getPublishedDataset = jest.fn();
+    const req = mockReq('not-a-uuid', getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(getPublishedDataset).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(NotFoundException));
+  });
+
+  it('should return NotFoundException when the API returns 404', async () => {
+    const getPublishedDataset = jest.fn().mockRejectedValue(new ApiException('Not Found', 404));
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(expect.any(NotFoundException));
+  });
+
+  it('should return NotFoundException when the API returns 401 (do not leak dataset existence)', async () => {
+    const getPublishedDataset = jest.fn().mockRejectedValue(new ApiException('Unauthorized', 401));
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(expect.any(NotFoundException));
+  });
+
+  it('should return NotFoundException when the API returns 403 (do not leak dataset existence)', async () => {
+    const getPublishedDataset = jest.fn().mockRejectedValue(new ApiException('Forbidden', 403));
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(expect.any(NotFoundException));
+  });
+
+  it('should pass through the original error when the API returns 500', async () => {
+    const apiError = new ApiException('Internal Server Error', 500);
+    const getPublishedDataset = jest.fn().mockRejectedValue(apiError);
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(apiError);
+  });
+
+  it('should pass through the original error on network failure (UnknownException)', async () => {
+    const networkError = new UnknownException('Service Unavailable');
+    const getPublishedDataset = jest.fn().mockRejectedValue(networkError);
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(networkError);
+  });
+});

--- a/tests/consumer-fetch-dataset-middleware.test.ts
+++ b/tests/consumer-fetch-dataset-middleware.test.ts
@@ -72,6 +72,18 @@ describe('fetchPublishedDataset middleware', () => {
     expect(next).toHaveBeenCalledWith(expect.any(NotFoundException));
   });
 
+  it('should pass through ApiException with a non-error status code', async () => {
+    const apiError = new ApiException('Moved Permanently', 301);
+    const getPublishedDataset = jest.fn().mockRejectedValue(apiError);
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(apiError);
+  });
+
   it('should pass through the original error when the API returns 500', async () => {
     const apiError = new ApiException('Internal Server Error', 500);
     const getPublishedDataset = jest.fn().mockRejectedValue(apiError);
@@ -82,6 +94,18 @@ describe('fetchPublishedDataset middleware', () => {
     await fetchPublishedDataset(req, res, next as NextFunction);
 
     expect(next).toHaveBeenCalledWith(apiError);
+  });
+
+  it('should pass through unexpected errors without a status property', async () => {
+    const unexpectedError = new Error('Cannot read properties of undefined');
+    const getPublishedDataset = jest.fn().mockRejectedValue(unexpectedError);
+    const req = mockReq(validDatasetId, getPublishedDataset);
+    const res = mockRes();
+    const next = jest.fn();
+
+    await fetchPublishedDataset(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(unexpectedError);
   });
 
   it('should pass through the original error on network failure (UnknownException)', async () => {


### PR DESCRIPTION
## Summary

- Consumer `fetchPublishedDataset` middleware was catching all API errors and converting them to 404s, masking real failures (backend 500s, timeouts, network errors)
- Now passes through 5xx errors so users see "server error" instead of a misleading "not found"
- 4xx errors (including 401/403) remain as 404 to avoid leaking dataset existence on the public-facing consumer
- Adds unit tests covering all error scenarios

## Test plan

- [x] Unit tests for success, invalid ID, 404, 401, 403, 500, and network failure cases
- [x] `npm run check` passes (prettier, lint, tests, build)
