### PR TITLE
SW-1227 Show hierarchy error message

### DIFF
--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -1031,7 +1031,8 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
             throw new Error();
           }
 
-          if (!(body.extension as { mismatch: boolean }).mismatch) {
+          const hasMismatch = (body?.extension as { mismatch?: boolean } | undefined)?.mismatch === true;
+          if (!hasMismatch) {
             errors = [{ field: 'csv', message: { key: body?.errors?.[0]?.message?.key } }];
             throw new Error();
           }

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -1047,7 +1047,7 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
           return;
         }
 
-        res.status(500);
+        res.status(error.status || 500);
         if (error.status === 500 && body?.errors?.[0]?.message?.key?.includes('lookup_table_loading_failed')) {
           const failurePreview = body as ViewErrDTO;
           res.render('publish/dimension-match-failure', {

--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -1015,20 +1015,24 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
         return;
       } catch (err) {
         const error = err as ApiException;
-        res.status(error.status);
         const body = JSON.parse((error.body as string) || '{}');
 
         if (body?.error?.includes('infected')) {
-          errors = [{ field: 'csv', message: { key: `publish.upload.errors.infected` } }];
           res.status(400);
+          errors = [{ field: 'csv', message: { key: `publish.upload.errors.infected` } }];
           throw new Error();
         }
 
         if (error.status === 400) {
+          res.status(error.status);
           if (body?.errors?.[0]?.message?.key?.includes('primary_key_failed')) {
             logger.error('Lookup table has duplicate rows');
             errors = [{ field: 'csv', message: { key: `errors.dimension_validation.primary_key_failed` } }];
-            res.status(400);
+            throw new Error();
+          }
+
+          if (!(body.extension as { mismatch: boolean }).mismatch) {
+            errors = [{ field: 'csv', message: { key: body?.errors?.[0]?.message?.key } }];
             throw new Error();
           }
 
@@ -1043,6 +1047,7 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
           return;
         }
 
+        res.status(500);
         if (error.status === 500 && body?.errors?.[0]?.message?.key?.includes('lookup_table_loading_failed')) {
           const failurePreview = body as ViewErrDTO;
           res.render('publish/dimension-match-failure', {
@@ -1054,7 +1059,6 @@ export const uploadLookupTable = async (req: Request, res: Response, next: NextF
         }
 
         logger.error(error, 'Something went wrong other than not matching');
-        res.status(500);
         errors = [{ field: 'unknown', message: { key: 'errors.dimension_validation.unknown_error' } }];
         throw new Error();
       }

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1576,6 +1576,9 @@
       "some_references_failed_to_match": "Ni ellir cyfateb y tabl am-edrych mesur gyda'r tabl data. Gwiriwch eich bod wedi lanlwytho'r tabl am-edrych cywir a bod eich tabl data yn gywir.",
       "unknown_error": "Nid oedd modd i'r system ychwanegu'r tabl am-edrych mesur i'r ciwb. Rhowch gynnig arall yn nes ymlaen neu cysylltwch â'r tîm cymorth."
     },
+    "lookup_table_validation": {
+      "bad_hierarchy": "Mae'r hierarchaeth yn y chwiliad yn anghyflawn neu'n cynnwys gwallau cyfeirio"
+    },
     "file_validation": {
       "invalid_decimals_present": "Dim ond gwerthoedd cyfanrifol cadarnhaol ddylai fod yn y golofn ddegol yn y tabl am-edrych mesur. Cywirwch y tabl am-edrych mesur a'i lanlwytho eto.",
       "wrong_data_type_in_reference": "Ni ellir cyfateb y tabl am-edrych gyda'r tabl data. Gwiriwch eich bod wedi lanlwytho'r tabl am-edrych cywir a bod eich tabl data yn gywir.",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1623,6 +1623,9 @@
       "some_references_failed_to_match": "Lookup table cannot be matched to the data table. Check you uploaded the correct lookup table and that your data table is correct.",
       "unknown_error": "Measure lookup table could not be added to the cube by the system. Try again later or contact support."
     },
+    "lookup_table_validation": {
+      "bad_hierarchy": "The hierarchy in the lookup is incomplete or contains reference errors"
+    },
     "file_validation": {
       "invalid_decimals_present": "The decimal column in the measure lookup table should only contain positive integer values. Correct the measure lookup table and upload it again.",
       "wrong_data_type_in_reference": "Lookup table cannot be matched to the data table. Check you uploaded the correct lookup table and that your data table is correct.",


### PR DESCRIPTION
All errors on lookups were showing the mismatch screen.  This wasn't quite right as some other errors can come out of the upload of a lookup including the new hierarchy error message.  Quick change to handle errors on lookups in a similar way to measure lookup uploads.