### PR TITLE
SW-1278: assert translation export item stays complete after import

### DIFF
--- a/tests-e2e/publish/helpers/publishing-steps.ts
+++ b/tests-e2e/publish/helpers/publishing-steps.ts
@@ -359,6 +359,11 @@ export async function completeTranslations(page: Page, testInfo: TestInfo, datas
   await page.getByRole('link', { name: 'Continue' }).click();
   expect(page.url()).toContain(`${baseUrl}/en-GB/publish/${datasetId}/tasklist`);
   await checkTasklistItemComplete(page, 'Import translations');
+  // SW-1278 — a publisher reported that "Export text fields for translation" reverts
+  // to Incomplete immediately after a successful import. The previous version of this
+  // helper only checked the import item, so a reverted export status would have been
+  // invisible to the publish-dataset spec.
+  await checkTasklistItemComplete(page, 'Export text fields for translation');
 }
 
 export async function completePublicationDate(page: Page, datasetId: string, minutesFromNow: number) {


### PR DESCRIPTION
## Summary

`completeTranslations()` in the publish-dataset Playwright helper previously only asserted that **Import translations** showed Completed after a successful import. The reported bug is the reverse — **Export text fields for translation** flipping back to Incomplete immediately after import — which means the existing assertion would not have caught it.

Added a second assertion right after the existing import check, so a regression of the export status would now fail the publish-dataset spec.

[SW-1278]: https://marvellconsulting.atlassian.net/browse/SW-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ