### PR TITLE
SW-1254: log image SHA on container deploy for traceability

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,6 +82,8 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ HEALTHCHECK --interval=5m --timeout=3s \
 ENV NODE_ENV=production
 EXPOSE 3000
 
+# Bake the git SHA into the image so the running app can report which commit it was built from.
+# Passed at build time by CI (build-args: GIT_SHA=${{ github.sha }}); defaults to "unknown" for local builds.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
 # set the user to non-root (node)
 USER node
 

--- a/src/consumer/server.ts
+++ b/src/consumer/server.ts
@@ -7,5 +7,8 @@ import { logger } from '../shared/utils/logger';
 const PORT = config.frontend.consumer.port;
 
 app.listen(PORT, () => {
-  logger.info(`Consumer frontend is running on port ${PORT}`);
+  logger.info(
+    { event: 'app_boot', service: 'consumer', gitSha: config.build.gitSha, appEnv: config.env, port: PORT },
+    `Consumer frontend is running on port ${PORT}`
+  );
 });

--- a/src/publisher/server.ts
+++ b/src/publisher/server.ts
@@ -7,5 +7,8 @@ import { logger } from '../shared/utils/logger';
 const PORT = config.frontend.publisher.port;
 
 app.listen(PORT, () => {
-  logger.info(`Publisher frontend is running on port ${PORT}`);
+  logger.info(
+    { event: 'app_boot', service: 'publisher', gitSha: config.build.gitSha, appEnv: config.env, port: PORT },
+    `Publisher frontend is running on port ${PORT}`
+  );
 });

--- a/src/shared/config/app-config.interface.ts
+++ b/src/shared/config/app-config.interface.ts
@@ -8,6 +8,9 @@ import { SessionStore } from './session-store.enum';
 
 export interface AppConfig {
   env: AppEnv;
+  build: {
+    gitSha: string;
+  };
   email: {
     support: {
       en: string;

--- a/src/shared/config/envs/default.ts
+++ b/src/shared/config/envs/default.ts
@@ -10,6 +10,9 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 export const getDefaultConfig = (): AppConfig => {
   return {
     env: AppEnv.Default, // MUST be overridden by other configs
+    build: {
+      gitSha: process.env.GIT_SHA || 'unknown'
+    },
     email: {
       support: {
         en: 'StatsWales@gov.wales',


### PR DESCRIPTION
## SW-1254 — Deploy → SHA → PR traceability (frontend)

Part of [SW-1254](https://marvell-consulting.atlassian.net/browse/SW-1254). Mirrors the backend change so the frontend self-reports the commit it was built from, making post-incident "what was running at time X?" a one-minute lookup instead of an hours-long forensics exercise.

### What changed
- **Bake the git SHA into the image.** `Dockerfile` accepts `ARG GIT_SHA` and exposes it as `ENV GIT_SHA`; the Docker build workflow passes `build-args: GIT_SHA=${{ github.sha }}`. Local builds default to `unknown`.
- **Expose it at runtime.** New `build.gitSha` config field (interface + `default.ts`), read from `process.env.GIT_SHA`.
- **Structured boot log on both servers.** The publisher and consumer startup lines are now `logger.info({ event: 'app_boot', service, gitSha, appEnv, port }, …)` (tagged `service: 'publisher' | 'consumer'`). Container stdout already flows to the `swprod-log-analytics` workspace, so this is queryable with no new infra — filter `ContainerAppConsoleLogs_CL` on `app_boot`.

### Companion PRs
- `statswales-backend` — same boot-log pattern + `gitSha` on `/healthcheck/`.
- `statswales-terraform` — SHA in the Azure DevOps run name + runbook lookup steps.

### Verification
`npm run check` passes (lint, build, 290 tests).


[SW-1254]: https://marvellconsulting.atlassian.net/browse/SW-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ