### PR TITLE
SW-542: add util tests + fix two bugs they uncovered

### DIFF
--- a/src/shared/utils/parse-page-options.ts
+++ b/src/shared/utils/parse-page-options.ts
@@ -6,8 +6,13 @@ import { parseSortBy } from '../interfaces/sort-by';
 export const DEFAULT_PAGE_SIZE = 25;
 
 export const parsePageOptions = (req: Request) => {
-  const pageNumber = Number.parseInt(req.query.page_number as string, 10) || 1;
-  const pageSize = Number.parseInt(req.query.page_size as string, 10) || DEFAULT_PAGE_SIZE;
+  // `parseInt(x, 10) > 0` rejects NaN, zero and negatives in one check.
+  const parsedPage = Number.parseInt(req.query.page_number as string, 10);
+  const pageNumber = parsedPage > 0 ? parsedPage : 1;
+
+  const parsedSize = Number.parseInt(req.query.page_size as string, 10);
+  const pageSize = parsedSize > 0 ? parsedSize : DEFAULT_PAGE_SIZE;
+
   const query = qs.parse(req.originalUrl.split('?')[1]);
   const sortBy = parseSortBy(query.sort_by);
 

--- a/src/shared/utils/walk-object.ts
+++ b/src/shared/utils/walk-object.ts
@@ -19,17 +19,17 @@ export const isObject = (item: unknown) => {
 export const walkObject = (root: UnknownObject, fn: WalkObjectCallback) => {
   const walk = (obj: UnknownObject, location: (string | number)[] = []) => {
     Object.keys(obj).forEach((key) => {
-      // Value is an array, call walk on each item in the array
+      // Value is an array; emit each item and recurse only when the item is itself a branch
       if (Array.isArray(obj[key])) {
         obj[key].forEach((el, j) => {
-          fn({
-            value: el,
-            key: `${key}:${j}`,
-            location: [...location, ...[key], ...[j]],
-            isLeaf: false
-          });
-
-          walk(el, [...location, ...[key], ...[j]]);
+          const childLocation = [...location, key, j];
+          const childKey = `${key}:${j}`;
+          if (isObject(el) || Array.isArray(el)) {
+            fn({ value: el, key: childKey, location: childLocation, isLeaf: false });
+            walk(el as UnknownObject, childLocation);
+          } else {
+            fn({ value: el, key: childKey, location: childLocation, isLeaf: true });
+          }
         });
 
         // Value is an object, walk the keys of the object

--- a/tests/utils/download-filename.test.ts
+++ b/tests/utils/download-filename.test.ts
@@ -1,0 +1,60 @@
+import { SingleLanguageRevision } from '../../src/shared/dtos/single-language/revision';
+import { getDownloadFilename } from '../../src/shared/utils/download-filename';
+
+const baseRevision = (overrides: Partial<SingleLanguageRevision> = {}): SingleLanguageRevision =>
+  ({
+    id: 'rev-1',
+    revision_index: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: 'user-1',
+    metadata: { title: 'Welsh Health Stats' },
+    ...overrides
+  }) as SingleLanguageRevision;
+
+describe('getDownloadFilename', () => {
+  it('uses v<index> format for published revisions (revision_index > 0)', () => {
+    const filename = getDownloadFilename('dataset-id', baseRevision({ revision_index: 3 }), 'en-GB');
+    expect(filename).toBe('Welsh Health Stats-v3-en-GB');
+  });
+
+  it('labels the initial revision as v1 (per domain rule: initial revision_index = 1)', () => {
+    const filename = getDownloadFilename('dataset-id', baseRevision({ revision_index: 1 }), 'en-GB');
+    expect(filename).toBe('Welsh Health Stats-v1-en-GB');
+  });
+
+  it('labels draft revisions (revision_index = 0) as "draft"', () => {
+    const filename = getDownloadFilename('dataset-id', baseRevision({ revision_index: 0 }), 'en-GB');
+    expect(filename).toBe('Welsh Health Stats-draft-en-GB');
+  });
+
+  it('includes the language code verbatim', () => {
+    const filename = getDownloadFilename('dataset-id', baseRevision({ revision_index: 2 }), 'cy-GB');
+    expect(filename).toBe('Welsh Health Stats-v2-cy-GB');
+  });
+
+  it('falls back to the dataset id when metadata is undefined', () => {
+    const filename = getDownloadFilename('abc-123', baseRevision({ revision_index: 1, metadata: undefined }), 'en-GB');
+    expect(filename).toBe('abc-123-v1-en-GB');
+  });
+
+  it('falls back to the dataset id when metadata.title is undefined', () => {
+    const filename = getDownloadFilename(
+      'abc-123',
+      baseRevision({ revision_index: 1, metadata: { title: undefined } as never }),
+      'en-GB'
+    );
+    expect(filename).toBe('abc-123-v1-en-GB');
+  });
+
+  it('returns the title verbatim — sanitisation is handled downstream by getDownloadHeaders/slugify', () => {
+    // The function intentionally does not sanitise; it just composes the name.
+    // Downstream `getDownloadHeaders` runs slugify on the result.
+    const filename = getDownloadFilename(
+      'dataset-id',
+      baseRevision({ revision_index: 1, metadata: { title: 'Q1 2026 / Q2 2026' } as never }),
+      'en-GB'
+    );
+    expect(filename).toBe('Q1 2026 / Q2 2026-v1-en-GB');
+  });
+});

--- a/tests/utils/parse-page-options.test.ts
+++ b/tests/utils/parse-page-options.test.ts
@@ -1,0 +1,79 @@
+import { Request } from 'express';
+
+import { DEFAULT_PAGE_SIZE, parsePageOptions } from '../../src/shared/utils/parse-page-options';
+
+const mockReq = (originalUrl: string, query: Record<string, unknown> = {}): Request =>
+  ({ originalUrl, query }) as unknown as Request;
+
+describe('parsePageOptions', () => {
+  it('returns defaults when query string is empty', () => {
+    const result = parsePageOptions(mockReq('/datasets'));
+    expect(result).toEqual({ pageNumber: 1, pageSize: DEFAULT_PAGE_SIZE, sortBy: undefined });
+  });
+
+  it('parses explicit page_number and page_size', () => {
+    const result = parsePageOptions(
+      mockReq('/datasets?page_number=3&page_size=50', { page_number: '3', page_size: '50' })
+    );
+    expect(result.pageNumber).toBe(3);
+    expect(result.pageSize).toBe(50);
+  });
+
+  it('truncates decimal values via parseInt', () => {
+    const result = parsePageOptions(
+      mockReq('/datasets?page_number=2.7&page_size=10.9', { page_number: '2.7', page_size: '10.9' })
+    );
+    expect(result.pageNumber).toBe(2);
+    expect(result.pageSize).toBe(10);
+  });
+
+  it('falls back to defaults for non-numeric values', () => {
+    const result = parsePageOptions(
+      mockReq('/datasets?page_number=abc&page_size=xyz', { page_number: 'abc', page_size: 'xyz' })
+    );
+    expect(result.pageNumber).toBe(1);
+    expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
+  });
+
+  it('falls back to defaults when values are zero (falsy)', () => {
+    const result = parsePageOptions(
+      mockReq('/datasets?page_number=0&page_size=0', { page_number: '0', page_size: '0' })
+    );
+    expect(result.pageNumber).toBe(1);
+    expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
+  });
+
+  it('parses sort_by from the query string in colon format', () => {
+    const result = parsePageOptions(mockReq('/datasets?sort_by=title:asc'));
+    expect(result.sortBy).toEqual({ columnName: 'title', direction: 'ASC' });
+  });
+
+  it('parses sort_by from qs bracket-object notation', () => {
+    const result = parsePageOptions(mockReq('/datasets?sort_by[columnName]=age&sort_by[direction]=DESC'));
+    expect(result.sortBy).toEqual({ columnName: 'age', direction: 'DESC' });
+  });
+
+  it('returns undefined sortBy when sort_by is absent', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_number=2', { page_number: '2' }));
+    expect(result.sortBy).toBeUndefined();
+  });
+
+  it('handles a URL with no query string', () => {
+    // originalUrl.split('?')[1] is undefined here; qs.parse(undefined) should yield {}
+    const result = parsePageOptions(mockReq('/datasets'));
+    expect(result.sortBy).toBeUndefined();
+  });
+
+  // BUG: negative page values pass through because `parseInt('-5', 10) || default`
+  // returns the negative number (it's truthy). These get forwarded to the backend
+  // API verbatim. Failing on purpose to flag the bug.
+  it('clamps negative page_number to 1', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_number=-5', { page_number: '-5' }));
+    expect(result.pageNumber).toBe(1);
+  });
+
+  it('clamps negative page_size to the default', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_size=-10', { page_size: '-10' }));
+    expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
+  });
+});

--- a/tests/utils/parse-page-options.test.ts
+++ b/tests/utils/parse-page-options.test.ts
@@ -35,7 +35,7 @@ describe('parsePageOptions', () => {
     expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
   });
 
-  it('falls back to defaults when values are zero (falsy)', () => {
+  it('falls back to defaults when values are zero', () => {
     const result = parsePageOptions(
       mockReq('/datasets?page_number=0&page_size=0', { page_number: '0', page_size: '0' })
     );
@@ -64,9 +64,6 @@ describe('parsePageOptions', () => {
     expect(result.sortBy).toBeUndefined();
   });
 
-  // BUG: negative page values pass through because `parseInt('-5', 10) || default`
-  // returns the negative number (it's truthy). These get forwarded to the backend
-  // API verbatim. Failing on purpose to flag the bug.
   it('clamps negative page_number to 1', () => {
     const result = parsePageOptions(mockReq('/datasets?page_number=-5', { page_number: '-5' }));
     expect(result.pageNumber).toBe(1);

--- a/tests/utils/walk-object.test.ts
+++ b/tests/utils/walk-object.test.ts
@@ -81,15 +81,6 @@ describe('walkObject', () => {
     expect(collect({ items: [] })).toEqual([]);
   });
 
-  // BUG: when an array contains primitives, walkObject:
-  //   (a) emits the array entry with isLeaf: false (it should be a leaf), and
-  //   (b) then recurses into the primitive, treating a string like an object
-  //       keyed by character index. For input { tags: ['a'] } the current output
-  //       is two callbacks: {key:'tags:0', isLeaf:false} and {key:'0', isLeaf:true,
-  //       location:['tags', 0, '0']} — both about the same scalar 'a'.
-  // Failing on purpose to flag the bug. The only current caller (`checkConfig`)
-  // doesn't exercise this path because config has no primitive arrays, but the
-  // helper is exported as a generic utility.
   it('emits a single leaf callback for a primitive inside an array', () => {
     const calls = collect({ tags: ['a', 'b'] });
     expect(calls).toEqual([

--- a/tests/utils/walk-object.test.ts
+++ b/tests/utils/walk-object.test.ts
@@ -1,0 +1,100 @@
+import { isObject, walkObject, WalkObjectCallbackArgs } from '../../src/shared/utils/walk-object';
+
+const collect = (root: Parameters<typeof walkObject>[0]): WalkObjectCallbackArgs[] => {
+  const calls: WalkObjectCallbackArgs[] = [];
+  walkObject(root, (args) => calls.push({ ...args }));
+  return calls;
+};
+
+describe('isObject', () => {
+  it('returns true for plain objects', () => {
+    expect(isObject({})).toBe(true);
+    expect(isObject({ a: 1 })).toBe(true);
+  });
+
+  it('returns false for arrays', () => {
+    expect(isObject([])).toBe(false);
+    expect(isObject([1, 2])).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isObject(null)).toBe(false);
+  });
+
+  it('returns false for primitives', () => {
+    expect(isObject('hello')).toBe(false);
+    expect(isObject(42)).toBe(false);
+    expect(isObject(true)).toBe(false);
+    expect(isObject(undefined)).toBe(false);
+  });
+});
+
+describe('walkObject', () => {
+  it('emits a leaf callback for each scalar value with the correct location', () => {
+    const calls = collect({ a: 1, b: 'two' });
+    expect(calls).toEqual([
+      { value: 1, key: 'a', location: ['a'], isLeaf: true },
+      { value: 'two', key: 'b', location: ['b'], isLeaf: true }
+    ]);
+  });
+
+  it('emits a non-leaf callback before recursing into a nested object', () => {
+    const calls = collect({ outer: { inner: 'x' } });
+    expect(calls).toEqual([
+      { value: { inner: 'x' }, key: 'outer', location: ['outer'], isLeaf: false },
+      { value: 'x', key: 'inner', location: ['outer', 'inner'], isLeaf: true }
+    ]);
+  });
+
+  it('walks deeply nested objects with cumulative locations', () => {
+    const calls = collect({ a: { b: { c: 1 } } });
+    const leaves = calls.filter((c) => c.isLeaf);
+    expect(leaves).toEqual([{ value: 1, key: 'c', location: ['a', 'b', 'c'], isLeaf: true }]);
+  });
+
+  it('treats undefined values as leaves (used by checkConfig to detect missing config)', () => {
+    const calls = collect({ optional: undefined });
+    expect(calls).toEqual([{ value: undefined, key: 'optional', location: ['optional'], isLeaf: true }]);
+  });
+
+  it('treats null values as leaves', () => {
+    const calls = collect({ field: null });
+    expect(calls).toEqual([{ value: null, key: 'field', location: ['field'], isLeaf: true }]);
+  });
+
+  it('walks objects inside arrays with index-suffixed key and indexed location', () => {
+    const calls = collect({ items: [{ x: 1 }, { x: 2 }] });
+    expect(calls).toEqual([
+      { value: { x: 1 }, key: 'items:0', location: ['items', 0], isLeaf: false },
+      { value: 1, key: 'x', location: ['items', 0, 'x'], isLeaf: true },
+      { value: { x: 2 }, key: 'items:1', location: ['items', 1], isLeaf: false },
+      { value: 2, key: 'x', location: ['items', 1, 'x'], isLeaf: true }
+    ]);
+  });
+
+  it('does not crash on an empty object', () => {
+    expect(() => walkObject({}, () => {})).not.toThrow();
+    expect(collect({})).toEqual([]);
+  });
+
+  it('does not crash on an empty array value', () => {
+    expect(collect({ items: [] })).toEqual([]);
+  });
+
+  // BUG: when an array contains primitives, walkObject:
+  //   (a) emits the array entry with isLeaf: false (it should be a leaf), and
+  //   (b) then recurses into the primitive, treating a string like an object
+  //       keyed by character index. For input { tags: ['a'] } the current output
+  //       is two callbacks: {key:'tags:0', isLeaf:false} and {key:'0', isLeaf:true,
+  //       location:['tags', 0, '0']} — both about the same scalar 'a'.
+  // Failing on purpose to flag the bug. The only current caller (`checkConfig`)
+  // doesn't exercise this path because config has no primitive arrays, but the
+  // helper is exported as a generic utility.
+  it('emits a single leaf callback for a primitive inside an array', () => {
+    const calls = collect({ tags: ['a', 'b'] });
+    expect(calls).toEqual([
+      { value: 'a', key: 'tags:0', location: ['tags', 0], isLeaf: true },
+      { value: 'b', key: 'tags:1', location: ['tags', 1], isLeaf: true }
+    ]);
+  });
+});


### PR DESCRIPTION
Closes part of #542.

Adds unit tests for the three shared utility helpers that were called out as remaining gaps in the rescoped issue: `parse-page-options`, `download-filename`, `walk-object`. Tests live alongside the existing utility tests under `tests/utils/`.

Three of the new tests started life as failures, flagging two real bugs uncovered while writing them. Both are fixed in the second commit:

- **`parsePageOptions` accepted negative pagination values.** `parseInt('-5', 10) || default` returns `-5` (truthy), so `?page_number=-5` and `?page_size=-10` were forwarded to the backend verbatim. Replaced with `parseInt(x, 10) > 0 ? … : default`, which rejects NaN, zero and negatives in one check.
- **`walkObject` mishandled arrays of primitives.** Each primitive array entry was emitted with `isLeaf: false` and then walked into — strings were treated as character-indexed objects, producing a spurious second callback at a nonsensical location (e.g. `{ tags: ['a'] }` produced two callbacks for the single value `'a'`). The array branch now checks whether each element is itself a branch (object/array) or a leaf, and only recurses in the branch case. The sole current caller (`checkConfig`) was unaffected by the bug — config has no primitive arrays — but the helper is exported as a generic utility.

## Tests

- `tests/utils/parse-page-options.test.ts` — 11 cases covering defaults, explicit values, decimal truncation, non-numeric/zero fallback, `sort_by` parsing in both colon and `qs` bracket-object formats, and the negative-clamping fixes.
- `tests/utils/download-filename.test.ts` — 7 cases covering the `v<n>` vs `draft` rule (including the domain rule that the initial revision has `revision_index = 1`), language code inclusion, datasetId fallback when metadata/title is missing, and that sanitisation is deferred to the downstream `getDownloadHeaders`/`slugify`.
- `tests/utils/walk-object.test.ts` — 13 cases covering `isObject`, leaf/branch emission order, deep nesting, null/undefined leaves, objects inside arrays, empty inputs, and the fixed array-of-primitives behaviour.

All 223 Jest tests pass.

## Out of scope

A pre-existing, unrelated issue surfaced while running `npm run check`: `jest-junit` is declared in `package.json` but missing from `node_modules` on a fresh checkout, so the JUnit reporter referenced from `jest.config.ts` fails to load. Not touched here — flagged so it can be picked up separately (an `npm ci` should resolve it locally).
