### PR TITLE
SW-1232: defend against bad date formats

### DIFF
--- a/src/publisher/views/components/DimensionPreviewTable.tsx
+++ b/src/publisher/views/components/DimensionPreviewTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isValid } from 'date-fns';
 
 import Table from '../../../shared/views/components/Table';
 import { ColumnHeader, ViewDTO } from '../../../shared/dtos/view-dto';
@@ -46,7 +47,9 @@ export default function DimensionPreviewTable(props: DimensionPreviewTableProps)
       switch (heading.name) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true, locale: i18n.language });
+          const date = new Date(value);
+          if (!isValid(date)) return value;
+          return dateFormat(date, 'do MMMM yyyy', { utc: true, locale: i18n.language });
         }
       }
       return value;

--- a/src/publisher/views/components/DimensionPreviewTable.tsx
+++ b/src/publisher/views/components/DimensionPreviewTable.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { isValid } from 'date-fns';
 
 import Table from '../../../shared/views/components/Table';
 import { ColumnHeader, ViewDTO } from '../../../shared/dtos/view-dto';
 import { useLocals } from '../../../shared/views/context/Locals';
 import T from '../../../shared/views/components/T';
 import { SingleLanguageDimension } from '../../../shared/dtos/single-language/dimension';
+import { DimensionType } from '../../../shared/enums/dimension-type';
 import { SourceType } from '../../../shared/enums/source-type';
 import { dateFormat } from '../../../shared/utils/date-format';
 
@@ -22,6 +22,11 @@ export type DimensionPreviewTableProps = {
 
 export default function DimensionPreviewTable(props: DimensionPreviewTableProps) {
   const { i18n } = useLocals();
+  // Only typed date dimensions are guaranteed by the backend to return ISO-formatted date strings.
+  // For other dimension types (e.g. lookup_table), `start_date`/`end_date` columns are user-supplied
+  // and may contain ambiguous formats like `DD/MM/YYYY` that JS would misinterpret as US dates.
+  const isTypedDateDimension =
+    props.dimension.type === DimensionType.Date || props.dimension.type === DimensionType.DatePeriod;
   const columns = props.headers.map((heading, index) => ({
     key: index,
     label:
@@ -44,13 +49,8 @@ export default function DimensionPreviewTable(props: DimensionPreviewTableProps)
       if (heading.source_type === 'line_number') {
         return <span className="linespan">{value}</span>;
       }
-      switch (heading.name) {
-        case 'start_date':
-        case 'end_date': {
-          const date = new Date(value);
-          if (!isValid(date)) return value;
-          return dateFormat(date, 'do MMMM yyyy', { utc: true, locale: i18n.language });
-        }
+      if (isTypedDateDimension && (heading.name === 'start_date' || heading.name === 'end_date')) {
+        return dateFormat(value, 'do MMMM yyyy', { utc: true, locale: i18n.language });
       }
       return value;
     },

--- a/src/publisher/views/components/MeasurePreviewTable.tsx
+++ b/src/publisher/views/components/MeasurePreviewTable.tsx
@@ -21,7 +21,7 @@ export default function MeasurePreviewTable(props: MeasurePreviewTableProps) {
       switch (col.name.toLowerCase()) {
         case 'start_date':
         case 'end_date': {
-          return dateFormat(new Date(value), 'do MMMM yyyy', { utc: true, locale: i18n.language });
+          return dateFormat(value, 'do MMMM yyyy', { utc: true, locale: i18n.language });
         }
         case 'date_type': {
           return <T>publish.measure_review.year_type.{value}</T>;

--- a/src/publisher/views/publish/date-chooser.jsx
+++ b/src/publisher/views/publish/date-chooser.jsx
@@ -35,7 +35,7 @@ export default function DateChooser(props) {
           }
         case 'start_date':
         case 'end_date':
-          return dateFormat(new Date(value), 'do MMMM yyyy', {
+          return dateFormat(value, 'do MMMM yyyy', {
             locale: props.i18n.language,
             utc: true
           });

--- a/src/shared/utils/date-format.ts
+++ b/src/shared/utils/date-format.ts
@@ -19,7 +19,7 @@ export const dateFormat = (
 ): string => {
   if (date == null || date === '') return '';
 
-  const tzDate = new TZDate(date as Date, options?.utc ? 'UTC' : 'Europe/London');
+  const tzDate = new TZDate(date instanceof Date ? date : new Date(date), options?.utc ? 'UTC' : 'Europe/London');
   if (!isValid(tzDate)) {
     return typeof date === 'string' ? date : '';
   }

--- a/src/shared/utils/date-format.ts
+++ b/src/shared/utils/date-format.ts
@@ -1,5 +1,5 @@
 import { TZDate } from '@date-fns/tz';
-import { FormatOptions, DateArg, format } from 'date-fns';
+import { FormatOptions, DateArg, format, isValid } from 'date-fns';
 import { cy, enGB } from 'date-fns/locale';
 
 import { Locale } from '../enums/locale';
@@ -10,8 +10,19 @@ interface DateFormatOptions extends Omit<FormatOptions, 'locale'> {
   utc?: boolean;
 }
 
-export const dateFormat = (date: DateArg<Date> & {}, formatStr: string, options?: DateFormatOptions): string => {
+// Returns the raw input (or '') when the value isn't a valid date, so callers can safely pass through
+// user-supplied strings (e.g. lookup table values) without crashing the render.
+export const dateFormat = (
+  date: DateArg<Date> | null | undefined,
+  formatStr: string,
+  options?: DateFormatOptions
+): string => {
+  if (date == null || date === '') return '';
+
   const tzDate = new TZDate(date as Date, options?.utc ? 'UTC' : 'Europe/London');
+  if (!isValid(tzDate)) {
+    return typeof date === 'string' ? date : '';
+  }
 
   const formatOptions: FormatOptions = {
     ...options,

--- a/tests/utils/date-format.test.ts
+++ b/tests/utils/date-format.test.ts
@@ -1,0 +1,53 @@
+import { dateFormat } from '../../src/shared/utils/date-format';
+
+describe('dateFormat', () => {
+  describe('valid inputs', () => {
+    it('formats an ISO date string', () => {
+      expect(dateFormat('2024-03-15T00:00:00Z', 'd MMMM yyyy', { utc: true })).toBe('15 March 2024');
+    });
+
+    it('formats a Date object', () => {
+      expect(dateFormat(new Date('2024-03-15T00:00:00Z'), 'd MMMM yyyy', { utc: true })).toBe('15 March 2024');
+    });
+
+    it('formats a numeric timestamp', () => {
+      expect(dateFormat(Date.UTC(2024, 2, 15), 'd MMMM yyyy', { utc: true })).toBe('15 March 2024');
+    });
+
+    it('applies the Welsh locale when `cy` is passed', () => {
+      expect(dateFormat('2024-03-15T00:00:00Z', 'MMMM', { utc: true, locale: 'cy-GB' })).toBe('Mawrth');
+    });
+  });
+
+  describe('nullish / empty inputs', () => {
+    it('returns an empty string for null', () => {
+      expect(dateFormat(null, 'd MMMM yyyy')).toBe('');
+    });
+
+    it('returns an empty string for undefined', () => {
+      expect(dateFormat(undefined, 'd MMMM yyyy')).toBe('');
+    });
+
+    it('returns an empty string for an empty string', () => {
+      expect(dateFormat('', 'd MMMM yyyy')).toBe('');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns the raw string for an unparseable date string', () => {
+      expect(dateFormat('30/09/2025', 'd MMMM yyyy')).toBe('30/09/2025');
+    });
+
+    it('returns the raw string for a nonsense date string', () => {
+      expect(dateFormat('not a date', 'd MMMM yyyy')).toBe('not a date');
+    });
+
+    it('returns an empty string for an Invalid Date object', () => {
+      expect(dateFormat(new Date('not a date'), 'd MMMM yyyy')).toBe('');
+    });
+
+    it('returns an empty string for NaN', () => {
+      expect(dateFormat(NaN, 'd MMMM yyyy')).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
If a user provides their own lookup for dates that includes the column headings "start_date" or "end_date" and a non-expected date format like "DD/MM/YYYY" the dateFormat() function throws an exception and the user gets a 500 page.

This adds a guard against bad formats and just replays the value as a plain string if it can't be parsed as a date.