### PR TITLE
SW-1235 e2e: preview link regression guard in update journey

### DIFF
--- a/tests-e2e/publish/preview-without-data.spec.ts
+++ b/tests-e2e/publish/preview-without-data.spec.ts
@@ -31,5 +31,32 @@ test.describe('Preview without data table', () => {
         page.getByText('You cannot preview this dataset until you have uploaded a data table')
       ).toBeVisible();
     });
+
+    test('Clicking the tasklist preview link before uploading data shows the not-found page', async ({
+      page,
+      context
+    }) => {
+      // Create a new dataset, navigate away, then return via the tasklist and use the sidebar link —
+      // i.e. the path a user would actually take, not a direct URL hit.
+      const altTitle = `${title} - via-tasklist`;
+      await startNewDataset(page);
+      await selectUserGroup(page, 'E2E tests');
+      const altDatasetId = await provideDatasetTitle(page, altTitle);
+
+      await page.goto(`${baseUrl}/en-GB`);
+      await page.goto(`${baseUrl}/en-GB/publish/${altDatasetId}/tasklist`);
+
+      const pagePromise = context.waitForEvent('page');
+      await page.getByRole('link', { name: 'Preview (opens in new tab)' }).click();
+      const previewPage = await pagePromise;
+      await previewPage.waitForLoadState('load');
+
+      expect(previewPage.url()).toContain(`${baseUrl}/en-GB/publish/${altDatasetId}/cube-preview`);
+      await expect(previewPage.getByRole('heading', { name: 'Page not found' })).toBeVisible();
+      await expect(
+        previewPage.getByText('You cannot preview this dataset until you have uploaded a data table')
+      ).toBeVisible();
+      await previewPage.close();
+    });
   });
 });

--- a/tests-e2e/publish/update-dataset.spec.ts
+++ b/tests-e2e/publish/update-dataset.spec.ts
@@ -50,6 +50,19 @@ test.describe('Update dataset', () => {
       await expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${datasetId}/tasklist`);
     });
 
+    test('Preview the dataset before any changes are made to the update', async ({ page, context }) => {
+      // regression guard (SW-1235): the draft revision has no data table yet, so the preview must
+      // fall back to the previously-published revision rather than 404.
+      await page.goto(`/en-GB/publish/${datasetId}/tasklist`);
+      const pagePromise = context.waitForEvent('page');
+      await page.getByRole('link', { name: 'Preview (opens in new tab)' }).click();
+      const previewPage = await pagePromise;
+      await previewPage.waitForLoadState('load');
+      expect(previewPage.url()).toContain(`${baseUrl}/en-GB/publish/${datasetId}/cube-preview`);
+      await expect(previewPage.getByText('This is a preview of this dataset.')).toBeVisible();
+      await previewPage.close();
+    });
+
     test('Update the dataset', async ({ page }, testInfo) => {
       await page.goto(`/en-GB/publish/${datasetId}/tasklist`);
       await page.getByRole('link', { name: 'Data table' }).click();
@@ -67,6 +80,17 @@ test.describe('Update dataset', () => {
       await completeUpdateReason(page, datasetId, 'Adding new data for the latest period.');
       await completeTranslations(page, testInfo, datasetId);
       await completePublicationDate(page, datasetId, 1);
+    });
+
+    test('Preview the dataset after updating the data, before submission', async ({ page, context }) => {
+      await page.goto(`/en-GB/publish/${datasetId}/tasklist`);
+      const pagePromise = context.waitForEvent('page');
+      await page.getByRole('link', { name: 'Preview (opens in new tab)' }).click();
+      const previewPage = await pagePromise;
+      await previewPage.waitForLoadState('load');
+      expect(previewPage.url()).toContain(`${baseUrl}/en-GB/publish/${datasetId}/cube-preview`);
+      await expect(previewPage.getByText('This is a preview of this dataset.')).toBeVisible();
+      await previewPage.close();
     });
 
     test('Submit dataset for approval', async ({ page }) => {

--- a/tests-e2e/publish/update-dataset.spec.ts
+++ b/tests-e2e/publish/update-dataset.spec.ts
@@ -50,7 +50,7 @@ test.describe('Update dataset', () => {
       await expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${datasetId}/tasklist`);
     });
 
-    test('Preview the dataset before any changes are made to the update', async ({ page, context }) => {
+    test('Preview the dataset before any data is uploaded to the update', async ({ page, context }) => {
       // regression guard (SW-1235): the draft revision has no data table yet, so the preview must
       // fall back to the previously-published revision rather than 404.
       await page.goto(`/en-GB/publish/${datasetId}/tasklist`);


### PR DESCRIPTION
## Summary

Adds regression coverage in the update-dataset e2e journey for SW-1235 ("You cannot preview this dataset until you have uploaded a data table" on an untouched update). Pairs with the backend fix in `statswales-backend#649`.

Two checkpoints were added to `tests-e2e/publish/update-dataset.spec.ts`, both driven from the tasklist sidebar's "Preview (opens in new tab)" link (the same path a real user follows):

- After `Start the update`, before any data is uploaded — this is the exact state that 404'd. Fails without the backend fix.
- After `Update the dataset`, before `Submit dataset for approval` — guards the post-upload case where the draft has its own data table.

## Test plan

- [x] `npx playwright test tests-e2e/publish/update-dataset.spec.ts --project=publish` — 45 passed (new tests: 336ms and 290ms).
- [x] `npm run check` passes locally.
