### PR TITLE
SW-1260 change filter notification to be highlight

### DIFF
--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -671,7 +671,7 @@
     padding: 25px 30px;
   }
 
-  .govuk-inset-text.highlight {
+  .govuk-inset-text--highlight {
     border-left: 10px solid colours.$yellow;
     background: colours.$paleyellow;
   }

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -674,6 +674,8 @@
   .govuk-inset-text--highlight {
     border-left: 10px solid colours.$yellow;
     background: colours.$paleyellow;
+    color: colours.$black;
+    padding: 25px 30px;
   }
 
   .govuk-radios--small .govuk-radios__item {

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -674,10 +674,6 @@
   .govuk-inset-text--highlight {
     border-left: 10px solid colours.$yellow;
     background: colours.$paleyellow;
-    color: colours.$black;
-    padding: 25px 30px;
-    color: colours.$black;
-    padding: 25px 30px;
   }
 
   .govuk-radios--small .govuk-radios__item {

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -676,6 +676,8 @@
     background: colours.$paleyellow;
     color: colours.$black;
     padding: 25px 30px;
+    color: colours.$black;
+    padding: 25px 30px;
   }
 
   .govuk-radios--small .govuk-radios__item {

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -671,6 +671,11 @@
     padding: 25px 30px;
   }
 
+  .govuk-inset-text.highlight {
+    border-left: 10px solid colours.$yellow;
+    background: colours.$paleyellow;
+  }
+
   .govuk-radios--small .govuk-radios__item {
     margin-bottom: 10px;
   }

--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -35,13 +35,13 @@ export const Filters = (props: FiltersProps) => {
       <h2 className="govuk-heading-m">{title}</h2>
 
       {isPivot && (
-        <div className="govuk-inset-text highlight">
+        <div className="govuk-inset-text--highlight">
           <T>filters.pivot_hidden_notice</T>
         </div>
       )}
 
       {disabled && (
-        <div className="govuk-inset-text highlight">
+        <div className="govuk-inset-text--highlight">
           <T>filters.disabled_filters_notice</T>
         </div>
       )}

--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -35,13 +35,13 @@ export const Filters = (props: FiltersProps) => {
       <h2 className="govuk-heading-m">{title}</h2>
 
       {isPivot && (
-        <div className="govuk-inset-text">
+        <div className="govuk-inset-text highlight">
           <T>filters.pivot_hidden_notice</T>
         </div>
       )}
 
       {disabled && (
-        <div className="govuk-inset-text">
+        <div className="govuk-inset-text highlight">
           <T>filters.disabled_filters_notice</T>
         </div>
       )}

--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -35,13 +35,13 @@ export const Filters = (props: FiltersProps) => {
       <h2 className="govuk-heading-m">{title}</h2>
 
       {isPivot && (
-        <div className="govuk-inset-text--highlight">
+        <div className="govuk-inset-text govuk-inset-text--highlight">
           <T>filters.pivot_hidden_notice</T>
         </div>
       )}
 
       {disabled && (
-        <div className="govuk-inset-text--highlight">
+        <div className="govuk-inset-text govuk-inset-text--highlight">
           <T>filters.disabled_filters_notice</T>
         </div>
       )}


### PR DESCRIPTION
GEL feedback say this should be in the highlight style specified in the GEL.  So made the switch by adding an extra CSS to class to change this.

Before:
<img width="1411" height="1197" alt="Screenshot 2026-05-07 at 10 56 10" src="https://github.com/user-attachments/assets/6153787e-6551-49fb-83c1-b21f890c0794" />

After:
<img width="1411" height="1197" alt="Screenshot 2026-05-07 at 10 57 01" src="https://github.com/user-attachments/assets/21ab8339-de1d-49f3-be79-594385b043a4" />
