### PR TITLE
SW-1246: cursor pagination past page 100

### DIFF
--- a/src/consumer/controllers/consumer.ts
+++ b/src/consumer/controllers/consumer.ts
@@ -8,7 +8,7 @@ import { stringify } from 'csv-stringify/sync';
 
 import { DatasetListItemDTO } from '../../shared/dtos/dataset-list-item';
 import { ResultsetWithCount } from '../../shared/interfaces/resultset-with-count';
-import { pageInfo } from '../../shared/utils/pagination';
+import { mergeCursorPageInfo, pageInfo } from '../../shared/utils/pagination';
 import { singleLangPublishedDataset, singleLangRevision } from '../../shared/utils/single-lang-dataset';
 import { getDatasetMetadata, metadataToCSV } from '../../shared/utils/dataset-metadata';
 import { NotFoundException } from '../../shared/exceptions/not-found.exception';
@@ -120,7 +120,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
   const revision = dataset.published_revision;
   const isUnpublished = revision?.unpublished_at || false;
   const isArchived = (dataset.archived_at && dataset.archived_at < new Date().toISOString()) || false;
-  const { pageNumber, pageSize, sortBy } = parsePageOptions(req);
+  const { pageNumber, pageSize, sortBy, cursor } = parsePageOptions(req);
 
   if (!revision) {
     next(new NotFoundException('no published revision found'));
@@ -134,7 +134,7 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
     RevisionDTO[]
   ] = await Promise.all([
     getDatasetMetadata(dataset, revision),
-    req.conapi.getPublishedDatasetView(dataset.id, pageNumber, pageSize, sortBy),
+    req.conapi.getPublishedDatasetView(dataset.id, pageNumber, pageSize, sortBy, cursor),
     req.conapi.getPublishedDatasetFilters(dataset.id),
     req.conapi.getPublicationHistory(dataset.id)
   ]);
@@ -152,6 +152,10 @@ export const viewPublishedDataset = async (req: Request, res: Response, next: Ne
   res.render('dataset/view', {
     ...view,
     ...pagination,
+    // Preserve the cursors emitted by the backend — the `pageInfo` helper
+    // only computes offset-based fields, but the Pagination component needs
+    // next_cursor / prev_cursor to render past the page-number cap.
+    page_info: mergeCursorPageInfo(pagination.page_info, view.page_info),
     datasetMetadata,
     filters,
     topics,
@@ -215,7 +219,7 @@ export const viewFilteredDataset = async (req: Request, res: Response, next: Nex
     return;
   }
 
-  const { pageNumber, pageSize, sortBy } = parsePageOptions(req);
+  const { pageNumber, pageSize, sortBy, cursor } = parsePageOptions(req);
 
   const [datasetMetadata, view, filters, publishedRevisions]: [
     PreviewMetadata,
@@ -224,7 +228,7 @@ export const viewFilteredDataset = async (req: Request, res: Response, next: Nex
     RevisionDTO[]
   ] = await Promise.all([
     getDatasetMetadata(dataset, revision),
-    req.conapi.getFilteredDatasetView(dataset.id, filterId, pageNumber, pageSize, sortBy),
+    req.conapi.getFilteredDatasetView(dataset.id, filterId, pageNumber, pageSize, sortBy, cursor),
     req.conapi.getPublishedDatasetFilters(dataset.id),
     req.conapi.getPublicationHistory(dataset.id)
   ]);
@@ -242,6 +246,7 @@ export const viewFilteredDataset = async (req: Request, res: Response, next: Nex
   res.render('dataset/view', {
     ...view,
     ...pagination,
+    page_info: mergeCursorPageInfo(pagination.page_info, view.page_info),
     datasetMetadata,
     filters,
     topics,
@@ -690,7 +695,7 @@ export const viewPivotedDataset = async (req: Request, res: Response, next: Next
       return;
     }
 
-    const { pageNumber, pageSize, sortBy } = parsePageOptions(req);
+    const { pageNumber, pageSize, sortBy, cursor } = parsePageOptions(req);
 
     const [datasetMetadata, view, filters, publishedRevisions]: [
       PreviewMetadata,
@@ -699,7 +704,7 @@ export const viewPivotedDataset = async (req: Request, res: Response, next: Next
       RevisionDTO[]
     ] = await Promise.all([
       getDatasetMetadata(dataset, revision),
-      req.conapi.getPivotedDatasetView(dataset.id, filterId, pageNumber, pageSize, sortBy),
+      req.conapi.getPivotedDatasetView(dataset.id, filterId, pageNumber, pageSize, sortBy, cursor),
       req.conapi.getPublishedDatasetFilters(dataset.id),
       req.conapi.getPublicationHistory(dataset.id)
     ]);
@@ -717,6 +722,7 @@ export const viewPivotedDataset = async (req: Request, res: Response, next: Next
     res.render('dataset/view', {
       ...view,
       ...pagination,
+      page_info: mergeCursorPageInfo(pagination.page_info, view.page_info),
       datasetMetadata,
       filters,
       topics,

--- a/src/consumer/services/consumer-api.ts
+++ b/src/consumer/services/consumer-api.ts
@@ -140,15 +140,11 @@ export class ConsumerApi {
     datasetId: string,
     pageNumber: number,
     pageSize: number,
-    sortBy?: SortByInterface
+    sortBy?: SortByInterface,
+    cursor?: string
   ): Promise<ViewV2DTO> {
     logger.debug(`Fetching published view of dataset: ${datasetId}`);
-    const query = new URLSearchParams({ page_number: pageNumber.toString(), page_size: pageSize.toString() });
-    query.append('format', 'frontend');
-
-    if (sortBy) {
-      query.append('sort_by', serializeSortBy(sortBy));
-    }
+    const query = buildPagedViewQuery(pageNumber, pageSize, sortBy, cursor);
 
     return this.fetch({ url: `v2/${datasetId}/data`, query }).then(
       (response) => response.json() as unknown as ViewV2DTO
@@ -183,18 +179,11 @@ export class ConsumerApi {
     filterId: string,
     pageNumber: number,
     pageSize: number,
-    sortBy?: SortByInterface
+    sortBy?: SortByInterface,
+    cursor?: string
   ): Promise<ViewV2DTO> {
     logger.debug(`Fetching filtered view of dataset: ${datasetId} with filter ID: ${filterId}`);
-    const query = new URLSearchParams({
-      page_number: pageNumber.toString(),
-      page_size: pageSize.toString(),
-      format: 'frontend'
-    });
-
-    if (sortBy) {
-      query.append('sort_by', serializeSortBy(sortBy));
-    }
+    const query = buildPagedViewQuery(pageNumber, pageSize, sortBy, cursor);
 
     return this.fetch({ url: `v2/${datasetId}/data/${filterId}`, query }).then(
       (response) => response.json() as unknown as ViewV2DTO
@@ -206,18 +195,11 @@ export class ConsumerApi {
     filterId: string,
     pageNumber: number,
     pageSize: number,
-    sortBy?: SortByInterface
+    sortBy?: SortByInterface,
+    cursor?: string
   ): Promise<ViewV2DTO> {
     logger.debug(`Fetching pivoted view of dataset: ${datasetId} with filter ID: ${filterId}`);
-    const query = new URLSearchParams({
-      page_number: pageNumber.toString(),
-      page_size: pageSize.toString(),
-      format: 'frontend'
-    });
-
-    if (sortBy) {
-      query.append('sort_by', serializeSortBy(sortBy));
-    }
+    const query = buildPagedViewQuery(pageNumber, pageSize, sortBy, cursor);
 
     return this.fetch({ url: `v2/${datasetId}/pivot/${filterId}`, query }).then(
       (response) => response.json() as unknown as ViewV2DTO
@@ -275,4 +257,27 @@ export class ConsumerApi {
       (response) => response.json() as unknown as ResultsetWithCount<SearchResultDTO>
     );
   }
+}
+
+// Backend rejects `cursor` + `page_number > 1` as mutually exclusive, so when
+// the caller has a cursor we drop page_number from the query entirely and let
+// the server treat it as a cursor-mode request.
+function buildPagedViewQuery(
+  pageNumber: number,
+  pageSize: number,
+  sortBy: SortByInterface | undefined,
+  cursor: string | undefined
+): URLSearchParams {
+  const query = new URLSearchParams();
+  if (cursor) {
+    query.append('cursor', cursor);
+  } else {
+    query.append('page_number', pageNumber.toString());
+  }
+  query.append('page_size', pageSize.toString());
+  query.append('format', 'frontend');
+  if (sortBy) {
+    query.append('sort_by', serializeSortBy(sortBy));
+  }
+  return query;
 }

--- a/src/consumer/views/dataset/components/DataTab.tsx
+++ b/src/consumer/views/dataset/components/DataTab.tsx
@@ -84,7 +84,7 @@ export default function DataTab(props: DataTabProps) {
               <div className="govuk-!-padding-top-5 govuk-!-margin-bottom-2">
                 <ViewTable {...props} isFiltered={props.selectedFilterOptions?.length > 0} isPivot={pivotSelected} />
               </div>
-              <Pagination {...props} />
+              <Pagination {...props} anchor="dataset-nav" />
               <RowsPerPage pageSize={props.page_size} />
             </div>
           )}

--- a/src/shared/dtos/view-dto.ts
+++ b/src/shared/dtos/view-dto.ts
@@ -18,9 +18,17 @@ export interface PageInfo {
 }
 
 export interface PageInfoV2 extends PageInfo {
-  current_page: number;
+  // current_page / start_record / end_record are nullable: the backend omits
+  // them in cursor-pagination mode where row offsets aren't meaningful.
+  current_page: number | null;
   page_size: number;
   total_pages: number;
+  // Opaque keyset cursors. The backend emits next_cursor whenever there are
+  // more rows after the current page (in either offset or cursor mode), and
+  // prev_cursor in cursor mode when a previous page exists. Both null when
+  // there is no further direction to travel.
+  next_cursor?: string | null;
+  prev_cursor?: string | null;
 }
 
 export interface ViewErrDTO {

--- a/src/shared/dtos/view-dto.ts
+++ b/src/shared/dtos/view-dto.ts
@@ -13,8 +13,12 @@ export interface ColumnHeader {
 
 export interface PageInfo {
   total_records: number | undefined;
-  start_record: number | undefined;
-  end_record: number | undefined;
+  // start_record / end_record are nullable to match the cursor-mode response
+  // shape — the backend returns null for these when paginating by keyset
+  // because row offsets aren't meaningful there. Non-cursor pagination still
+  // populates them with numbers.
+  start_record: number | null | undefined;
+  end_record: number | null | undefined;
 }
 
 export interface PageInfoV2 extends PageInfo {

--- a/src/shared/middleware/language-switcher.ts
+++ b/src/shared/middleware/language-switcher.ts
@@ -38,8 +38,9 @@ export const languageSwitcher: RequestHandler = (req, res, next): void => {
   // lang switching uses lang=xx query param, once triggered we want to remove it while keeping other query params.
   // `cursor` is dropped too — keyset cursors are bound to the language they were issued in (see SW-1246), and the
   // backend rejects mismatches with 400. Stripping it here resets the user to page 1 in the new language, which is
-  // the right place to start a fresh translated traversal anyway.
-  const queryParams = omit(req.query as Record<string, string>, 'lang', 'cursor');
+  // the right place to start a fresh translated traversal anyway. `page_hint` is the display-only counter that rides
+  // alongside the cursor, so it goes with it rather than lingering stale on the reset-to-page-1 URL.
+  const queryParams = omit(req.query as Record<string, string>, 'lang', 'cursor', 'page_hint');
 
   if ([Locale.English, Locale.EnglishGb].includes(lang as Locale) && !/^\/en-GB/.test(req.originalUrl)) {
     const newUrl = localeUrl(req.path, Locale.EnglishGb, queryParams);

--- a/src/shared/middleware/language-switcher.ts
+++ b/src/shared/middleware/language-switcher.ts
@@ -35,8 +35,11 @@ export const languageSwitcher: RequestHandler = (req, res, next): void => {
 
   const lang = req.language; // language detected by the translation middleware
 
-  // lang switching uses lang=xx query param, once triggered we want to remove it while keeping other query params
-  const queryParams = omit(req.query as Record<string, string>, 'lang');
+  // lang switching uses lang=xx query param, once triggered we want to remove it while keeping other query params.
+  // `cursor` is dropped too — keyset cursors are bound to the language they were issued in (see SW-1246), and the
+  // backend rejects mismatches with 400. Stripping it here resets the user to page 1 in the new language, which is
+  // the right place to start a fresh translated traversal anyway.
+  const queryParams = omit(req.query as Record<string, string>, 'lang', 'cursor');
 
   if ([Locale.English, Locale.EnglishGb].includes(lang as Locale) && !/^\/en-GB/.test(req.originalUrl)) {
     const newUrl = localeUrl(req.path, Locale.EnglishGb, queryParams);

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -64,6 +64,19 @@ export function paginationSequence(currentPage: number, totalPages: number): (st
   return sequence;
 }
 
+// Resolve the display-only page counter for cursor mode. Keyset pagination has
+// no inherent page index, so the UI threads an incrementing `page_hint` query
+// param through the Prev/Next links (the backend never sees it). It stays
+// accurate because cursor mode is strictly sequential — there are no numbered
+// jumps. Returns null when there's nothing trustworthy to show (not in cursor
+// mode, or a deep cursor link arrived without a valid positive hint), in which
+// case the summary falls back to the coarser "Page > cap" wording.
+export function resolveCursorPage(inCursorMode: boolean, rawHint: unknown): number | null {
+  if (!inCursorMode) return null;
+  const parsed = typeof rawHint === 'string' ? parseInt(rawHint, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
 // Combine the offset-based page_info from `pageInfo()` with the cursor fields
 // that come back on the backend view response. The backend's page_info carries
 // `next_cursor` / `prev_cursor`; the helper-computed page_info doesn't know

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -7,14 +7,17 @@ export const PAGE_NUMBER_CAP = 100;
 // Same shape as `paginationSequence` but treats `min(totalPages, PAGE_NUMBER_CAP)`
 // as the effective last page. The "summary" copy ("Page X of Y") still uses
 // the real `total_pages` from the response — only the numbered jump links are
-// capped.
+// capped. `currentPage` is clamped to the effective range so a direct hit at
+// `?page_number=101` doesn't leak the literal current page into the numbered
+// link set (which would render an above-cap page number).
 export function cappedPaginationSequence(
   currentPage: number,
   totalPages: number,
   cap: number = PAGE_NUMBER_CAP
 ): (string | number)[] {
   const effective = Math.min(totalPages, cap);
-  return paginationSequence(currentPage, effective);
+  const clampedCurrent = Math.min(Math.max(1, currentPage), effective);
+  return paginationSequence(clampedCurrent, effective);
 }
 
 export function paginationSequence(currentPage: number, totalPages: number): (string | number)[] {
@@ -66,15 +69,23 @@ export function paginationSequence(currentPage: number, totalPages: number): (st
 // `next_cursor` / `prev_cursor`; the helper-computed page_info doesn't know
 // about cursors. Template render spreads merge in order so this restores the
 // cursor fields onto the final object.
+//
+// Only fields *present* on `fromView` are propagated — a non-cursor response
+// (where the fields are absent rather than null) must leave the merged object
+// without the cursor markers, because the shared Pagination component treats
+// presence as the "this response supports cursors" signal.
 export function mergeCursorPageInfo<T extends { next_cursor?: string | null; prev_cursor?: string | null } | undefined>(
   base: object,
   fromView: T
 ): object {
-  return {
-    ...base,
-    next_cursor: fromView?.next_cursor ?? null,
-    prev_cursor: fromView?.prev_cursor ?? null
-  };
+  const out: Record<string, unknown> = { ...base };
+  if (fromView && 'next_cursor' in fromView) {
+    out.next_cursor = fromView.next_cursor ?? null;
+  }
+  if (fromView && 'prev_cursor' in fromView) {
+    out.prev_cursor = fromView.prev_cursor ?? null;
+  }
+  return out;
 }
 
 export const pageInfo = (currentPage: number | null | undefined, pageSize: number, totalRows: number) => {

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -1,3 +1,22 @@
+// Mirror of the backend's SW-1246 page_number cap. Numbered pagination is only
+// rendered up to this page; beyond it the UI must drive navigation via the
+// `next_cursor` / `prev_cursor` opaque tokens, because keyset queries are far
+// cheaper than deep OFFSET reads.
+export const PAGE_NUMBER_CAP = 100;
+
+// Same shape as `paginationSequence` but treats `min(totalPages, PAGE_NUMBER_CAP)`
+// as the effective last page. The "summary" copy ("Page X of Y") still uses
+// the real `total_pages` from the response — only the numbered jump links are
+// capped.
+export function cappedPaginationSequence(
+  currentPage: number,
+  totalPages: number,
+  cap: number = PAGE_NUMBER_CAP
+): (string | number)[] {
+  const effective = Math.min(totalPages, cap);
+  return paginationSequence(currentPage, effective);
+}
+
 export function paginationSequence(currentPage: number, totalPages: number): (string | number)[] {
   if (totalPages <= 1) {
     return [];
@@ -42,8 +61,42 @@ export function paginationSequence(currentPage: number, totalPages: number): (st
   return sequence;
 }
 
-export const pageInfo = (currentPage: number, pageSize: number, totalRows: number) => {
+// Combine the offset-based page_info from `pageInfo()` with the cursor fields
+// that come back on the backend view response. The backend's page_info carries
+// `next_cursor` / `prev_cursor`; the helper-computed page_info doesn't know
+// about cursors. Template render spreads merge in order so this restores the
+// cursor fields onto the final object.
+export function mergeCursorPageInfo<T extends { next_cursor?: string | null; prev_cursor?: string | null } | undefined>(
+  base: object,
+  fromView: T
+): object {
+  return {
+    ...base,
+    next_cursor: fromView?.next_cursor ?? null,
+    prev_cursor: fromView?.prev_cursor ?? null
+  };
+}
+
+export const pageInfo = (currentPage: number | null | undefined, pageSize: number, totalRows: number) => {
   const totalPages = Math.ceil(totalRows / pageSize);
+
+  // Cursor-mode responses set current_page to null because row offsets aren't
+  // meaningful when paginating by keyset. Surface that to the view layer by
+  // returning null fields rather than NaN — the Pagination component renders
+  // the cursor-only "Next / Previous" variant in that case.
+  if (currentPage == null) {
+    return {
+      current_page: null,
+      total_pages: totalPages,
+      page_size: pageSize,
+      page_info: {
+        total_records: totalRows,
+        start_record: null,
+        end_record: null
+      },
+      pagination: [] as (string | number)[]
+    };
+  }
 
   return {
     current_page: currentPage,
@@ -54,6 +107,6 @@ export const pageInfo = (currentPage: number, pageSize: number, totalRows: numbe
       start_record: (currentPage - 1) * pageSize + 1,
       end_record: Math.min(currentPage * pageSize, totalRows)
     },
-    pagination: totalPages > 1 ? paginationSequence(currentPage, totalPages) : []
+    pagination: totalPages > 1 ? cappedPaginationSequence(currentPage, totalPages) : []
   };
 };

--- a/src/shared/utils/parse-page-options.ts
+++ b/src/shared/utils/parse-page-options.ts
@@ -2,13 +2,17 @@ import { Request } from 'express';
 import qs from 'qs';
 
 import { parseSortBy } from '../interfaces/sort-by';
+import { PAGE_NUMBER_CAP } from './pagination';
 
 export const DEFAULT_PAGE_SIZE = 25;
 
 export const parsePageOptions = (req: Request) => {
   // `parseInt(x, 10) > 0` rejects NaN, zero and negatives in one check.
   const parsedPage = Number.parseInt(req.query.page_number as string, 10);
-  const pageNumber = parsedPage > 0 ? parsedPage : 1;
+  // Clamp to PAGE_NUMBER_CAP — the backend rejects anything higher with 400,
+  // so silently capping here matches the cursor-aware UI: numbered jumps stop
+  // at the cap, deeper navigation flows through next_cursor.
+  const pageNumber = parsedPage > 0 ? Math.min(parsedPage, PAGE_NUMBER_CAP) : 1;
 
   const parsedSize = Number.parseInt(req.query.page_size as string, 10);
   const pageSize = parsedSize > 0 ? parsedSize : DEFAULT_PAGE_SIZE;
@@ -16,5 +20,8 @@ export const parsePageOptions = (req: Request) => {
   const query = qs.parse(req.originalUrl.split('?')[1]);
   const sortBy = parseSortBy(query.sort_by);
 
-  return { pageNumber, pageSize, sortBy };
+  const rawCursor = req.query.cursor;
+  const cursor = typeof rawCursor === 'string' && rawCursor.length > 0 ? rawCursor : undefined;
+
+  return { pageNumber, pageSize, sortBy, cursor };
 };

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -126,6 +126,16 @@ export default function Pagination({
               </div>
             )}
             <ul className="govuk-pagination__list">
+              {/* Cursor mode has no numbered jump links, but we still surface
+                  the tracked page number as the current item so it reads like
+                  the offset pagination (just without the other page links).
+                  Omitted when the counter is untrustworthy (deep cursor link
+                  with no page_hint). */}
+              {inCursorMode && cursorPage != null && (
+                <li className="govuk-pagination__item govuk-pagination__item--current govuk-pagination__inactive">
+                  <span aria-current="page">{cursorPage}</span>
+                </li>
+              )}
               {numberedLinks.map((page, index) => {
                 if (page === '...') {
                   return (

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import T from './T';
 import { useLocals } from '../context/Locals';
 import { PageInfo } from '../../dtos/view-dto';
-import { PAGE_NUMBER_CAP } from '../../utils/pagination';
+import { PAGE_NUMBER_CAP, resolveCursorPage } from '../../utils/pagination';
 import qs from 'qs';
 
 export type PaginationProps = {
@@ -46,13 +46,19 @@ export default function Pagination({
   }
 
   const [baseUrl, query] = url.split('?');
-  // Strip page_number / cursor so we can re-emit the right one per link
-  // rather than carrying a stale value forward.
+  // Strip page_number / cursor / page_hint so we can re-emit the right value
+  // per link rather than carrying a stale one forward.
   const parsedQuery = { ...qs.parse(query) };
   delete (parsedQuery as Record<string, unknown>).page_number;
   delete (parsedQuery as Record<string, unknown>).cursor;
+  const rawHint = (parsedQuery as Record<string, unknown>).page_hint;
+  delete (parsedQuery as Record<string, unknown>).page_hint;
 
   const atOrPastCap = supportsCursor && current_page != null && current_page >= PAGE_NUMBER_CAP;
+
+  // Display-only page counter for cursor mode (see resolveCursorPage). null
+  // when untrustworthy, in which case the summary falls back to "Page > cap".
+  const cursorPage = resolveCursorPage(inCursorMode, rawHint);
 
   const showPrevLink = inCursorMode ? prevCursor != null : current_page! > 1;
   const showNextLink = inCursorMode
@@ -64,13 +70,26 @@ export default function Pagination({
       // doesn't apply and "Next" works all the way to total_pages.
       (!supportsCursor || current_page! < PAGE_NUMBER_CAP || nextCursor != null);
 
+  // page_hint for the cursor Prev/Next links. In cursor mode we step the
+  // tracked counter; at the cap boundary (last offset page → first cursor
+  // page) we seed it from the known page number. Omitted when there's nothing
+  // trustworthy to carry, so the summary degrades gracefully.
+  const prevHint = cursorPage != null ? { page_hint: cursorPage - 1 } : {};
+  const nextHint = inCursorMode
+    ? cursorPage != null
+      ? { page_hint: cursorPage + 1 }
+      : {}
+    : atOrPastCap
+      ? { page_hint: current_page! + 1 }
+      : {};
+
   const prevHref = inCursorMode
-    ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: prevCursor!, page_size }, anchor)
+    ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, ...prevHint, cursor: prevCursor!, page_size }, anchor)
     : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! - 1, page_size }, anchor);
 
   const nextHref =
     inCursorMode || atOrPastCap
-      ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: nextCursor!, page_size }, anchor)
+      ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, ...nextHint, cursor: nextCursor!, page_size }, anchor)
       : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! + 1, page_size }, anchor);
 
   // Numbered jumps are only meaningful in offset mode. In cursor mode we
@@ -159,9 +178,15 @@ export default function Pagination({
 
       <div className="govuk-pagination__summary">
         {inCursorMode ? (
-          <>
-            Page &gt; {PAGE_NUMBER_CAP} of {total_pages}
-          </>
+          cursorPage != null ? (
+            <>
+              Page {cursorPage} of {total_pages}
+            </>
+          ) : (
+            <>
+              Page &gt; {PAGE_NUMBER_CAP} of {total_pages}
+            </>
+          )
         ) : (
           <>
             Page {current_page} of {total_pages}

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -3,16 +3,19 @@ import React from 'react';
 import T from './T';
 import { useLocals } from '../context/Locals';
 import { PageInfo } from '../../dtos/view-dto';
+import { PAGE_NUMBER_CAP } from '../../utils/pagination';
 import qs from 'qs';
 
 export type PaginationProps = {
   pagination: (number | string)[];
   total_pages: number;
-  current_page: number;
+  // null in cursor mode — the backend doesn't surface a page index when
+  // paginating by keyset.
+  current_page: number | null;
   page_size: number;
   hide_pagination_hint?: boolean;
   anchor?: string;
-  page_info: PageInfo;
+  page_info: PageInfo & { next_cursor?: string | null; prev_cursor?: string | null };
 };
 
 export default function Pagination({
@@ -25,17 +28,49 @@ export default function Pagination({
   page_info
 }: PaginationProps) {
   const { buildUrl, url, i18n } = useLocals();
-  if (total_pages <= 1) {
+
+  const inCursorMode = current_page == null;
+  const nextCursor = page_info.next_cursor ?? null;
+  const prevCursor = page_info.prev_cursor ?? null;
+
+  if (total_pages <= 1 && !inCursorMode) {
     return null;
   }
+
   const [baseUrl, query] = url.split('?');
-  const parsedQuery = qs.parse(query);
+  // Strip page_number / cursor so we can re-emit the right one per link
+  // rather than carrying a stale value forward.
+  const parsedQuery = { ...qs.parse(query) };
+  delete (parsedQuery as Record<string, unknown>).page_number;
+  delete (parsedQuery as Record<string, unknown>).cursor;
+
+  const showPrevLink = inCursorMode ? prevCursor != null : current_page! > 1;
+  const showNextLink = inCursorMode
+    ? nextCursor != null
+    : current_page! < total_pages &&
+      // At the cap boundary the next link switches to a cursor — only emit a
+      // page_number-based link while we're inside the capped range.
+      (current_page! < PAGE_NUMBER_CAP || nextCursor != null);
+
+  const prevHref = inCursorMode
+    ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: prevCursor!, page_size }, anchor)
+    : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! - 1, page_size }, anchor);
+
+  const nextHref =
+    inCursorMode || current_page! >= PAGE_NUMBER_CAP
+      ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: nextCursor!, page_size }, anchor)
+      : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! + 1, page_size }, anchor);
+
+  // Numbered jumps are only meaningful in offset mode. In cursor mode we
+  // render Prev/Next links and a coarser summary.
+  const numberedLinks = inCursorMode ? [] : pagination;
+
   return (
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-third">
           <div className="total-rows">
-            {!hide_pagination_hint && (
+            {!hide_pagination_hint && !inCursorMode && (
               <div>
                 <T
                   start={page_info.start_record?.toLocaleString()}
@@ -50,18 +85,9 @@ export default function Pagination({
         </div>
         <div className="govuk-grid-column-two-thirds">
           <nav className="govuk-pagination" aria-label="Pagination">
-            {current_page > 1 && (
+            {showPrevLink && (
               <div className={clsx('govuk-pagination__prev')}>
-                <a
-                  className="govuk-link govuk-pagination__link"
-                  href={buildUrl(
-                    baseUrl,
-                    i18n.language,
-                    { ...parsedQuery, page_number: current_page - 1, page_size },
-                    anchor
-                  )}
-                  rel="prev"
-                >
+                <a className="govuk-link govuk-pagination__link" href={prevHref} rel="prev">
                   <span className="govuk-pagination__link-title">
                     <T>pagination.previous</T>
                   </span>
@@ -69,7 +95,7 @@ export default function Pagination({
               </div>
             )}
             <ul className="govuk-pagination__list">
-              {pagination.map((page, index) => {
+              {numberedLinks.map((page, index) => {
                 if (page === '...') {
                   return (
                     <li key={index} className="govuk-pagination__item govuk-pagination__item--ellipses">
@@ -106,18 +132,9 @@ export default function Pagination({
               })}
             </ul>
 
-            {current_page < total_pages && (
+            {showNextLink && (
               <div className={clsx('govuk-pagination__next')}>
-                <a
-                  className="govuk-link govuk-pagination__link"
-                  href={buildUrl(
-                    baseUrl,
-                    i18n.language,
-                    { ...parsedQuery, page_number: current_page + 1, page_size },
-                    anchor
-                  )}
-                  rel="next"
-                >
+                <a className="govuk-link govuk-pagination__link" href={nextHref} rel="next">
                   <span className="govuk-pagination__link-title">
                     <T>pagination.next</T>
                   </span>
@@ -129,7 +146,15 @@ export default function Pagination({
       </div>
 
       <div className="govuk-pagination__summary">
-        Page {current_page} of {total_pages}
+        {inCursorMode ? (
+          <>
+            Page &gt; {PAGE_NUMBER_CAP} of {total_pages}
+          </>
+        ) : (
+          <>
+            Page {current_page} of {total_pages}
+          </>
+        )}
       </div>
     </>
   );

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -29,9 +29,17 @@ export default function Pagination({
 }: PaginationProps) {
   const { buildUrl, url, i18n } = useLocals();
 
-  const inCursorMode = current_page == null;
-  const nextCursor = page_info.next_cursor ?? null;
-  const prevCursor = page_info.prev_cursor ?? null;
+  // `Pagination` is shared across the consumer view (cursor-aware) AND
+  // non-cursor pages like dataset list, search, topic browse and admin.
+  // Detect cursor opt-in by the *presence* of either cursor field in the
+  // response envelope — not by their value, because a cursor-aware response
+  // legitimately carries `next_cursor: null` on the last page. Without this
+  // gate the cap-and-cursor switching would kick in for non-cursor pages
+  // with >100 pages and break their pagination.
+  const supportsCursor = 'next_cursor' in page_info || 'prev_cursor' in page_info;
+  const inCursorMode = supportsCursor && current_page == null;
+  const nextCursor = supportsCursor ? (page_info.next_cursor ?? null) : null;
+  const prevCursor = supportsCursor ? (page_info.prev_cursor ?? null) : null;
 
   if (total_pages <= 1 && !inCursorMode) {
     return null;
@@ -44,20 +52,24 @@ export default function Pagination({
   delete (parsedQuery as Record<string, unknown>).page_number;
   delete (parsedQuery as Record<string, unknown>).cursor;
 
+  const atOrPastCap = supportsCursor && current_page != null && current_page >= PAGE_NUMBER_CAP;
+
   const showPrevLink = inCursorMode ? prevCursor != null : current_page! > 1;
   const showNextLink = inCursorMode
     ? nextCursor != null
     : current_page! < total_pages &&
       // At the cap boundary the next link switches to a cursor — only emit a
-      // page_number-based link while we're inside the capped range.
-      (current_page! < PAGE_NUMBER_CAP || nextCursor != null);
+      // page_number-based link while we're inside the capped range. For
+      // non-cursor paginations (no cursor fields on the response) the cap
+      // doesn't apply and "Next" works all the way to total_pages.
+      (!supportsCursor || current_page! < PAGE_NUMBER_CAP || nextCursor != null);
 
   const prevHref = inCursorMode
     ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: prevCursor!, page_size }, anchor)
     : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! - 1, page_size }, anchor);
 
   const nextHref =
-    inCursorMode || current_page! >= PAGE_NUMBER_CAP
+    inCursorMode || atOrPastCap
       ? buildUrl(baseUrl, i18n.language, { ...parsedQuery, cursor: nextCursor!, page_size }, anchor)
       : buildUrl(baseUrl, i18n.language, { ...parsedQuery, page_number: current_page! + 1, page_size }, anchor);
 

--- a/src/shared/views/components/Table.tsx
+++ b/src/shared/views/components/Table.tsx
@@ -104,7 +104,9 @@ function TableHeader<T>({
     // Drop it so the new sort starts a fresh traversal from the first page
     // rather than hitting a 400 (see SW-1246).
     const carriedQuery = omit(query, 'cursor');
-    const newQuery = param ? qs.stringify({ ...carriedQuery, sort_by: param }) : qs.stringify(omit(carriedQuery, 'sort_by'));
+    const newQuery = param
+      ? qs.stringify({ ...carriedQuery, sort_by: param })
+      : qs.stringify(omit(carriedQuery, 'sort_by'));
 
     const url = size(newQuery) ? `${originalUrl}?${newQuery}` : originalUrl;
     return anchor ? `${url}#${anchor}` : url;

--- a/src/shared/views/components/Table.tsx
+++ b/src/shared/views/components/Table.tsx
@@ -99,7 +99,12 @@ function TableHeader<T>({
     }
 
     const param = getSortParam();
-    const newQuery = param ? qs.stringify({ ...query, sort_by: param }) : qs.stringify(omit(query, 'sort_by'));
+    // Changing the sort resolves a different keyset sort plan on the backend
+    // (different sortHash), so any cursor we were carrying is no longer valid.
+    // Drop it so the new sort starts a fresh traversal from the first page
+    // rather than hitting a 400 (see SW-1246).
+    const carriedQuery = omit(query, 'cursor');
+    const newQuery = param ? qs.stringify({ ...carriedQuery, sort_by: param }) : qs.stringify(omit(carriedQuery, 'sort_by'));
 
     const url = size(newQuery) ? `${originalUrl}?${newQuery}` : originalUrl;
     return anchor ? `${url}#${anchor}` : url;

--- a/tests/consumer-api.test.ts
+++ b/tests/consumer-api.test.ts
@@ -351,6 +351,18 @@ describe('ConsumerApi', () => {
       mockResponse = Promise.resolve(new Response(null, { status: 500, statusText: 'Internal Server Error' }));
       await expect(consumerApi.getPublishedDatasetView(randomUUID(), 1, 10)).rejects.toThrow(ApiException);
     });
+
+    it('sends cursor and omits page_number when a cursor is supplied (SW-1246)', async () => {
+      const datasetId = randomUUID();
+      mockResponse = Promise.resolve(new Response(JSON.stringify({})));
+
+      await consumerApi.getPublishedDatasetView(datasetId, 1, 25, undefined, 'opaque-cursor-token');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/v2/${datasetId}/data?cursor=opaque-cursor-token&page_size=25&format=frontend&lang=en`,
+        expect.any(Object)
+      );
+    });
   });
 
   describe('getPublishedDatasetFilters', () => {

--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -105,6 +105,15 @@ describe('cappedPaginationSequence', () => {
     const result = cappedPaginationSequence(1, 200);
     expect(result).toEqual([1, 2, '...', 100]);
   });
+
+  test('clamps currentPage to the effective last page so above-cap pages do not leak in', () => {
+    // A user direct-hits ?page_number=150 on a 30000-page view. Numbered
+    // links must still stop at 100 — the clamp pulls currentPage back so
+    // paginationSequence does not seed the set with 150.
+    const result = cappedPaginationSequence(150, 30000);
+    expect(result.every((p) => typeof p === 'string' || (p as number) <= PAGE_NUMBER_CAP)).toBe(true);
+    expect(result[result.length - 1]).toBe(PAGE_NUMBER_CAP);
+  });
 });
 
 describe('mergeCursorPageInfo', () => {
@@ -114,10 +123,22 @@ describe('mergeCursorPageInfo', () => {
     expect(merged).toEqual({ ...base, next_cursor: 'tok', prev_cursor: null });
   });
 
-  test('emits nulls when the view did not supply cursors', () => {
+  test('omits cursor keys entirely when the view did not supply them', () => {
+    // Shared Pagination treats *presence* of either cursor key as the
+    // "cursor pagination supported" signal — non-cursor views (dataset list,
+    // search, admin) must therefore not have null cursor keys layered on.
     const base = { total_records: 100 };
     const merged = mergeCursorPageInfo(base, undefined);
+    expect('next_cursor' in merged).toBe(false);
+    expect('prev_cursor' in merged).toBe(false);
+  });
+
+  test('preserves null cursors when the view actively supplied them', () => {
+    // A cursor-mode response on the last page genuinely carries
+    // `next_cursor: null` — that must propagate through so the
+    // Pagination component still recognises cursor support.
+    const merged = mergeCursorPageInfo({ total_records: 50 }, { next_cursor: null, prev_cursor: 'tok' });
     expect((merged as Record<string, unknown>).next_cursor).toBeNull();
-    expect((merged as Record<string, unknown>).prev_cursor).toBeNull();
+    expect((merged as Record<string, unknown>).prev_cursor).toBe('tok');
   });
 });

--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -3,7 +3,8 @@ import {
   cappedPaginationSequence,
   mergeCursorPageInfo,
   pageInfo,
-  paginationSequence
+  paginationSequence,
+  resolveCursorPage
 } from '../../src/shared/utils/pagination';
 
 // input params are [currentPage, totalPages]
@@ -140,5 +141,42 @@ describe('mergeCursorPageInfo', () => {
     const merged = mergeCursorPageInfo({ total_records: 50 }, { next_cursor: null, prev_cursor: 'tok' });
     expect((merged as Record<string, unknown>).next_cursor).toBeNull();
     expect((merged as Record<string, unknown>).prev_cursor).toBe('tok');
+  });
+});
+
+describe('resolveCursorPage', () => {
+  test('returns null when not in cursor mode regardless of hint', () => {
+    expect(resolveCursorPage(false, '101')).toBeNull();
+  });
+
+  test('returns the hinted page when in cursor mode with a valid hint', () => {
+    expect(resolveCursorPage(true, '101')).toBe(101);
+  });
+
+  test('returns null when the hint is missing', () => {
+    // Deep cursor link arrived without the display counter — fall back to the
+    // coarse "Page > cap" summary rather than guessing.
+    expect(resolveCursorPage(true, undefined)).toBeNull();
+  });
+
+  test('returns null for a non-numeric hint', () => {
+    expect(resolveCursorPage(true, 'abc')).toBeNull();
+  });
+
+  test('returns null for a non-positive hint', () => {
+    expect(resolveCursorPage(true, '0')).toBeNull();
+    expect(resolveCursorPage(true, '-5')).toBeNull();
+  });
+
+  test('ignores non-string hint values', () => {
+    // qs.parse can yield arrays/objects for repeated or nested params; those
+    // are not a usable page number.
+    expect(resolveCursorPage(true, ['101'])).toBeNull();
+    expect(resolveCursorPage(true, 101)).toBeNull();
+  });
+
+  test('parses a leading integer from a hint with trailing characters', () => {
+    // parseInt semantics — tolerant of a stray suffix, still yields the page.
+    expect(resolveCursorPage(true, '102abc')).toBe(102);
   });
 });

--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -1,4 +1,10 @@
-import { pageInfo, paginationSequence } from '../../src/shared/utils/pagination';
+import {
+  PAGE_NUMBER_CAP,
+  cappedPaginationSequence,
+  mergeCursorPageInfo,
+  pageInfo,
+  paginationSequence
+} from '../../src/shared/utils/pagination';
 
 // input params are [currentPage, totalPages]
 // expected output is an array of page numbers as strings, with skipped pages represented by '...'
@@ -70,5 +76,48 @@ describe('pageInfo', () => {
       },
       pagination: []
     });
+  });
+
+  test('returns the cursor-mode shape when currentPage is null', () => {
+    const result = pageInfo(null, 25, 50000);
+    expect(result.current_page).toBeNull();
+    expect(result.total_pages).toBe(2000);
+    expect(result.page_info.start_record).toBeNull();
+    expect(result.page_info.end_record).toBeNull();
+    expect(result.pagination).toEqual([]);
+  });
+});
+
+describe('cappedPaginationSequence', () => {
+  test('caps numbered links at PAGE_NUMBER_CAP (default 100)', () => {
+    // 30000 pages total — the user is on page 50, well below the cap.
+    const result = cappedPaginationSequence(50, 30000);
+    // Last numbered link should be 100, not 30000
+    expect(result[result.length - 1]).toBe(PAGE_NUMBER_CAP);
+  });
+
+  test('falls through to the real total when below the cap', () => {
+    expect(cappedPaginationSequence(2, 10)).toEqual(paginationSequence(2, 10));
+  });
+
+  test('uses the cap as effective last page when current is below cap', () => {
+    // current=1, totalPages=200 → effective=100 → should look like 1, 2, ..., 100
+    const result = cappedPaginationSequence(1, 200);
+    expect(result).toEqual([1, 2, '...', 100]);
+  });
+});
+
+describe('mergeCursorPageInfo', () => {
+  test('layers next_cursor / prev_cursor from the view onto the base page_info', () => {
+    const base = { total_records: 100, start_record: 1, end_record: 25 };
+    const merged = mergeCursorPageInfo(base, { next_cursor: 'tok', prev_cursor: null });
+    expect(merged).toEqual({ ...base, next_cursor: 'tok', prev_cursor: null });
+  });
+
+  test('emits nulls when the view did not supply cursors', () => {
+    const base = { total_records: 100 };
+    const merged = mergeCursorPageInfo(base, undefined);
+    expect((merged as Record<string, unknown>).next_cursor).toBeNull();
+    expect((merged as Record<string, unknown>).prev_cursor).toBeNull();
   });
 });

--- a/tests/utils/parse-page-options.test.ts
+++ b/tests/utils/parse-page-options.test.ts
@@ -73,4 +73,29 @@ describe('parsePageOptions', () => {
     const result = parsePageOptions(mockReq('/datasets?page_size=-10', { page_size: '-10' }));
     expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
   });
+
+  it('caps page_number at the page-number cap to match backend rejection (SW-1246)', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_number=500', { page_number: '500' }));
+    expect(result.pageNumber).toBe(100);
+  });
+
+  it('passes page_number through unchanged when under the cap', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_number=42', { page_number: '42' }));
+    expect(result.pageNumber).toBe(42);
+  });
+
+  it('parses a cursor query parameter', () => {
+    const result = parsePageOptions(mockReq('/datasets?cursor=abc.def', { cursor: 'abc.def' }));
+    expect(result.cursor).toBe('abc.def');
+  });
+
+  it('treats an empty cursor as absent', () => {
+    const result = parsePageOptions(mockReq('/datasets?cursor=', { cursor: '' }));
+    expect(result.cursor).toBeUndefined();
+  });
+
+  it('returns undefined cursor when not supplied', () => {
+    const result = parsePageOptions(mockReq('/datasets?page_number=2', { page_number: '2' }));
+    expect(result.cursor).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Teaches the consumer view to paginate by opaque cursor past page 100, matching the backend cursor (keyset) pagination added in the paired backend PR. Numbered pagination links are capped at 100; "Next" beyond the cap drives traversal via the backend-issued `next_cursor` token.

[SW-1246](https://marvell-consulting.atlassian.net/browse/SW-1246) — paired with the backend cursor pagination work.

## What changed

- **`PageInfoV2`** extended with `next_cursor` / `prev_cursor` (nullable strings).
- **`consumer-api.ts`** accepts an optional `cursor` on `getPublishedDatasetView` / `getFilteredDatasetView` / `getPivotedDatasetView`. When `cursor` is set, `page_number` is omitted from the upstream request.
- **`Pagination.tsx`** renders numbered jumps up to `PAGE_NUMBER_CAP = 100`. Beyond the cap "Next" and "Previous" drive the URL via `cursor=…` instead of `page_number=…`.
- **`parse-page-options.ts`** parses an optional `cursor` and clamps any incoming `page_number` to 100 frontend-side, so we never round-trip through a known 400.
- **`pagination.ts`** gains `PAGE_NUMBER_CAP`, `cappedPaginationSequence` (numbered links capped without affecting the summary's real `total_pages`), and `mergeCursorPageInfo` (restores the backend's cursor fields onto the helper-computed `page_info`). `pageInfo` returns nulls for `current_page` / `start_record` / `end_record` in cursor mode.

## Page number in cursor mode

Keyset pagination has no inherent page index, so the backend sends `current_page: null` past the cap. Rather than only showing "Page > 100 of N", the UI threads a **display-only `page_hint`** counter through the Prev/Next URLs:

- Seeded from the known page number at the cap boundary (the page-100 "Next" link carries `page_hint=101`), then stepped ±1 per click.
- Stays accurate because cursor navigation is strictly sequential — there are no numbered jumps past the cap.
- `page_hint` never reaches the backend (the controller reads only known params; `consumer-api` builds its own upstream query), so it can't trip the `cursor` + `page_number` 400.
- Parsed via the pure, unit-tested `resolveCursorPage` helper. When a deep cursor link arrives without a trustworthy hint it falls back to "Page > 100 of N" rather than guessing.

## Viewport anchor

Pagination links now carry the `#dataset-nav` anchor (`<Pagination anchor="dataset-nav">` in `DataTab`), so clicking through pages keeps the viewport on the data table instead of scrolling to the top — matching the behaviour already applied to the sortable column headers. Scoped to the data tab so the shared `Pagination` component doesn't emit a dead anchor on the list / search / admin pages.

## Cursor invalidation — UI

Two paths invalidate the cursor on the backend (different sortHash or language → 400):

- **Language switch** — `language-switcher.ts` strips `cursor` (and its companion `page_hint`) from the redirect alongside `lang`, so the user lands on page 1 of the translated traversal.
- **Column-header sort** — `Table.tsx`'s sort URL builder strips `cursor` before re-emitting the link, so toggling a sort starts a fresh keyset traversal rather than 400-ing.

In both cases starting fresh from page 1 is the correct semantic — a different language or sort plan is a different traversal.

## Test plan

- [ ] `npm run check` (or equivalent) is green
- [ ] Numbered links render 1–100 only on a dataset with `total_pages > 100`
- [ ] "Next" on page 100 navigates via `cursor=…` (URL no longer has `page_number`)
- [ ] "Previous" past the cap uses `cursor=…` from `prev_cursor`
- [ ] Summary shows the real page number while clicking through cursor mode ("Page 101 of N", "Page 102 of N", …); falls back to "Page > 100 of N" on a deep cursor link with no `page_hint`
- [ ] Clicking a page link keeps the viewport at the data table (no scroll to top)
- [ ] Switching language while paginated drops `cursor` + `page_hint` and resets to page 1
- [ ] Clicking a sortable column header while paginated drops `cursor` and resets to page 1
- [ ] Summary still shows real "Page X of Y" inside the capped range
- [ ] Pagination snapshot test passes at `total_pages = 200` with numbered links capped and Next cursor-driven


[SW-1246]: https://marvellconsulting.atlassian.net/browse/SW-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
