### PR TITLE
SW-1059: Show both Welsh and English published URLs in the overview

### DIFF
--- a/src/publisher/views/publish/overview/overview.jsx
+++ b/src/publisher/views/publish/overview/overview.jsx
@@ -16,7 +16,8 @@ export default function Overview(props) {
   const openUnpublishTask = props.openTasks.find((task) => task.action === 'unpublish');
   const openArchiveTask = props.openTasks.find((task) => task.action === 'archive');
   const openUnarchiveTask = props.openTasks.find((task) => task.action === 'unarchive');
-  const eventualPublicUrl = `${config.frontend.consumer.url}/${props.i18n.language}/${props.dataset.id}/start`;
+  const englishPublicUrl = `${config.frontend.consumer.url}/en-GB/${props.dataset.id}/start`;
+  const welshPublicUrl = `${config.frontend.consumer.welshUrl || config.frontend.consumer.url}/cy-GB/${props.dataset.id}/start`;
 
   return (
     <Layout {...props} title={props.title}>
@@ -50,12 +51,21 @@ export default function Overview(props) {
           )}
 
           {props.datasetStatus === 'new' && (
-            <p
-              className="govuk-body govuk-!-margin-0"
-              dangerouslySetInnerHTML={{
-                __html: props.t('publish.overview.live_url', { url: eventualPublicUrl })
-              }}
-            />
+            <>
+              <p className="govuk-body govuk-!-margin-0">{props.t('publish.overview.live_url')}</p>
+              <p
+                className="govuk-body govuk-!-margin-0"
+                dangerouslySetInnerHTML={{
+                  __html: props.t('publish.overview.live_url_en', { url: englishPublicUrl })
+                }}
+              />
+              <p
+                className="govuk-body govuk-!-margin-0"
+                dangerouslySetInnerHTML={{
+                  __html: props.t('publish.overview.live_url_cy', { url: welshPublicUrl })
+                }}
+              />
+            </>
           )}
 
           <div className="overview-details">

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1075,6 +1075,10 @@
     },
     "overview": {
       "subheading": "Trosolwg o'r set ddata",
+      "group": "Grŵp: <strong>{{groupName}}</strong>",
+      "live_url": "Ar ôl ei chyhoeddi, bydd y set ddata ar gael yn:",
+      "live_url_en": "Saesneg: <strong>{{url}}</strong>",
+      "live_url_cy": "Cymraeg: <strong>{{url}}</strong>",
       "publish": {
         "requested": {
           "publish_at": "Dyddiad cyhoeddi arfaethedig: <strong>{{publishAt}}</strong>",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1121,7 +1121,9 @@
     "overview": {
       "subheading": "Dataset overview",
       "group": "Group: <strong>{{groupName}}</strong>",
-      "live_url": "Once published, the dataset will be available at: <strong>{{url}}</strong>",
+      "live_url": "Once published, the dataset will be available at:",
+      "live_url_en": "English: <strong>{{url}}</strong>",
+      "live_url_cy": "Welsh: <strong>{{url}}</strong>",
       "publish": {
         "requested": {
           "publish_at": "Proposed publication date: <strong>{{publishAt}}</strong>",

--- a/tests/publish-overview.test.ts
+++ b/tests/publish-overview.test.ts
@@ -1,0 +1,86 @@
+import request from 'supertest';
+import JWT from 'jsonwebtoken';
+import { http, HttpResponse } from 'msw';
+
+import app from '../src/publisher/app';
+import { config } from '../src/shared/config';
+import { GlobalRole } from '../src/shared/enums/global-role';
+import { UserStatus } from '../src/shared/enums/user-status';
+import { mockBackend } from './mocks/backend';
+import { completedDataset } from './mocks/fixtures';
+
+const testUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+  provider: 'test',
+  global_roles: [] as GlobalRole[],
+  groups: [],
+  status: UserStatus.Active,
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z'
+};
+
+describe('Publish overview page', () => {
+  const jwt = JWT.sign({ user: testUser }, config.auth.jwt.secret);
+  const datasetId = completedDataset.id;
+  const consumerUrl = config.frontend.consumer.url;
+
+  // The URL is interpolated into a translation string and rendered via i18next, which HTML-escapes
+  // the value — so forward slashes appear as &#x2F; in the response body.
+  const htmlEscape = (value: string) => value.replace(/\//g, '&#x2F;');
+  const englishUrl = htmlEscape(`${consumerUrl}/en-GB/${datasetId}/start`);
+  const welshUrl = htmlEscape(`${consumerUrl}/cy-GB/${datasetId}/start`);
+
+  beforeAll(() => {
+    mockBackend.listen({
+      onUnhandledRequest: ({ url }, print) => {
+        if (!url.includes(config.backend.url)) return;
+        print.error();
+      }
+    });
+  });
+
+  beforeEach(() => {
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        // completedDataset has no first_published_at / archived_at, so it resolves to status 'new'
+        return HttpResponse.json(completedDataset);
+      }),
+      http.get(`${config.backend.url}/dataset/${datasetId}/history`, () => {
+        return HttpResponse.json([]);
+      })
+    );
+  });
+
+  afterEach(() => mockBackend.resetHandlers());
+  afterAll(() => mockBackend.close());
+
+  const makeAgent = () => {
+    const agent = request.agent(app);
+    agent.set('Cookie', `jwt=${jwt}`);
+    return agent;
+  };
+
+  test('shows both the English and Welsh published URLs in English', async () => {
+    const agent = makeAgent();
+    const res = await agent.get(`/en-GB/publish/${datasetId}/overview`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(englishUrl);
+    expect(res.text).toContain(welshUrl);
+    expect(res.text).toContain('English:');
+    expect(res.text).toContain('Welsh:');
+  });
+
+  test('shows both the English and Welsh published URLs in Welsh', async () => {
+    const agent = makeAgent();
+    const res = await agent.get(`/cy-GB/publish/${datasetId}/overview`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(englishUrl);
+    expect(res.text).toContain(welshUrl);
+    // Welsh labels, confirming the cy.json keys resolve rather than falling back to English
+    expect(res.text).toContain('Saesneg:');
+    expect(res.text).toContain('Cymraeg:');
+  });
+});


### PR DESCRIPTION
## SW-1059: Show both the Welsh and English published URLs in the overview

### Problem

The dataset overview page shows a future "Once published, the dataset will be available at: <url>" line for unpublished datasets (`datasetStatus === 'new'`), but it only rendered a single URL built from the current page language. A publisher viewing the page in English saw only the English URL and had to switch the whole page to Welsh to grab the Welsh one.

### Change

- The overview page now builds both an English (`/en-GB/.../start`) and Welsh (`/cy-GB/.../start`) public URL and renders an intro line plus two labelled lines (English / Welsh), shown regardless of the current page language.
- The Welsh URL uses `consumer.welshUrl || consumer.url` as its base, matching the canonical-URL pattern already used in the consumer `Layout.tsx`.

### Bonus fix

`cy.json` was missing the `publish.overview.group` and `publish.overview.live_url` keys, so Welsh overview pages were falling back to the English strings for those two lines. Added the missing Welsh translations.

### i18n note

The new Welsh strings reuse existing terms (`Grŵp`, `Saesneg`, `Cymraeg`) but should be confirmed by a Welsh speaker before merge.

### Tests

Added `tests/publish-overview.test.ts` — asserts both URLs render in both `/en-GB` and `/cy-GB`, and that the Welsh labels resolve (not English fallback).

`npm run check` passes (prettier, lint, 269 tests, build).
