### PR TITLE
SW-1276: add a hint explaining that auto redirect also hides the dataset from search / topics

### DIFF
--- a/src/publisher/views/publish/task/ReplacementDatasetPicker.jsx
+++ b/src/publisher/views/publish/task/ReplacementDatasetPicker.jsx
@@ -45,10 +45,14 @@ export default function ReplacementDatasetPicker(props) {
               type="checkbox"
               value="true"
               defaultChecked={props.values?.auto_redirect === 'true' || props.values?.auto_redirect === true}
+              aria-describedby="auto-redirect-item-hint"
             />
             <label className="govuk-label govuk-checkboxes__label" htmlFor="auto-redirect">
               <T>publish.task.action.archive.form.auto_redirect.label</T>
             </label>
+            <div id="auto-redirect-item-hint" className="govuk-hint govuk-checkboxes__hint">
+              <T>publish.task.action.archive.form.auto_redirect.hint</T>
+            </div>
           </div>
         </div>
       </div>

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1228,7 +1228,8 @@
               }
             },
             "auto_redirect": {
-              "label": "Ailgyfeirio ymwelwyr yn awtomatig i’r set ddata newydd yn ei lle"
+              "label": "Ailgyfeirio ymwelwyr yn awtomatig i’r set ddata newydd yn ei lle",
+              "hint": "Bydd ticio hwn hefyd yn cuddio’r set ddata hon o ganlyniadau chwilio a rhestrau pynciau."
             }
           },
           "success": "Gwnaethpwyd cais i archifo’r set ddata",

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1229,7 +1229,7 @@
             },
             "auto_redirect": {
               "label": "Ailgyfeirio ymwelwyr yn awtomatig i’r set ddata newydd yn ei lle",
-              "hint": "Bydd ticio hwn hefyd yn cuddio’r set ddata hon o ganlyniadau chwilio a rhestrau pynciau."
+              "hint": "Bydd ticio hyn hefyd yn cuddio’r set ddata hon o ganlyniadau chwilio a rhestrau pwnc."
             }
           },
           "success": "Gwnaethpwyd cais i archifo’r set ddata",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1276,7 +1276,8 @@
               }
             },
             "auto_redirect": {
-              "label": "Automatically redirect visitors to the replacement dataset"
+              "label": "Automatically redirect visitors to the replacement dataset",
+              "hint": "Ticking this will also hide this dataset from search results and topic listings."
             }
           },
           "success": "Dataset archiving requested",


### PR DESCRIPTION
https://github.com/Marvell-Consulting/statswales-backend/pull/680 makes it so that datasets that are archived, have a replacement dataset set and auto-redirect enabled are now filtered from the search results and topic listings.

This PR updates the content on the archival form to inform the publisher that this will happen if they tick the auto-redirect checkbox.