### PR TITLE
SW-1258 Update cookie banner to GEL

### DIFF
--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -16,8 +16,16 @@
     display: inline;
   }
 
-  .cookie-banner {
+  #cookie-banner {
     padding-top: 20px;
+    background-color: #eaeaea;
+  }
+
+  #cookies-accept-all,
+  #cookieOptions {
+    background-color: transparent;
+    border: solid #0b4b95 3px;
+    color: #0b4b95;
   }
 
   h1,

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -18,14 +18,14 @@
 
   #cookie-banner {
     padding-top: 20px;
-    background-color: #eaeaea;
+    background-color: colours.$lightgrey_semi;
   }
 
   #cookies-accept-all:not(:focus),
   #cookieOptions:not(:focus) {
     background-color: transparent;
-    border: solid #0b4b95 3px;
-    color: #0b4b95;
+    border: solid colours.$blue 3px;
+    color: colours.$blue;
   }
 
   h1,

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -21,8 +21,8 @@
     background-color: #eaeaea;
   }
 
-  #cookies-accept-all,
-  #cookieOptions {
+  #cookies-accept-all:not(:focus),
+  #cookieOptions:not(:focus) {
     background-color: transparent;
     border: solid #0b4b95 3px;
     color: #0b4b95;

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -22,11 +22,20 @@
     background-color: colours.$lightgrey_semi;
   }
 
-  #cookies-accept-all:not(:focus),
-  #cookieOptions:not(:focus) {
+  #cookies-accept-all,
+  #cookieOptions {
     background-color: transparent;
-    border: solid colours.$blue 3px;
+    border: solid colours.$blue 2px;
     color: colours.$blue;
+    padding: 10px 20px;
+  }
+
+  #cookies-accept-all:active,
+  #cookieOptions:active {
+    background-color: colours.$yellow;
+    border: solid colours.$black 2px;
+    color: colours.$black;
+    padding: 10px 20px;
   }
 
   h1,

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -35,7 +35,6 @@
     background-color: colours.$yellow;
     border: solid colours.$black 2px;
     color: colours.$black;
-    padding: 10px 20px;
   }
 
   h1,

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -17,6 +17,7 @@
   }
 
   #cookie-banner {
+    display: flow-root;
     padding-top: 20px;
     background-color: colours.$lightgrey_semi;
   }

--- a/src/shared/views/components/CookieBanner.tsx
+++ b/src/shared/views/components/CookieBanner.tsx
@@ -9,7 +9,7 @@ export default function CookieBanner() {
 
   return (
     <div id="cookie-banner">
-      <div className="cookie-banner container-fluid">
+      <div className="container-fluid">
         <p className="govuk-body">
           <T>cookies.banner.required.summary</T>
         </p>

--- a/src/shared/views/components/CookieBanner.tsx
+++ b/src/shared/views/components/CookieBanner.tsx
@@ -8,31 +8,33 @@ export default function CookieBanner() {
   if (!showCookieBanner) return null;
 
   return (
-    <div id="cookie-banner" className="cookie-banner container-fluid">
-      <p className="govuk-body">
-        <T>cookies.banner.required.summary</T>
-      </p>
+    <div id="cookie-banner">
+      <div className="cookie-banner container-fluid">
+        <p className="govuk-body">
+          <T>cookies.banner.required.summary</T>
+        </p>
 
-      <p className="govuk-body">
-        <T>cookies.banner.optional.summary</T>
-      </p>
+        <p className="govuk-body">
+          <T>cookies.banner.optional.summary</T>
+        </p>
 
-      <form id="cookie-banner-form" action={buildUrl('/cookies', i18n.language)} method="post">
-        <input type="hidden" name="acceptAll" value="true" />
+        <form id="cookie-banner-form" action={buildUrl('/cookies', i18n.language)} method="post">
+          <input type="hidden" name="acceptAll" value="true" />
 
-        <div className="govuk-button-group">
-          <button id="cookies-accept-all" className="govuk-button govuk-button--secondary">
-            <T>cookies.banner.buttons.accept_all</T>
-          </button>
-          <a
-            id="cookieOptions"
-            className="govuk-button govuk-button--secondary"
-            href={buildUrl('/cookies', i18n.language)}
-          >
-            <T>cookies.banner.buttons.change_settings</T>
-          </a>
-        </div>
-      </form>
+          <div className="govuk-button-group">
+            <button id="cookies-accept-all" className="govuk-button govuk-button--secondary">
+              <T>cookies.banner.buttons.accept_all</T>
+            </button>
+            <a
+              id="cookieOptions"
+              className="govuk-button govuk-button--secondary"
+              href={buildUrl('/cookies', i18n.language)}
+            >
+              <T>cookies.banner.buttons.change_settings</T>
+            </a>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The cookie banner needed to be updated slightly to use the new GEL styling.  The buttons need to change and the background needed to be a subtle grey which spanned the whole of the top.

<img width="2255" height="366" alt="Screenshot 2026-05-11 at 5 35 52 pm" src="https://github.com/user-attachments/assets/36faede1-2b75-424a-b2dc-2b4b5af5e61b" />
