### PR TITLE
SW-1262 Align sort select correctly according to GEL

### DIFF
--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -89,7 +89,7 @@ function Sort(props) {
   return (
     <>
       <form id="sort-form" className="govuk-!-margin-bottom-6" method="GET">
-        <div className="govuk-form-group">
+        <div className="govuk-form-group govuk-form-select-inline">
           <label className="govuk-label" htmlFor="sort-by">
             <T>consumer.topic_list.sort.label</T>
           </label>

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -605,6 +605,16 @@
     display: inline-block;
   }
 
+  .govuk-form-select-inline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .govuk-form-select-inline > label {
+    margin-right: 1em;
+  }
+
   .govuk-error-message {
     font-weight: normal;
     color: colours.$black;


### PR DESCRIPTION
GEL requires select boxes to be inline and aligned to the middle.  This adjust the CSS on the sort by select to meet this criteria.

Before:
<img width="1411" height="1197" alt="Screenshot 2026-05-07 at 10 55 28" src="https://github.com/user-attachments/assets/b7aff6ec-edae-4884-8cda-428a13b3c3e6" />

After
<img width="1411" height="1197" alt="Screenshot 2026-05-07 at 10 55 57" src="https://github.com/user-attachments/assets/da6f9d24-9b7a-4545-b9bf-5293ffad97fe" />
