### PR TITLE
SW-931: Fix breadcrumb styling for GOV.WALES GEL compliance

### DIFF
--- a/src/consumer/views/components/Breadcrumbs.tsx
+++ b/src/consumer/views/components/Breadcrumbs.tsx
@@ -48,7 +48,10 @@ export function Breadcrumbs(props: BreadcrumbsProps) {
         )}
 
         {props.breadcrumbs?.map((breadcrumb) => (
-          <li className="govuk-breadcrumbs__list-item" key={breadcrumb.id}>
+          <li
+            className={`govuk-breadcrumbs__list-item${!breadcrumb.url ? ' govuk-breadcrumbs__list-item--current' : ''}`}
+            key={breadcrumb.id}
+          >
             {breadcrumb.url ? (
               <a className="govuk-breadcrumbs__link" href={breadcrumb.url}>
                 {breadcrumb.label}

--- a/src/consumer/views/components/Breadcrumbs.tsx
+++ b/src/consumer/views/components/Breadcrumbs.tsx
@@ -50,6 +50,7 @@ export function Breadcrumbs(props: BreadcrumbsProps) {
         {props.breadcrumbs?.map((breadcrumb) => (
           <li
             className={`govuk-breadcrumbs__list-item${!breadcrumb.url ? ' govuk-breadcrumbs__list-item--current' : ''}`}
+            aria-current={!breadcrumb.url ? 'page' : undefined}
             key={breadcrumb.id}
           >
             {breadcrumb.url ? (

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -1204,16 +1204,27 @@
       display: none;
     }
 
+    // Fallback for browsers without :has() support: show the current page item
+    .govuk-breadcrumbs__list-item--current {
+      display: flex;
+      align-items: center;
+    }
+
     // Last item is a link (no current-page indicator) — show it as the parent
     .govuk-breadcrumbs__list-item:last-child:not(.govuk-breadcrumbs__list-item--current) {
       display: flex;
       align-items: center;
     }
 
-    // Last item is current page (span, no link) — show the item before it as parent
-    .govuk-breadcrumbs__list-item:nth-last-child(2):has(~ .govuk-breadcrumbs__list-item--current) {
+    // Enhancement when :has() is supported: show parent and hide current
+    .govuk-breadcrumbs__list:has(.govuk-breadcrumbs__list-item--current)
+      .govuk-breadcrumbs__list-item:nth-last-child(2) {
       display: flex;
       align-items: center;
+    }
+
+    .govuk-breadcrumbs__list:has(.govuk-breadcrumbs__list-item--current) .govuk-breadcrumbs__list-item--current {
+      display: none;
     }
   }
 

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -1189,6 +1189,34 @@
     border-color: colours.$midgrey;
   }
 
+  .govuk-breadcrumbs__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .govuk-breadcrumbs__list-item {
+    float: none;
+  }
+
+  @media screen and (max-width: 767px) {
+    .govuk-breadcrumbs__list-item {
+      display: none;
+    }
+
+    // Last item is a link (no current-page indicator) — show it as the parent
+    .govuk-breadcrumbs__list-item:last-child:not(.govuk-breadcrumbs__list-item--current) {
+      display: flex;
+      align-items: center;
+    }
+
+    // Last item is current page (span, no link) — show the item before it as parent
+    .govuk-breadcrumbs__list-item:nth-last-child(2):has(~ .govuk-breadcrumbs__list-item--current) {
+      display: flex;
+      align-items: center;
+    }
+  }
+
   .govuk-pagination__prev {
     padding-left: 15px;
   }


### PR DESCRIPTION
On mobile (< 768px), the breadcrumb trail now shows only the immediate parent item rather than the full trail, in line with GOV.WALES GEL Section 2.1.

When the breadcrumb trail wraps across lines, items now break as whole units (chevron stays with its text) and the continuation is left-aligned, achieved by switching the breadcrumb list from float-based to flex layout.

Changes:
- Add `govuk-breadcrumbs__list-item--current` class to non-linked (current page) breadcrumb items so CSS can identify the parent item on mobile
- Switch `.govuk-breadcrumbs__list` to `display: flex; flex-wrap: wrap` to fix line-break alignment
- Add `@media (max-width: 767px)` rules to show only the parent breadcrumb: the last item when all items are links (MultiPathBreadcrumbs), or the second-to-last when the last is the current-page indicator