### PR TITLE
SW-541 Add Jest coverage thresholds

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -22,6 +22,15 @@ const config: Config = {
     '/src/controllers/datalake.ts',
     '/src/config/envs/'
   ],
+  // Thresholds set ~2% below current coverage to prevent regression. See #541.
+  coverageThreshold: {
+    global: {
+      statements: 35,
+      branches: 19,
+      functions: 24,
+      lines: 33
+    }
+  },
   setupFiles: ['<rootDir>/tests/.jest/set-env-vars.ts']
 };
 


### PR DESCRIPTION
Closes #541.

Adds Jest `coverageThreshold` configuration so CI fails if test coverage drops below current levels.

## Thresholds

Set ~2% below current coverage per the recommendation in #541:

| Metric | Current | Threshold |
|---|---|---|
| Statements | 37.17% | 35 |
| Branches | 21.35% | 19 |
| Functions | 26.45% | 24 |
| Lines | 35.11% | 33 |

Coverage has risen modestly since #541 was filed (e.g. statements 34.15% → 37.17%), so the new floors are higher than the numbers in the original issue.

## Enforcement

`collectCoverage: true` is already set in `jest.config.ts`, so every `npm test` run — locally and in CI — enforces the thresholds. No CI workflow changes required.
