### PR TITLE
SW-1256: Fix breadcrumb trail styles

### DIFF
--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -964,8 +964,9 @@
     width: 25%;
   }
 
-  .govuk-breadcrumbs {
-    margin-top: 20px;
+  .govuk-breadcrumbs.govuk-\!-margin-0,
+  .govuk-breadcrumbs.govuk-\!-margin-top-4 {
+    margin-top: 20px !important;
   }
 
   .govuk-breadcrumbs__link:link,

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -964,10 +964,18 @@
     width: 25%;
   }
 
+  .govuk-breadcrumbs {
+    margin-top: 20px;
+  }
+
   .govuk-breadcrumbs__link:link,
   .govuk-breadcrumbs__link:visited {
     color: colours.$blue;
     font-size: 16px;
+  }
+
+  .govuk-breadcrumbs__link:hover {
+    color: colours.$lightblue;
   }
 
   .govuk-heading-xl,


### PR DESCRIPTION
Reduce top margin to 20px and add hover state to breadcrumb links.

<img width="574" height="258" alt="image" src="https://github.com/user-attachments/assets/67accaf6-a7ed-49ad-b2b3-269e8f448419" />
