### PR TITLE
Posting a large amount of text to the summary or collection metadata …

### DIFF
--- a/src/publisher/controllers/publish.ts
+++ b/src/publisher/controllers/publish.ts
@@ -2163,7 +2163,7 @@ export const provideSummary = async (req: Request, res: Response) => {
     }
   }
 
-  res.render('publish/summary', { summary, errors });
+  res.render('publish/summary', { summary, errors: errors ?? res.locals.errors });
 };
 
 export const provideCollection = async (req: Request, res: Response) => {
@@ -2195,7 +2195,7 @@ export const provideCollection = async (req: Request, res: Response) => {
     }
   }
 
-  res.render('publish/collection', { collection, errors });
+  res.render('publish/collection', { collection, errors: errors ?? res.locals.errors });
 };
 
 export const provideQuality = async (req: Request, res: Response) => {

--- a/src/publisher/routes/publish.ts
+++ b/src/publisher/routes/publish.ts
@@ -67,7 +67,9 @@ const uploadNoneOrFieldError =
     upload.none()(req, res, (err: unknown) => {
       if (err instanceof multer.MulterError && err.code === 'LIMIT_FIELD_VALUE') {
         req.session.errors = [{ field, message: { key: errorKey } }];
-        req.session.save(() => res.redirect(req.originalUrl));
+        const redirectTarget =
+          req.originalUrl.startsWith('/') && !req.originalUrl.startsWith('//') ? req.originalUrl : '/';
+        req.session.save(() => res.redirect(redirectTarget));
         return;
       }
       next(err);

--- a/src/publisher/routes/publish.ts
+++ b/src/publisher/routes/publish.ts
@@ -69,7 +69,13 @@ const uploadNoneOrFieldError =
         req.session.errors = [{ field, message: { key: errorKey } }];
         const redirectTarget =
           req.originalUrl.startsWith('/') && !req.originalUrl.startsWith('//') ? req.originalUrl : '/';
-        req.session.save(() => res.redirect(redirectTarget));
+        req.session.save((saveErr) => {
+          if (saveErr) {
+            next(saveErr);
+            return;
+          }
+          res.redirect(redirectTarget);
+        });
         return;
       }
       next(err);

--- a/src/publisher/routes/publish.ts
+++ b/src/publisher/routes/publish.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction, RequestHandler } from 'express';
 import multer from 'multer';
 
 import { fetchDataset } from '../middleware/fetch-dataset';
@@ -59,7 +59,20 @@ import { redirectIfOpenPublishRequest } from '../middleware/redirect-if-open-pub
 
 export const publish = Router();
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ storage: multer.memoryStorage(), limits: { fieldSize: 10 * 1024 * 1024 } });
+
+const uploadNoneOrFieldError =
+  (field: string, errorKey: string): RequestHandler =>
+  (req: Request, res: Response, next: NextFunction) => {
+    upload.none()(req, res, (err: unknown) => {
+      if (err instanceof multer.MulterError && err.code === 'LIMIT_FIELD_VALUE') {
+        req.session.errors = [{ field, message: { key: errorKey } }];
+        req.session.save(() => res.redirect(req.originalUrl));
+        return;
+      }
+      next(err);
+    });
+  };
 
 publish.use(noCache, flashMessages, flashErrors);
 
@@ -395,7 +408,7 @@ publish.post(
   '/:datasetId/summary',
   fetchDataset(Include.Meta),
   redirectIfOpenPublishRequest,
-  upload.none(),
+  uploadNoneOrFieldError('summary', 'publish.summary.form.description.error.too_long'),
   provideSummary
 );
 
@@ -404,7 +417,7 @@ publish.post(
   '/:datasetId/collection',
   fetchDataset(Include.Meta),
   redirectIfOpenPublishRequest,
-  upload.none(),
+  uploadNoneOrFieldError('collection', 'publish.collection.form.collection.error.too_long'),
   provideCollection
 );
 

--- a/src/publisher/routes/publish.ts
+++ b/src/publisher/routes/publish.ts
@@ -59,7 +59,9 @@ import { redirectIfOpenPublishRequest } from '../middleware/redirect-if-open-pub
 
 export const publish = Router();
 
-const upload = multer({ storage: multer.memoryStorage(), limits: { fieldSize: 10 * 1024 * 1024 } });
+export const MULTIPART_FIELD_SIZE_LIMIT = 10 * 1024 * 1024;
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fieldSize: MULTIPART_FIELD_SIZE_LIMIT } });
 
 const uploadNoneOrFieldError =
   (field: string, errorKey: string): RequestHandler =>

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -633,7 +633,8 @@
       "form": {
         "description": {
           "error": {
-            "missing": "Nodwch y crynodeb o’r set ddata hon a’i newidynnau"
+            "missing": "Nodwch y crynodeb o’r set ddata hon a’i newidynnau",
+            "too_long": "Mae’r crynodeb yn rhy hir"
           }
         }
       }
@@ -648,7 +649,8 @@
       "form": {
         "collection": {
           "error": {
-            "missing": "Nodwch sut oedd y data wedi cael ei gasglu neu ei gyfrifo"
+            "missing": "Nodwch sut oedd y data wedi cael ei gasglu neu ei gyfrifo",
+            "too_long": "Mae disgrifiad y casgliad yn rhy hir"
           }
         }
       }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -662,7 +662,8 @@
       "form": {
         "description": {
           "error": {
-            "missing": "Enter the summary of this dataset and its variables"
+            "missing": "Enter the summary of this dataset and its variables",
+            "too_long": "The summary is too long"
           }
         }
       }
@@ -677,7 +678,8 @@
       "form": {
         "collection": {
           "error": {
-            "missing": "Enter how the data was collected or calculated"
+            "missing": "Enter how the data was collected or calculated",
+            "too_long": "The collection description is too long"
           }
         }
       }

--- a/tests/publish-field-size.test.ts
+++ b/tests/publish-field-size.test.ts
@@ -1,0 +1,97 @@
+import request from 'supertest';
+import JWT from 'jsonwebtoken';
+import { http, HttpResponse } from 'msw';
+
+import { i18next } from '../src/shared/middleware/translation';
+import app from '../src/publisher/app';
+import { config } from '../src/shared/config';
+import { Locale } from '../src/shared/enums/locale';
+import { GlobalRole } from '../src/shared/enums/global-role';
+import { UserStatus } from '../src/shared/enums/user-status';
+import { mockBackend } from './mocks/backend';
+import { completedDataset } from './mocks/fixtures';
+
+const FIELD_SIZE_LIMIT = 10 * 1024 * 1024; // must match limit in publish.ts
+
+const testUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+  provider: 'test',
+  global_roles: [] as GlobalRole[],
+  groups: [],
+  status: UserStatus.Active,
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z'
+};
+
+describe('Publish route field size errors', () => {
+  const t = i18next.t;
+  const jwt = JWT.sign({ user: testUser }, config.auth.jwt.secret);
+  const datasetId = completedDataset.id;
+
+  beforeAll(() => {
+    mockBackend.listen({
+      onUnhandledRequest: ({ url }, print) => {
+        if (!url.includes(config.backend.url)) return;
+        print.error();
+      }
+    });
+  });
+
+  beforeEach(() => {
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return HttpResponse.json(completedDataset);
+      }),
+      http.get(`${config.backend.url}/dataset/${datasetId}/tasks`, () => {
+        return HttpResponse.json([]);
+      })
+    );
+  });
+
+  afterEach(() => {
+    mockBackend.resetHandlers();
+  });
+
+  afterAll(() => mockBackend.close());
+
+  const makeAgent = () => {
+    const agent = request.agent(app);
+    agent.set('Cookie', `jwt=${jwt}`);
+    return agent;
+  };
+
+  describe('POST /:datasetId/summary', () => {
+    test('redirects back and shows error when summary exceeds field size limit', async () => {
+      const agent = makeAgent();
+      const oversizedValue = 'a'.repeat(FIELD_SIZE_LIMIT + 1);
+
+      const postRes = await agent.post(`/en-GB/publish/${datasetId}/summary`).field('summary', oversizedValue);
+
+      expect(postRes.status).toBe(302);
+      expect(postRes.header.location).toBe(`/en-GB/publish/${datasetId}/summary`);
+
+      const getRes = await agent.get(`/en-GB/publish/${datasetId}/summary`);
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.text).toContain(t('publish.summary.form.description.error.too_long', { lng: Locale.English }));
+    });
+  });
+
+  describe('POST /:datasetId/collection', () => {
+    test('redirects back and shows error when collection exceeds field size limit', async () => {
+      const agent = makeAgent();
+      const oversizedValue = 'a'.repeat(FIELD_SIZE_LIMIT + 1);
+
+      const postRes = await agent.post(`/en-GB/publish/${datasetId}/collection`).field('collection', oversizedValue);
+
+      expect(postRes.status).toBe(302);
+      expect(postRes.header.location).toBe(`/en-GB/publish/${datasetId}/collection`);
+
+      const getRes = await agent.get(`/en-GB/publish/${datasetId}/collection`);
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.text).toContain(t('publish.collection.form.collection.error.too_long', { lng: Locale.English }));
+    });
+  });
+});

--- a/tests/publish-field-size.test.ts
+++ b/tests/publish-field-size.test.ts
@@ -10,8 +10,7 @@ import { GlobalRole } from '../src/shared/enums/global-role';
 import { UserStatus } from '../src/shared/enums/user-status';
 import { mockBackend } from './mocks/backend';
 import { completedDataset } from './mocks/fixtures';
-
-const FIELD_SIZE_LIMIT = 10 * 1024 * 1024; // must match limit in publish.ts
+import { MULTIPART_FIELD_SIZE_LIMIT } from '../src/publisher/routes/publish';
 
 const testUser = {
   id: 'test-user-id',
@@ -64,7 +63,7 @@ describe('Publish route field size errors', () => {
   describe('POST /:datasetId/summary', () => {
     test('redirects back and shows error when summary exceeds field size limit', async () => {
       const agent = makeAgent();
-      const oversizedValue = 'a'.repeat(FIELD_SIZE_LIMIT + 1);
+      const oversizedValue = 'a'.repeat(MULTIPART_FIELD_SIZE_LIMIT + 1);
 
       const postRes = await agent.post(`/en-GB/publish/${datasetId}/summary`).field('summary', oversizedValue);
 
@@ -81,7 +80,7 @@ describe('Publish route field size errors', () => {
   describe('POST /:datasetId/collection', () => {
     test('redirects back and shows error when collection exceeds field size limit', async () => {
       const agent = makeAgent();
-      const oversizedValue = 'a'.repeat(FIELD_SIZE_LIMIT + 1);
+      const oversizedValue = 'a'.repeat(MULTIPART_FIELD_SIZE_LIMIT + 1);
 
       const postRes = await agent.post(`/en-GB/publish/${datasetId}/collection`).field('collection', oversizedValue);
 


### PR DESCRIPTION
…pages caused a raw `MulterError: Field value too large` crash, with no useful message shown to the user.

**Increase field size limit** (`src/publisher/routes/publish.ts`)

Raised Multer's `fieldSize` limit from the default 1 MB to 10 MB to accommodate legitimate large text inputs.

**Graceful error handling for oversized fields** (`src/publisher/routes/publish.ts`)

Added a `uploadNoneOrFieldError` middleware wrapper that intercepts Multer's `LIMIT_FIELD_VALUE` error. Instead of crashing, it saves a user-facing error to the session and redirects back to the originating page. Applied to the `POST /:datasetId/summary` and `POST /:datasetId/collection` routes.

**Show flash errors in summary and collection views** (`src/publisher/controllers/publish.ts`)

Fixed `provideSummary` and `provideCollection` to fall back to `res.locals.errors` (populated by the flash middleware) when the controller has no errors of its own. Previously, passing `errors: undefined` to `res.render` silently discarded any session-flashed errors.

**Error message translations** (`src/shared/i18n/en.json`, `src/shared/i18n/cy.json`)

Added `too_long` error keys for both the summary and collection fields in English and Welsh.

**Tests** (`tests/publish-field-size.test.ts`)

Two new integration tests — one per route — that POST an oversized field value, assert a redirect back to the same page, then follow the redirect and verify the translated error message is rendered in the GOV.UK error summary.