### PR TITLE
SW-1261 Update small button hover state

### DIFF
--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -205,10 +205,12 @@
     &:hover:not(:focus) {
       background: colours.$darkgrey;
       border: 2px colours.$darkgrey solid;
+      color: colours.$white;
     }
 
     &:hover:focus {
       background: colours.$darkgrey;
+      color: colours.$white;
     }
   }
 

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -202,13 +202,7 @@
   }
 
   .govuk-button-small {
-    &:hover:not(:focus) {
-      background: colours.$darkgrey;
-      border-color: colours.$darkgrey;
-      color: colours.$white;
-    }
-
-    &:hover:focus {
+    &:hover {
       background: colours.$darkgrey;
       border-color: colours.$darkgrey;
       color: colours.$white;

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -201,9 +201,15 @@
     }
   }
 
-  .govuk-button-small:hover {
-    background: colours.$darkgrey;
-    border: 2px colours.$darkgrey solid;
+  .govuk-button-small {
+    &:hover:not(:focus) {
+      background: colours.$darkgrey;
+      border: 2px colours.$darkgrey solid;
+    }
+
+    &:hover:focus {
+      background: colours.$darkgrey;
+    }
   }
 
   .button-black {

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -204,12 +204,13 @@
   .govuk-button-small {
     &:hover:not(:focus) {
       background: colours.$darkgrey;
-      border: colours.$darkgrey;
+      border-color: colours.$darkgrey;
       color: colours.$white;
     }
 
     &:hover:focus {
       background: colours.$darkgrey;
+      border-color: colours.$darkgrey;
       color: colours.$white;
     }
   }

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -204,7 +204,7 @@
   .govuk-button-small {
     &:hover:not(:focus) {
       background: colours.$darkgrey;
-      border: 2px colours.$darkgrey solid;
+      border: colours.$darkgrey;
       color: colours.$white;
     }
 

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -201,6 +201,11 @@
     }
   }
 
+  .govuk-button-small:hover {
+    background: colours.$darkgrey;
+    border: 2px colours.$darkgrey solid;
+  }
+
   .button-black {
     background-color: colours.$black;
     border-color: colours.$black;


### PR DESCRIPTION
The GEL team have asked us to update the hoverstate so that the visible border is removed and the background is changed to darkgrey.

<img width="421" height="117" alt="Screenshot 2026-05-12 at 10 29 26" src="https://github.com/user-attachments/assets/8a960df5-f706-4d5f-918c-4fdbb6dd64b2" />
