### PR TITLE
SW-1260 Change back the notice when disabled filters

### DIFF
--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -41,7 +41,7 @@ export const Filters = (props: FiltersProps) => {
       )}
 
       {disabled && (
-        <div className="govuk-inset-text govuk-inset-text--highlight">
+        <div className="govuk-inset-text">
           <T>filters.disabled_filters_notice</T>
         </div>
       )}


### PR DESCRIPTION
The disabled filters notice should have remained a normal callout.  This changes this notice back rather than making it a highlight.