### PR TITLE
SW-1191: Remove 'ar' from Welsh guidance

### DIFF
--- a/docs/guidance/cy/Data-preparation-‐-New-datasets.md
+++ b/docs/guidance/cy/Data-preparation-‐-New-datasets.md
@@ -179,24 +179,24 @@ Gall eich set ddata gynnwys data ar gyfer cyfnodau amser lluosog. Er enghraifft,
 
 #### Cyfnodau treigl neu sy’n gorgyffwrdd
 
-Efallai y bydd amgylchiadau pan fydd y cyfnodau yn eich set ddata yn gorgyffwrdd. Er enghraifft, pan fo eich gwerthoedd data yn cynrychioli gwerthoedd cronnol i ddyddiad penodol, megis y swm ar gyfer y flwyddyn yn gorffen ar 30 Mehefin, yna y swm ar gyfer y flwyddyn yn gorffen ar 31 Gorffennaf, ac ati. Yn yr achosion hyn, dylech ddilyn y drefn fformatio ganlynol:
+Efallai y bydd amgylchiadau pan fydd y cyfnodau yn eich set ddata yn gorgyffwrdd. Er enghraifft, pan fo eich gwerthoedd data yn cynrychioli gwerthoedd cronnol i ddyddiad penodol, megis y swm ar gyfer y flwyddyn yn gorffen 30 Mehefin, yna y swm ar gyfer y flwyddyn yn gorffen 31 Gorffennaf, ac ati. Yn yr achosion hyn, dylech ddilyn y drefn fformatio ganlynol:
 
 - rhagddodiad yn dynodi hyd y cyfnod
 - yna unrhyw rai o’r fformatiau dyddiad penodol a ddisgrifir yn yr adran ‘[Pwyntiau penodol mewn amser](#guidance-pwyntiau-penodol-mewn-amser)
 
 Enghreifftiau:
 
-| Fformat yn y tabl data | Enghraifft   | Sut y bydd yn ymddangos ar y wefan        |
-| :--------------------- | :----------- | :---------------------------------------- |
-| XYYYYY-MM-DD           | XY2022-03-31 | 10 mlynedd yn gorffen ar 31 Mawrth 2022   |
-| 5YYYYY-MM-DD           | 5Y2022-03-31 | 5 mlynedd yn gorffen ar 31 Mawrth 2022    |
-| 3YYYYY-MM-DD           | 3Y2022-03-31 | 3 blynedd yn gorffen ar 31 Mawrth 2022    |
-| 2YYYYY-MM-DD           | 2Y2022-03-31 | 2 flynedd yn gorffen ar 31 Mawrth 2022    |
-| YEYYYY-MM-DD           | YE2022-03-31 | Blwyddyn yn gorffen ar 31 Mawrth 2022     |
-| HEYYYY-MM-DD           | HE2022-05-31 | Hanner blwyddyn yn gorffen ar 31 Mai 2022 |
-| QEYYYY-MM-DD           | QE2022-05-30 | Chwarter yn gorffen ar 30 Mai 2022        |
-| MEDD-MM-YYYY           | ME15-03-2022 | Mis yn gorffen ar 15 Mawrth 2022          |
-| WEDD-MM-YYYY           | WE25-03-2022 | Wythnos yn gorffen ar 25 Mawrth 2022      |
+| Fformat yn y tabl data | Enghraifft   | Sut y bydd yn ymddangos ar y wefan     |
+| :--------------------- | :----------- | :------------------------------------- |
+| XYYYYY-MM-DD           | XY2022-03-31 | 10 mlynedd yn gorffen 31 Mawrth 2022   |
+| 5YYYYY-MM-DD           | 5Y2022-03-31 | 5 mlynedd yn gorffen 31 Mawrth 2022    |
+| 3YYYYY-MM-DD           | 3Y2022-03-31 | 3 blynedd yn gorffen 31 Mawrth 2022    |
+| 2YYYYY-MM-DD           | 2Y2022-03-31 | 2 flynedd yn gorffen 31 Mawrth 2022    |
+| YEYYYY-MM-DD           | YE2022-03-31 | Blwyddyn yn gorffen 31 Mawrth 2022     |
+| HEYYYY-MM-DD           | HE2022-05-31 | Hanner blwyddyn yn gorffen 31 Mai 2022 |
+| QEYYYY-MM-DD           | QE2022-05-30 | Chwarter yn gorffen 30 Mai 2022        |
+| MEDD-MM-YYYY           | ME15-03-2022 | Mis yn gorffen 15 Mawrth 2022          |
+| WEDD-MM-YYYY           | WE25-03-2022 | Wythnos yn gorffen 25 Mawrth 2022      |
 
 #### Cyfnodau ansafonol
 


### PR DESCRIPTION
## Summary

- SW-1191: `gorffen` should not be followed by `ar` before a date.
- Removes `ar` from the 10 occurrences of `yn gorffen ar` in the Welsh "Data preparation – New datasets" guidance — two in prose (line 182) and the nine example table rows.
- Table column widths re-aligned by prettier via `npm run check`.
- The glossary entry for the `gorffen` field name (line 302) is a different grammatical context and is left unchanged.

Paired with the backend translation fix on SW-1191.

## Test plan

- [x] `npm run check` passes (prettier, lint, 181 tests, build).
- [ ] Render the Welsh "Paratoi data: Setiau data newydd" guidance page locally and confirm the "Cyfnodau treigl neu sy'n gorgyffwrdd" section reads e.g. `10 mlynedd yn gorffen 31 Mawrth 2022` with no `ar`.
