### PR TITLE
SW-1286: Add searchable selector for high-cardinality dimension filters

### DIFF
--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -54,6 +54,7 @@ const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; 
         <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png" />
         <link rel="manifest" href="/assets/manifest.json" />
         <link rel="stylesheet" href="/assets/css/govuk-frontend.min.css" />
+        <link rel="stylesheet" href="/assets/css/accessible-autocomplete.min.css" />
         <link rel="stylesheet" href="/assets/css/app.css" />
 
         <CanonicalUrls />

--- a/src/consumer/views/components/Layout.tsx
+++ b/src/consumer/views/components/Layout.tsx
@@ -54,7 +54,6 @@ const Layout = ({ children, title, noPad }: PropsWithChildren<{ title?: string; 
         <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png" />
         <link rel="manifest" href="/assets/manifest.json" />
         <link rel="stylesheet" href="/assets/css/govuk-frontend.min.css" />
-        <link rel="stylesheet" href="/assets/css/accessible-autocomplete.min.css" />
         <link rel="stylesheet" href="/assets/css/app.css" />
 
         <CanonicalUrls />

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1673,6 +1673,12 @@
       "aria": "Chwilio gwerthoedd {{columnName}}",
       "no_match": "Nid oes gwerthoedd yn cyfateb â'ch chwiliad"
     },
+    "searchable": {
+      "select_all": "Dewis pob gwerth<span class=\"govuk-visually-hidden\"> ar gyfer {{columnName}}</span>",
+      "clear": "Clirio'r dewis<span class=\"govuk-visually-hidden\"> ar gyfer {{columnName}}</span>",
+      "remove": "Tynnu",
+      "no_js_notice": "Mae gan y newidyn hwn {{total}} o werthoedd, sy'n ormod i'w rhestru. Mae angen JavaScript i chwilio. Dangosir y {{cap}} gwerth cyntaf isod; trowch JavaScript ymlaen i chwilio a dewis o'u plith i gyd."
+    },
     "apply_all_selections": "Cymhwyso’r holl ddewisiadau",
     "select_all_variables": "Ailosod yr holl hidlwyr",
     "active_filters_notice": "Mae newidynnau yn y tabl hwn wedi'u hidlo. Gallwch newid pa werthoedd sy'n cael eu dangos yn y tabl yn y ddewislen 'Hidlwyr newidynnau'.",

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -1674,10 +1674,8 @@
       "no_match": "Nid oes gwerthoedd yn cyfateb â'ch chwiliad"
     },
     "searchable": {
-      "select_all": "Dewis pob gwerth<span class=\"govuk-visually-hidden\"> ar gyfer {{columnName}}</span>",
-      "clear": "Clirio'r dewis<span class=\"govuk-visually-hidden\"> ar gyfer {{columnName}}</span>",
-      "remove": "Tynnu",
-      "no_js_notice": "Mae gan y newidyn hwn {{total}} o werthoedd, sy'n ormod i'w rhestru. Mae angen JavaScript i chwilio. Dangosir y {{cap}} gwerth cyntaf isod; trowch JavaScript ymlaen i chwilio a dewis o'u plith i gyd."
+      "notice": "Yn dangos y {{cap}} gwerth cyntaf o {{total}}. Nid yw'r newidyn hwn wedi'i hidlo hyd nes i chi ddewis gwerthoedd.",
+      "clear": "Clirio'r dewis<span class=\"govuk-visually-hidden\"> ar gyfer {{columnName}}</span>"
     },
     "apply_all_selections": "Cymhwyso’r holl ddewisiadau",
     "select_all_variables": "Ailosod yr holl hidlwyr",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1721,6 +1721,12 @@
       "aria": "Search {{columnName}} values",
       "no_match": "No values match your search"
     },
+    "searchable": {
+      "select_all": "Select all values<span class=\"govuk-visually-hidden\"> for {{columnName}}</span>",
+      "clear": "Clear selection<span class=\"govuk-visually-hidden\"> for {{columnName}}</span>",
+      "remove": "Remove",
+      "no_js_notice": "This variable has {{total}} values, which is too many to list. Searching requires JavaScript. The first {{cap}} values are shown below; turn on JavaScript to search and choose from all of them."
+    },
     "apply_all_selections": "Apply all selections",
     "select_all_variables": "Reset all filters",
     "pivot_hidden_notice": "Your current table can only show the data for 2 sets of variables at a time. All other variables have to be represented by a single value. You can change which variables and values are shown in your table.",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1722,10 +1722,8 @@
       "no_match": "No values match your search"
     },
     "searchable": {
-      "select_all": "Select all values<span class=\"govuk-visually-hidden\"> for {{columnName}}</span>",
-      "clear": "Clear selection<span class=\"govuk-visually-hidden\"> for {{columnName}}</span>",
-      "remove": "Remove",
-      "no_js_notice": "This variable has {{total}} values, which is too many to list. Searching requires JavaScript. The first {{cap}} values are shown below; turn on JavaScript to search and choose from all of them."
+      "notice": "Showing the first {{cap}} of {{total}} values. This variable is not filtered until you select values.",
+      "clear": "Clear selection<span class=\"govuk-visually-hidden\"> for {{columnName}}</span>"
     },
     "apply_all_selections": "Apply all selections",
     "select_all_variables": "Reset all filters",

--- a/src/shared/public/assets/js/filter-search.js
+++ b/src/shared/public/assets/js/filter-search.js
@@ -1,0 +1,183 @@
+// Progressive enhancement for high-cardinality dimension filters (thousands of
+// values). The server embeds the full value list as JSON and renders a capped
+// no-JS checkbox fallback. Here we replace that fallback with a typeahead +
+// chips selector so only a handful of nodes are ever in the DOM.
+//
+// Selection model (mirrors the plain checkbox filters):
+//   - "all"  → dimension not filtered; submits a filter_all[col]=1 sentinel
+//   - "some" → submits one filter[col].<value>[] hidden input per chosen value
+//   - "none" → submits nothing; the server reports "select at least 1 value"
+(() => {
+  if (typeof accessibleAutocomplete === 'undefined') return; // library missing: keep no-JS fallback
+
+  const escapeHtml = (s) =>
+    s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
+
+  const form = document.querySelector('.filters-container')?.closest('form');
+  const searchableFilters = [...document.querySelectorAll('.filter[data-searchable]')];
+
+  searchableFilters.forEach((filterEl) => {
+    const app = filterEl.querySelector('.filter-search-app');
+    const optionsScript = filterEl.querySelector('script.filter-options-data');
+    const stateScript = filterEl.querySelector('script.filter-state-data');
+    const noJs = filterEl.querySelector('.filter-nojs');
+    if (!app || !optionsScript || !stateScript) return;
+
+    let options;
+    let initial;
+    try {
+      options = JSON.parse(optionsScript.textContent); // [[label, value], [label, value, 1], ...]
+      initial = JSON.parse(stateScript.textContent); // { state, selected: [value, ...] }
+    } catch {
+      return; // malformed data: leave the no-JS fallback in place
+    }
+
+    const column = filterEl.dataset.column;
+    const total = Number(filterEl.dataset.total) || options.length;
+    const inputId = `${filterEl.id}-search`;
+
+    // value -> label lookup, and the searchable item list (excluding disabled)
+    const labelOf = new Map();
+    const items = [];
+    options.forEach(([label, value, disabled]) => {
+      labelOf.set(value, label);
+      if (!disabled) items.push({ l: label, v: value });
+    });
+
+    // The no-JS checkboxes would otherwise submit too — remove them entirely.
+    if (noJs) noJs.remove();
+    app.hidden = false;
+    app.classList.remove('js-only');
+
+    const selected = new Map(); // value -> label, in insertion order
+    let mode = initial.state === 'some' ? 'some' : initial.state === 'none' ? 'none' : 'all';
+    if (mode === 'some') {
+      (initial.selected || []).forEach((v) => selected.set(v, labelOf.get(v) ?? decodeURIComponent(v)));
+    }
+
+    const wrap = app.querySelector('.filter-search-input-wrap');
+    const chipList = app.querySelector('.filter-chips');
+    const countLabel = filterEl.querySelector('.number-selected');
+    const placeholder = wrap?.dataset.placeholder || '';
+    const ariaLabel = wrap?.dataset.aria || '';
+    const noMatch = wrap?.dataset.noMatch || '';
+    const removeLabel = wrap?.dataset.removeLabel || 'Remove';
+
+    const updateCount = () => {
+      if (countLabel) countLabel.textContent = String(mode === 'all' ? total : selected.size);
+    };
+
+    const fieldName = (value) => `filter[${column}].${value}[]`;
+
+    const renderChips = () => {
+      chipList.textContent = '';
+      selected.forEach((label, value) => {
+        const li = document.createElement('li');
+        li.className = 'filter-chip';
+
+        const text = document.createElement('span');
+        text.className = 'filter-chip__label';
+        text.textContent = label;
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'filter-chip__remove';
+        remove.setAttribute('aria-label', `${removeLabel} ${label}`);
+        remove.innerHTML = '<span aria-hidden="true">×</span>';
+        remove.addEventListener('click', () => {
+          selected.delete(value);
+          if (selected.size === 0) mode = 'none';
+          renderChips();
+          updateCount();
+        });
+
+        const field = document.createElement('input');
+        field.type = 'hidden';
+        field.name = fieldName(value);
+        field.value = value;
+
+        li.append(text, remove, field);
+        chipList.appendChild(li);
+      });
+    };
+
+    const addSelection = (value, label) => {
+      if (!value || selected.has(value)) return;
+      selected.set(value, label ?? labelOf.get(value) ?? value);
+      mode = 'some';
+      renderChips();
+      updateCount();
+    };
+
+    // Controls: select all / clear
+    app.querySelector('.filter-search-select-all')?.addEventListener('click', () => {
+      selected.clear();
+      mode = 'all';
+      renderChips();
+      updateCount();
+    });
+    app.querySelector('.filter-search-clear')?.addEventListener('click', () => {
+      selected.clear();
+      mode = 'none';
+      renderChips();
+      updateCount();
+    });
+
+    // Typeahead
+    accessibleAutocomplete({
+      element: wrap,
+      id: inputId,
+      minLength: 1,
+      confirmOnBlur: false,
+      autoselect: false,
+      showNoOptionsFound: true,
+      placeholder,
+      tNoResults: () => noMatch,
+      source: (query, populateResults) => {
+        const q = query.trim().toLowerCase();
+        if (!q) return populateResults([]);
+        const out = [];
+        for (let i = 0; i < items.length && out.length < 50; i++) {
+          const it = items[i];
+          if (selected.has(it.v)) continue;
+          if (it.l.toLowerCase().includes(q)) out.push(it);
+        }
+        populateResults(out);
+      },
+      templates: {
+        inputValue: () => '', // keep the box clear so the next value can be searched
+        suggestion: (it) => (typeof it === 'string' ? escapeHtml(it) : escapeHtml(it.l))
+      },
+      onConfirm: (it) => {
+        if (!it) return;
+        addSelection(it.v, it.l);
+        const input = document.getElementById(inputId);
+        if (input) {
+          input.value = '';
+          input.focus();
+        }
+      }
+    });
+
+    const input = document.getElementById(inputId);
+    if (input && ariaLabel) input.setAttribute('aria-label', ariaLabel);
+
+    renderChips();
+    updateCount();
+
+    // Keep a sentinel input in sync so "all selected" submits as "not filtered".
+    const sentinelName = `filter_all[${column}]`;
+    if (form) {
+      form.addEventListener('submit', () => {
+        app.querySelector(`input[name="${CSS.escape(sentinelName)}"]`)?.remove();
+        if (mode === 'all') {
+          const sentinel = document.createElement('input');
+          sentinel.type = 'hidden';
+          sentinel.name = sentinelName;
+          sentinel.value = '1';
+          app.appendChild(sentinel);
+        }
+      });
+    }
+  });
+})();

--- a/src/shared/public/assets/js/filter-search.js
+++ b/src/shared/public/assets/js/filter-search.js
@@ -1,183 +1,144 @@
 // Progressive enhancement for high-cardinality dimension filters (thousands of
-// values). The server embeds the full value list as JSON and renders a capped
-// no-JS checkbox fallback. Here we replace that fallback with a typeahead +
-// chips selector so only a handful of nodes are ever in the DOM.
+// values). The server renders the first NO_JS_FILTER_CAP values as a normal
+// checkbox list and embeds the full value list as JSON. Here we reveal the
+// search box and let it reach values beyond the rendered cap: matches from the
+// full list that aren't already on the page are injected as checkboxes.
 //
-// Selection model (mirrors the plain checkbox filters):
-//   - "all"  → dimension not filtered; submits a filter_all[col]=1 sentinel
-//   - "some" → submits one filter[col].<value>[] hidden input per chosen value
-//   - "none" → submits nothing; the server reports "select at least 1 value"
+// Selection is positive — ticking a box selects that value. The form carries an
+// always-present filter_all sentinel, so an untouched filter submits as "not
+// filtered" and ticked values apply via their filter[col].VALUE[] inputs. No
+// submit-time JS is needed for that; this script only handles search and the
+// selected-count label.
 (() => {
-  if (typeof accessibleAutocomplete === 'undefined') return; // library missing: keep no-JS fallback
+  const RESULT_LIMIT = 100; // max out-of-cap matches injected per search
 
-  const escapeHtml = (s) =>
-    s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
-
-  const form = document.querySelector('.filters-container')?.closest('form');
-  const searchableFilters = [...document.querySelectorAll('.filter[data-searchable]')];
-
-  searchableFilters.forEach((filterEl) => {
-    const app = filterEl.querySelector('.filter-search-app');
+  document.querySelectorAll('.filter[data-searchable]').forEach((filterEl) => {
     const optionsScript = filterEl.querySelector('script.filter-options-data');
-    const stateScript = filterEl.querySelector('script.filter-state-data');
-    const noJs = filterEl.querySelector('.filter-nojs');
-    if (!app || !optionsScript || !stateScript) return;
+    const group = filterEl.querySelector('.filter-body .govuk-checkboxes');
+    if (!optionsScript || !group) return;
 
     let options;
-    let initial;
     try {
       options = JSON.parse(optionsScript.textContent); // [[label, value], [label, value, 1], ...]
-      initial = JSON.parse(stateScript.textContent); // { state, selected: [value, ...] }
     } catch {
-      return; // malformed data: leave the no-JS fallback in place
+      return; // malformed data: leave the rendered checkboxes as-is
     }
 
     const column = filterEl.dataset.column;
-    const total = Number(filterEl.dataset.total) || options.length;
-    const inputId = `${filterEl.id}-search`;
+    const nameFor = (value) => `filter[${column}].${value}[]`;
+    const all = options.map(([label, value, disabled]) => ({
+      label,
+      value,
+      search: label.toLowerCase(),
+      disabled: !!disabled
+    }));
 
-    // value -> label lookup, and the searchable item list (excluding disabled)
-    const labelOf = new Map();
-    const items = [];
-    options.forEach(([label, value, disabled]) => {
-      labelOf.set(value, label);
-      if (!disabled) items.push({ l: label, v: value });
-    });
-
-    // The no-JS checkboxes would otherwise submit too — remove them entirely.
-    if (noJs) noJs.remove();
-    app.hidden = false;
-    app.classList.remove('js-only');
-
-    const selected = new Map(); // value -> label, in insertion order
-    let mode = initial.state === 'some' ? 'some' : initial.state === 'none' ? 'none' : 'all';
-    if (mode === 'some') {
-      (initial.selected || []).forEach((v) => selected.set(v, labelOf.get(v) ?? decodeURIComponent(v)));
-    }
-
-    const wrap = app.querySelector('.filter-search-input-wrap');
-    const chipList = app.querySelector('.filter-chips');
     const countLabel = filterEl.querySelector('.number-selected');
-    const placeholder = wrap?.dataset.placeholder || '';
-    const ariaLabel = wrap?.dataset.aria || '';
-    const noMatch = wrap?.dataset.noMatch || '';
-    const removeLabel = wrap?.dataset.removeLabel || 'Remove';
+    const noMatch = filterEl.querySelector('.filter-search-no-match');
+    const searchInput = filterEl.querySelector('.filter-search-input');
+
+    // Values already on the page (the server-rendered first cap), plus any we inject.
+    const rendered = new Set([...group.querySelectorAll('input[type="checkbox"]')].map((cb) => cb.value));
+    const injected = [];
 
     const updateCount = () => {
-      if (countLabel) countLabel.textContent = String(mode === 'all' ? total : selected.size);
+      if (countLabel) countLabel.textContent = String(group.querySelectorAll('input:checked').length);
     };
 
-    const fieldName = (value) => `filter[${column}].${value}[]`;
+    const wireCheckbox = (cb) => cb.addEventListener('change', updateCount);
+    group.querySelectorAll('input[type="checkbox"]').forEach(wireCheckbox);
 
-    const renderChips = () => {
-      chipList.textContent = '';
-      selected.forEach((label, value) => {
-        const li = document.createElement('li');
-        li.className = 'filter-chip';
+    const makeCheckbox = ({ label, value, disabled }) => {
+      const item = document.createElement('div');
+      item.className = 'govuk-checkboxes__item';
+      item.dataset.injected = '1';
 
-        const text = document.createElement('span');
-        text.className = 'filter-chip__label';
-        text.textContent = label;
+      const id = nameFor(value).replace(/\s+/g, '_');
+      const input = document.createElement('input');
+      input.className = 'govuk-checkboxes__input';
+      input.id = id;
+      input.name = nameFor(value);
+      input.type = 'checkbox';
+      input.value = value;
+      input.disabled = disabled;
+      wireCheckbox(input);
 
-        const remove = document.createElement('button');
-        remove.type = 'button';
-        remove.className = 'filter-chip__remove';
-        remove.setAttribute('aria-label', `${removeLabel} ${label}`);
-        remove.innerHTML = '<span aria-hidden="true">×</span>';
-        remove.addEventListener('click', () => {
-          selected.delete(value);
-          if (selected.size === 0) mode = 'none';
-          renderChips();
-          updateCount();
-        });
+      const labelEl = document.createElement('label');
+      labelEl.className = 'govuk-label govuk-checkboxes__label';
+      labelEl.htmlFor = id;
+      labelEl.textContent = label;
 
-        const field = document.createElement('input');
-        field.type = 'hidden';
-        field.name = fieldName(value);
-        field.value = value;
-
-        li.append(text, remove, field);
-        chipList.appendChild(li);
-      });
+      item.append(input, labelEl);
+      return item;
     };
 
-    const addSelection = (value, label) => {
-      if (!value || selected.has(value)) return;
-      selected.set(value, label ?? labelOf.get(value) ?? value);
-      mode = 'some';
-      renderChips();
-      updateCount();
-    };
-
-    // Controls: select all / clear
-    app.querySelector('.filter-search-select-all')?.addEventListener('click', () => {
-      selected.clear();
-      mode = 'all';
-      renderChips();
-      updateCount();
-    });
-    app.querySelector('.filter-search-clear')?.addEventListener('click', () => {
-      selected.clear();
-      mode = 'none';
-      renderChips();
-      updateCount();
-    });
-
-    // Typeahead
-    accessibleAutocomplete({
-      element: wrap,
-      id: inputId,
-      minLength: 1,
-      confirmOnBlur: false,
-      autoselect: false,
-      showNoOptionsFound: true,
-      placeholder,
-      tNoResults: () => noMatch,
-      source: (query, populateResults) => {
-        const q = query.trim().toLowerCase();
-        if (!q) return populateResults([]);
-        const out = [];
-        for (let i = 0; i < items.length && out.length < 50; i++) {
-          const it = items[i];
-          if (selected.has(it.v)) continue;
-          if (it.l.toLowerCase().includes(q)) out.push(it);
-        }
-        populateResults(out);
-      },
-      templates: {
-        inputValue: () => '', // keep the box clear so the next value can be searched
-        suggestion: (it) => (typeof it === 'string' ? escapeHtml(it) : escapeHtml(it.l))
-      },
-      onConfirm: (it) => {
-        if (!it) return;
-        addSelection(it.v, it.l);
-        const input = document.getElementById(inputId);
-        if (input) {
-          input.value = '';
-          input.focus();
+    // Drop unchecked injected boxes so the DOM doesn't grow without bound;
+    // keep checked ones — they're part of the selection and must keep submitting.
+    const pruneInjected = () => {
+      for (let i = injected.length - 1; i >= 0; i--) {
+        const cb = injected[i].querySelector('input');
+        if (!cb.checked) {
+          rendered.delete(cb.value);
+          injected[i].remove();
+          injected.splice(i, 1);
         }
       }
-    });
+    };
 
-    const input = document.getElementById(inputId);
-    if (input && ariaLabel) input.setAttribute('aria-label', ariaLabel);
+    const applySearch = (term) => {
+      const q = term.trim().toLowerCase();
+      pruneInjected();
 
-    renderChips();
-    updateCount();
+      if (!q) {
+        group.querySelectorAll('.govuk-checkboxes__item').forEach((item) => (item.style.display = ''));
+        noMatch?.classList.add('js-hidden');
+        return;
+      }
 
-    // Keep a sentinel input in sync so "all selected" submits as "not filtered".
-    const sentinelName = `filter_all[${column}]`;
-    if (form) {
-      form.addEventListener('submit', () => {
-        app.querySelector(`input[name="${CSS.escape(sentinelName)}"]`)?.remove();
-        if (mode === 'all') {
-          const sentinel = document.createElement('input');
-          sentinel.type = 'hidden';
-          sentinel.name = sentinelName;
-          sentinel.value = '1';
-          app.appendChild(sentinel);
-        }
+      let matches = 0;
+
+      // Filter the boxes already on the page by their label.
+      group.querySelectorAll('.govuk-checkboxes__item').forEach((item) => {
+        const label = item.querySelector('label');
+        const hit = !!label && label.textContent.toLowerCase().includes(q);
+        item.style.display = hit ? '' : 'none';
+        if (hit) matches++;
+      });
+
+      // Pull in matches from the full list that aren't rendered yet.
+      for (let i = 0; i < all.length && injected.length < RESULT_LIMIT; i++) {
+        const opt = all[i];
+        if (rendered.has(opt.value) || !opt.search.includes(q)) continue;
+        group.appendChild(makeCheckbox(opt));
+        rendered.add(opt.value);
+        injected.push(group.lastChild);
+        matches++;
+      }
+
+      noMatch?.classList.toggle('js-hidden', matches > 0);
+    };
+
+    // Reveal the search box (hidden by default so it never shows without JS).
+    filterEl.querySelector('.filter-search')?.classList.remove('js-hidden');
+    filterEl.querySelector('.filter-head')?.classList.remove('js-hidden');
+
+    if (searchInput) {
+      let debounce;
+      searchInput.addEventListener('input', (e) => {
+        clearTimeout(debounce);
+        const value = e.target.value;
+        debounce = setTimeout(() => applySearch(value), 200);
       });
     }
+
+    // Clear selection: untick everything and drop injected boxes.
+    filterEl.querySelector('.filter-search-clear')?.addEventListener('click', () => {
+      group.querySelectorAll('input:checked').forEach((cb) => (cb.checked = false));
+      if (searchInput) searchInput.value = '';
+      applySearch('');
+      updateCount();
+    });
+
+    updateCount();
   });
 })();

--- a/src/shared/public/assets/js/filter-search.js
+++ b/src/shared/public/assets/js/filter-search.js
@@ -85,23 +85,37 @@
       }
     };
 
+    // Move checked items to the top of the group so the current selection stays
+    // visible even when a search term filters out everything that doesn't match.
+    const pinCheckedFirst = () => {
+      const checked = [...group.querySelectorAll('.govuk-checkboxes__item')].filter(
+        (item) => item.querySelector('input')?.checked
+      );
+      for (let i = checked.length - 1; i >= 0; i--) {
+        if (group.firstChild !== checked[i]) group.insertBefore(checked[i], group.firstChild);
+      }
+    };
+
     const applySearch = (term) => {
       const q = term.trim().toLowerCase();
       pruneInjected();
 
       if (!q) {
         group.querySelectorAll('.govuk-checkboxes__item').forEach((item) => (item.style.display = ''));
+        pinCheckedFirst();
         noMatch?.classList.add('js-hidden');
         return;
       }
 
       let matches = 0;
 
-      // Filter the boxes already on the page by their label.
+      // Filter the boxes already on the page by their label. Checked boxes stay
+      // visible regardless, so a search never hides the user's current selection.
       group.querySelectorAll('.govuk-checkboxes__item').forEach((item) => {
+        const cb = item.querySelector('input');
         const label = item.querySelector('label');
         const hit = !!label && label.textContent.toLowerCase().includes(q);
-        item.style.display = hit ? '' : 'none';
+        item.style.display = hit || cb?.checked ? '' : 'none';
         if (hit) matches++;
       });
 
@@ -115,6 +129,7 @@
         matches++;
       }
 
+      pinCheckedFirst();
       noMatch?.classList.toggle('js-hidden', matches > 0);
     };
 

--- a/src/shared/public/assets/js/filters.js
+++ b/src/shared/public/assets/js/filters.js
@@ -16,7 +16,8 @@
     }
   }
 
-  const filters = document.querySelectorAll('.filter');
+  // Searchable (high-cardinality) filters are handled by filter-search.js.
+  const filters = [...document.querySelectorAll('.filter')].filter((f) => !f.hasAttribute('data-searchable'));
 
   // On submit, disable all checkboxes for filters where every option is checked
   // so the server receives an empty selection (= no filter applied).

--- a/src/shared/public/scss/_filters.scss
+++ b/src/shared/public/scss/_filters.scss
@@ -80,16 +80,13 @@
     padding: 10px 0;
   }
 
-  // High-cardinality dimensions: typeahead + chips instead of a long
-  // checkbox list (see SearchableFilter / filter-search.js).
-  .filter-search-app {
-    .filter-search-controls {
-      display: flex;
-      gap: 1em;
+  // High-cardinality dimensions render the first N values as a normal checkbox
+  // list; the search box reaches the rest (see SearchableFilter / filter-search.js).
+  .filter--searchable {
+    .filter-searchable-notice {
       margin-bottom: 10px;
     }
 
-    .filter-search-select-all,
     .filter-search-clear {
       background: none;
       border: none;
@@ -111,56 +108,6 @@
           0 4px colours.$black;
         color: colours.$black;
         text-decoration: none;
-      }
-    }
-
-    .filter-chips {
-      list-style: none;
-      margin: 10px 0 0;
-      padding: 0;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      max-height: 300px;
-      overflow: auto;
-    }
-
-    .filter-chip {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      background-color: colours.$lightgrey_light;
-      border: 1px solid colours.$darkgrey;
-      border-radius: 4px;
-      padding: 2px 6px 2px 10px;
-      font-size: 14px;
-      max-width: 100%;
-    }
-
-    .filter-chip__label {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .filter-chip__remove {
-      background: none;
-      border: none;
-      cursor: pointer;
-      font-size: 18px;
-      line-height: 1;
-      padding: 0 4px;
-      color: colours.$darkgrey;
-
-      &:hover {
-        color: colours.$black;
-      }
-
-      &:focus {
-        outline: 3px solid transparent;
-        background-color: colours.$yellow;
-        box-shadow: 0 0 0 1px colours.$black;
-        color: colours.$black;
       }
     }
   }

--- a/src/shared/public/scss/_filters.scss
+++ b/src/shared/public/scss/_filters.scss
@@ -80,6 +80,91 @@
     padding: 10px 0;
   }
 
+  // High-cardinality dimensions: typeahead + chips instead of a long
+  // checkbox list (see SearchableFilter / filter-search.js).
+  .filter-search-app {
+    .filter-search-controls {
+      display: flex;
+      gap: 1em;
+      margin-bottom: 10px;
+    }
+
+    .filter-search-select-all,
+    .filter-search-clear {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 14px;
+      color: colours.$blue;
+      text-decoration: underline;
+      cursor: pointer;
+
+      &:hover {
+        color: colours.$black;
+      }
+
+      &:focus {
+        outline: 3px solid transparent;
+        background-color: colours.$yellow;
+        box-shadow:
+          0 -2px colours.$yellow,
+          0 4px colours.$black;
+        color: colours.$black;
+        text-decoration: none;
+      }
+    }
+
+    .filter-chips {
+      list-style: none;
+      margin: 10px 0 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      max-height: 300px;
+      overflow: auto;
+    }
+
+    .filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background-color: colours.$lightgrey_light;
+      border: 1px solid colours.$darkgrey;
+      border-radius: 4px;
+      padding: 2px 6px 2px 10px;
+      font-size: 14px;
+      max-width: 100%;
+    }
+
+    .filter-chip__label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .filter-chip__remove {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 18px;
+      line-height: 1;
+      padding: 0 4px;
+      color: colours.$darkgrey;
+
+      &:hover {
+        color: colours.$black;
+      }
+
+      &:focus {
+        outline: 3px solid transparent;
+        background-color: colours.$yellow;
+        box-shadow: 0 0 0 1px colours.$black;
+        color: colours.$black;
+      }
+    }
+  }
+
   .filter-container {
     border: 1px solid colours.$darkgrey;
     padding: 10px;

--- a/src/shared/views/components/filters/CheckboxFilter.tsx
+++ b/src/shared/views/components/filters/CheckboxFilter.tsx
@@ -6,6 +6,8 @@ import { CheckboxOptions } from '../Checkbox';
 import { CheckboxGroup } from '../CheckboxGroup';
 import T from '../T';
 import { useLocals } from '../../context/Locals';
+import { SearchableFilter } from './SearchableFilter';
+import { isSearchableFilter } from './searchable-filter';
 
 export type CheckboxFilterProps = {
   filter: FilterTable;
@@ -42,6 +44,11 @@ const allOptionValues = (options: FilterValues[]): string[] => {
 
 export const CheckboxFilter = ({ filter, values, disabled = false }: CheckboxFilterProps) => {
   const { t, errors } = useLocals();
+
+  if (isSearchableFilter(filter)) {
+    return <SearchableFilter filter={filter} values={values} disabled={disabled} />;
+  }
+
   const fieldName = `filter[${filter.factTableColumn}]`;
   const hasError = errors?.some((e) => e.field === fieldName);
 

--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -7,6 +7,7 @@ import { Filter } from '../../../interfaces/filter';
 import { useLocals } from '../../context/Locals';
 import { DatasetDTO } from '../../../dtos/dataset';
 import { RadioFilter } from './RadioFilter';
+import { isSearchableFilter } from './searchable-filter';
 
 export type FiltersProps = {
   filters: FilterTable[];
@@ -25,6 +26,7 @@ export const Filters = (props: FiltersProps) => {
   const { buildUrl, i18n } = useLocals();
 
   const isPivot = !!(props.rows && props.columns);
+  const hasSearchable = filters?.some((filter) => isSearchableFilter(filter));
 
   const selectAllLink = preview
     ? buildUrl(`/publish/${dataset.id}/cube-preview`, i18n.language)
@@ -83,6 +85,12 @@ export const Filters = (props: FiltersProps) => {
       )}
 
       <script type="module" src="/assets/js/filters.js" />
+      {hasSearchable && (
+        <>
+          <script src="/assets/js/accessible-autocomplete.min.js" />
+          <script type="module" src="/assets/js/filter-search.js" />
+        </>
+      )}
     </div>
   );
 };

--- a/src/shared/views/components/filters/Filters.tsx
+++ b/src/shared/views/components/filters/Filters.tsx
@@ -85,12 +85,7 @@ export const Filters = (props: FiltersProps) => {
       )}
 
       <script type="module" src="/assets/js/filters.js" />
-      {hasSearchable && (
-        <>
-          <script src="/assets/js/accessible-autocomplete.min.js" />
-          <script type="module" src="/assets/js/filter-search.js" />
-        </>
-      )}
+      {hasSearchable && <script type="module" src="/assets/js/filter-search.js" />}
     </div>
   );
 };

--- a/src/shared/views/components/filters/SearchableFilter.tsx
+++ b/src/shared/views/components/filters/SearchableFilter.tsx
@@ -93,12 +93,12 @@ export const SearchableFilter = ({ filter, values, disabled = false }: Searchabl
           {/* Enhanced by filter-search.js once JS is available */}
           <div className="filter-search-app js-only" hidden>
             <div className="filter-search-controls">
-              <button type="button" className="filter-search-select-all govuk-link button-as-link">
+              <button type="button" className="filter-search-select-all govuk-link">
                 <T columnName={filter.columnName} raw>
                   filters.searchable.select_all
                 </T>
               </button>
-              <button type="button" className="filter-search-clear govuk-link button-as-link">
+              <button type="button" className="filter-search-clear govuk-link">
                 <T columnName={filter.columnName} raw>
                   filters.searchable.clear
                 </T>

--- a/src/shared/views/components/filters/SearchableFilter.tsx
+++ b/src/shared/views/components/filters/SearchableFilter.tsx
@@ -16,39 +16,40 @@ export type SearchableFilterProps = {
 // "<!--" in a label break out of the element. JSON.parse reads < fine.
 const safeJson = (data: unknown): string => JSON.stringify(data).replace(/</g, '\\u003c');
 
-// High-cardinality dimensions (thousands of values). Instead of one checkbox per
-// value — which freezes the browser — we render a search-driven selector:
-//   - the full value list is embedded once as compact JSON for the client script
-//   - JS builds a typeahead + chips UI from it (filter-search.js)
-//   - without JS a capped list of plain checkboxes is shown as a fallback
+// High-cardinality dimensions (thousands of values). Rendering one checkbox per
+// value freezes the browser, so we render the first NO_JS_FILTER_CAP values as a
+// normal checkbox list and embed the full value list as JSON. filter-search.js
+// lets the search box reach values beyond the rendered cap by injecting matching
+// checkboxes on demand. Without JS the first cap values remain selectable.
+//
+// Selection is positive: the dimension is "not filtered" until the user ticks a
+// value. An always-present filter_all sentinel encodes that default — when no
+// value is checked the server treats the column as not filtered; when values are
+// checked they apply via the filter[col].VALUE[] inputs. (See the cubePreview
+// controller: the sentinel only suppresses the "select a value" validation;
+// actual filtering is driven by the submitted filter[] values.)
 export const SearchableFilter = ({ filter, values, disabled = false }: SearchableFilterProps) => {
   const { t, errors } = useLocals();
   const fieldName = `filter[${filter.factTableColumn}]`;
   const hasError = errors?.some((e) => e.field === fieldName);
 
   const total = filter.values.length;
+  const cap = Math.min(NO_JS_FILTER_CAP, total);
   const filterId = `filter-${filter.factTableColumn.replaceAll(/\s+/g, '_')}`;
 
   // `values` is the active selection echoed back by the API (decoded references).
   const selected = values ?? [];
   const selectedEncoded = selected.map(encodeURIComponent);
 
-  // Initial state: an active selection shows those chips; an error shows none;
-  // otherwise the default is "all selected" (i.e. the dimension is not filtered).
-  const initialState = hasError ? 'none' : selected.length > 0 ? 'some' : 'all';
-  const selectedCount = initialState === 'all' ? total : selected.length;
-
+  // Full list for the client search, and the capped slice rendered as checkboxes
+  // (selected values first so an active selection is always on the page).
   const options = toSearchOptions(filter.values);
-
-  // No-JS fallback: render a capped slice of plain checkboxes so the dimension
-  // remains (partially) usable without JavaScript.
   const cappedOptions = cappedFilterValues(filter.values, selected, NO_JS_FILTER_CAP);
   const cappedNormalized = cappedOptions.map((opt) => ({
     label: opt.description,
     value: encodeURIComponent(opt.reference),
     disabled: opt.count === '0'
   }));
-  const cappedCheckedValues = hasError ? [] : selectedEncoded;
 
   return (
     <div
@@ -73,7 +74,7 @@ export const SearchableFilter = ({ filter, values, disabled = false }: Searchabl
         )}
 
         <div className="dimension-accordion__count">
-          <T filtered={selectedCount} total={total} raw>
+          <T filtered={selected.length} total={total} raw>
             filters.summary
           </T>
         </div>
@@ -84,51 +85,45 @@ export const SearchableFilter = ({ filter, values, disabled = false }: Searchabl
             className="filter-options-data"
             dangerouslySetInnerHTML={{ __html: safeJson(options) }}
           />
-          <script
-            type="application/json"
-            className="filter-state-data"
-            dangerouslySetInnerHTML={{ __html: safeJson({ state: initialState, selected: selectedEncoded }) }}
-          />
 
-          {/* Enhanced by filter-search.js once JS is available */}
-          <div className="filter-search-app js-only" hidden>
-            <div className="filter-search-controls">
-              <button type="button" className="filter-search-select-all govuk-link">
-                <T columnName={filter.columnName} raw>
-                  filters.searchable.select_all
-                </T>
-              </button>
-              <button type="button" className="filter-search-clear govuk-link">
-                <T columnName={filter.columnName} raw>
-                  filters.searchable.clear
-                </T>
-              </button>
-            </div>
-            <div
-              className="filter-search-input-wrap"
-              data-placeholder={t('filters.search.placeholder')}
-              data-aria={t('filters.search.aria', { columnName: filter.columnName })}
-              data-no-match={t('filters.search.no_match')}
-              data-remove-label={t('filters.searchable.remove')}
-            />
-            <ul className="filter-chips" />
-          </div>
+          <p className="govuk-hint govuk-!-font-size-16 filter-searchable-notice">
+            <T cap={cap} total={total} raw>
+              filters.searchable.notice
+            </T>
+          </p>
 
-          {/* No-JS fallback */}
-          <div className="filter-nojs">
-            <p className="govuk-body govuk-!-font-size-16">
-              <T total={total} cap={Math.min(NO_JS_FILTER_CAP, total)} raw>
-                filters.searchable.no_js_notice
-              </T>
-            </p>
-            <div className="filter-body">
-              <CheckboxGroup
-                name={`filter[${filter.factTableColumn}]`}
-                options={cappedNormalized}
-                values={cappedCheckedValues}
+          <div className="filter-head js-hidden">
+            <div className="filter-search js-hidden">
+              <input
+                type="text"
+                id={`${filterId}-search`}
+                className="govuk-input filter-search-input"
+                placeholder={t('filters.search.placeholder')}
+                aria-label={t('filters.search.aria', { columnName: filter.columnName })}
               />
             </div>
+            {!disabled && (
+              <div className="filter-controls">
+                <button type="button" className="filter-search-clear">
+                  <T columnName={filter.columnName} raw>
+                    filters.searchable.clear
+                  </T>
+                </button>
+              </div>
+            )}
           </div>
+
+          <div className="filter-body">
+            <CheckboxGroup name={fieldName} options={cappedNormalized} values={hasError ? [] : selectedEncoded} />
+            <span className="filter-search-no-match govuk-body js-hidden">
+              <T>filters.search.no_match</T>
+            </span>
+          </div>
+
+          {/* Default = not filtered until a value is picked. Always present so the
+              server never reports this column as missing a selection; submitted
+              filter[] values still take effect when the user ticks options. */}
+          {!disabled && <input type="hidden" name={`filter_all[${filter.factTableColumn}]`} value="1" />}
         </div>
 
         {disabled ? null : (

--- a/src/shared/views/components/filters/SearchableFilter.tsx
+++ b/src/shared/views/components/filters/SearchableFilter.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+
+import { FilterTable } from '../../../dtos/filter-table';
+import { CheckboxGroup } from '../CheckboxGroup';
+import T from '../T';
+import { useLocals } from '../../context/Locals';
+import { NO_JS_FILTER_CAP, cappedFilterValues, toSearchOptions } from './searchable-filter';
+
+export type SearchableFilterProps = {
+  filter: FilterTable;
+  values?: string[];
+  disabled?: boolean;
+};
+
+// Embed data as JSON inside a <script> without letting a stray "</script>" or
+// "<!--" in a label break out of the element. JSON.parse reads < fine.
+const safeJson = (data: unknown): string => JSON.stringify(data).replace(/</g, '\\u003c');
+
+// High-cardinality dimensions (thousands of values). Instead of one checkbox per
+// value — which freezes the browser — we render a search-driven selector:
+//   - the full value list is embedded once as compact JSON for the client script
+//   - JS builds a typeahead + chips UI from it (filter-search.js)
+//   - without JS a capped list of plain checkboxes is shown as a fallback
+export const SearchableFilter = ({ filter, values, disabled = false }: SearchableFilterProps) => {
+  const { t, errors } = useLocals();
+  const fieldName = `filter[${filter.factTableColumn}]`;
+  const hasError = errors?.some((e) => e.field === fieldName);
+
+  const total = filter.values.length;
+  const filterId = `filter-${filter.factTableColumn.replaceAll(/\s+/g, '_')}`;
+
+  // `values` is the active selection echoed back by the API (decoded references).
+  const selected = values ?? [];
+  const selectedEncoded = selected.map(encodeURIComponent);
+
+  // Initial state: an active selection shows those chips; an error shows none;
+  // otherwise the default is "all selected" (i.e. the dimension is not filtered).
+  const initialState = hasError ? 'none' : selected.length > 0 ? 'some' : 'all';
+  const selectedCount = initialState === 'all' ? total : selected.length;
+
+  const options = toSearchOptions(filter.values);
+
+  // No-JS fallback: render a capped slice of plain checkboxes so the dimension
+  // remains (partially) usable without JavaScript.
+  const cappedOptions = cappedFilterValues(filter.values, selected, NO_JS_FILTER_CAP);
+  const cappedNormalized = cappedOptions.map((opt) => ({
+    label: opt.description,
+    value: encodeURIComponent(opt.reference),
+    disabled: opt.count === '0'
+  }));
+  const cappedCheckedValues = hasError ? [] : selectedEncoded;
+
+  return (
+    <div
+      className="filter filter--searchable"
+      id={filterId}
+      data-total={total}
+      data-column={filter.factTableColumn}
+      data-searchable
+    >
+      <details className="dimension-accordion" open={hasError || undefined}>
+        <summary className="dimension-accordion__summary">
+          <span className="dimension-accordion__title">{filter.columnName}</span>
+        </summary>
+
+        {hasError && (
+          <p className="filter-error govuk-error-message">
+            <span className="govuk-visually-hidden">Error: </span>
+            <T columnName={filter.columnName} raw>
+              filters.no_values_selected
+            </T>
+          </p>
+        )}
+
+        <div className="dimension-accordion__count">
+          <T filtered={selectedCount} total={total} raw>
+            filters.summary
+          </T>
+        </div>
+
+        <div className="filter-container option-select">
+          <script
+            type="application/json"
+            className="filter-options-data"
+            dangerouslySetInnerHTML={{ __html: safeJson(options) }}
+          />
+          <script
+            type="application/json"
+            className="filter-state-data"
+            dangerouslySetInnerHTML={{ __html: safeJson({ state: initialState, selected: selectedEncoded }) }}
+          />
+
+          {/* Enhanced by filter-search.js once JS is available */}
+          <div className="filter-search-app js-only" hidden>
+            <div className="filter-search-controls">
+              <button type="button" className="filter-search-select-all govuk-link button-as-link">
+                <T columnName={filter.columnName} raw>
+                  filters.searchable.select_all
+                </T>
+              </button>
+              <button type="button" className="filter-search-clear govuk-link button-as-link">
+                <T columnName={filter.columnName} raw>
+                  filters.searchable.clear
+                </T>
+              </button>
+            </div>
+            <div
+              className="filter-search-input-wrap"
+              data-placeholder={t('filters.search.placeholder')}
+              data-aria={t('filters.search.aria', { columnName: filter.columnName })}
+              data-no-match={t('filters.search.no_match')}
+              data-remove-label={t('filters.searchable.remove')}
+            />
+            <ul className="filter-chips" />
+          </div>
+
+          {/* No-JS fallback */}
+          <div className="filter-nojs">
+            <p className="govuk-body govuk-!-font-size-16">
+              <T total={total} cap={Math.min(NO_JS_FILTER_CAP, total)} raw>
+                filters.searchable.no_js_notice
+              </T>
+            </p>
+            <div className="filter-body">
+              <CheckboxGroup
+                name={`filter[${filter.factTableColumn}]`}
+                options={cappedNormalized}
+                values={cappedCheckedValues}
+              />
+            </div>
+          </div>
+        </div>
+
+        {disabled ? null : (
+          <div className="filter-apply">
+            <button
+              name="dataViewsChoice"
+              value="filter"
+              type="submit"
+              className="govuk-button govuk-button-small button-black"
+              data-module="govuk-button"
+            >
+              <T>filters.apply_all_selections</T>
+            </button>
+          </div>
+        )}
+      </details>
+    </div>
+  );
+};

--- a/src/shared/views/components/filters/searchable-filter.ts
+++ b/src/shared/views/components/filters/searchable-filter.ts
@@ -1,0 +1,51 @@
+import { FilterTable, FilterValues } from '../../../dtos/filter-table';
+
+// Above this many values a dimension is rendered as a searchable selector
+// (typeahead + chips) instead of one checkbox per value. Rendering tens of
+// thousands of checkboxes freezes the browser, so we cap what hits the DOM.
+export const SEARCHABLE_FILTER_THRESHOLD = 1000;
+
+// How many values the no-JS fallback renders as plain checkboxes. JS users get
+// the full list via the embedded JSON; without JS only this many are reachable.
+export const NO_JS_FILTER_CAP = 1000;
+
+// Compact tuple used for the embedded JSON: [label, encodedValue, disabled?].
+// Tuples keep the payload small — there can be tens of thousands of these.
+type SearchOption = [label: string, value: string] | [label: string, value: string, disabled: 1];
+
+// A filter is only made searchable when it's a flat list (no hierarchy) above
+// the threshold. Hierarchical dimensions keep the existing tree of checkboxes —
+// flattening one into a search list would lose the parent/child structure.
+const isFlat = (values: FilterValues[]): boolean => values.every((v) => !v.children?.length);
+
+export const isSearchableFilter = (filter: FilterTable, threshold: number = SEARCHABLE_FILTER_THRESHOLD): boolean => {
+  return isFlat(filter.values) && filter.values.length > threshold;
+};
+
+// The subset rendered for the no-JS fallback: any currently-selected values
+// first (so an active filter still shows its selection), then fill up to the
+// cap with the remaining values. `selected` holds decoded references.
+export const cappedFilterValues = (
+  values: FilterValues[],
+  selected: string[] = [],
+  cap: number = NO_JS_FILTER_CAP
+): FilterValues[] => {
+  if (values.length <= cap) return values;
+
+  const selectedSet = new Set(selected);
+  const chosen = values.filter((v) => selectedSet.has(v.reference));
+  if (chosen.length >= cap) return chosen.slice(0, cap);
+
+  const rest = values.filter((v) => !selectedSet.has(v.reference));
+  return [...chosen, ...rest.slice(0, cap - chosen.length)];
+};
+
+// Encode references the same way normalizeFilters does, so the values submitted
+// by the search selector match what the server expects from a ticked checkbox.
+export const toSearchOptions = (values: FilterValues[]): SearchOption[] => {
+  return values.map((opt) =>
+    opt.count === '0'
+      ? [opt.description, encodeURIComponent(opt.reference), 1]
+      : [opt.description, encodeURIComponent(opt.reference)]
+  );
+};

--- a/tests/utils/searchable-filter.test.ts
+++ b/tests/utils/searchable-filter.test.ts
@@ -1,0 +1,87 @@
+import { FilterTable, FilterValues } from '../../src/shared/dtos/filter-table';
+import {
+  SEARCHABLE_FILTER_THRESHOLD,
+  NO_JS_FILTER_CAP,
+  isSearchableFilter,
+  cappedFilterValues,
+  toSearchOptions
+} from '../../src/shared/views/components/filters/searchable-filter';
+
+const flatValues = (count: number): FilterValues[] =>
+  Array.from({ length: count }, (_, i) => ({ reference: `ref-${i}`, description: `Value ${i}` }));
+
+const filter = (values: FilterValues[]): FilterTable => ({
+  columnName: 'Drug',
+  factTableColumn: 'drug',
+  values
+});
+
+describe('isSearchableFilter', () => {
+  test('is false for a small flat list', () => {
+    expect(isSearchableFilter(filter(flatValues(10)))).toBe(false);
+  });
+
+  test('is false at exactly the threshold', () => {
+    expect(isSearchableFilter(filter(flatValues(SEARCHABLE_FILTER_THRESHOLD)))).toBe(false);
+  });
+
+  test('is true above the threshold', () => {
+    expect(isSearchableFilter(filter(flatValues(SEARCHABLE_FILTER_THRESHOLD + 1)))).toBe(true);
+  });
+
+  test('respects a custom threshold', () => {
+    expect(isSearchableFilter(filter(flatValues(50)), 25)).toBe(true);
+    expect(isSearchableFilter(filter(flatValues(50)), 100)).toBe(false);
+  });
+
+  test('is false for a hierarchical list even when large', () => {
+    const values: FilterValues[] = [
+      { reference: 'parent', description: 'Parent', children: flatValues(SEARCHABLE_FILTER_THRESHOLD + 1) }
+    ];
+    expect(isSearchableFilter(filter(values))).toBe(false);
+  });
+});
+
+describe('cappedFilterValues', () => {
+  test('returns everything when under the cap', () => {
+    const values = flatValues(10);
+    expect(cappedFilterValues(values, [], 200)).toHaveLength(10);
+  });
+
+  test('caps to the limit when over', () => {
+    expect(cappedFilterValues(flatValues(5000), [], NO_JS_FILTER_CAP)).toHaveLength(NO_JS_FILTER_CAP);
+  });
+
+  test('puts selected values first so an active selection is always shown', () => {
+    const values = flatValues(5000);
+    const selected = ['ref-4000', 'ref-4500'];
+    const capped = cappedFilterValues(values, selected, 200);
+    expect(capped).toHaveLength(200);
+    expect(capped.slice(0, 2).map((v) => v.reference)).toEqual(selected);
+  });
+
+  test('does not exceed the cap even with many selected values', () => {
+    const values = flatValues(5000);
+    const selected = values.slice(0, 300).map((v) => v.reference);
+    const capped = cappedFilterValues(values, selected, 200);
+    expect(capped).toHaveLength(200);
+  });
+});
+
+describe('toSearchOptions', () => {
+  test('encodes the reference to match a submitted checkbox value', () => {
+    const values: FilterValues[] = [{ reference: '2018/19', description: 'April 2018 to March 2019' }];
+    expect(toSearchOptions(values)).toEqual([['April 2018 to March 2019', '2018%2F19']]);
+  });
+
+  test('marks zero-count values as disabled with a trailing 1', () => {
+    const values: FilterValues[] = [
+      { reference: 'a', description: 'A', count: '5' },
+      { reference: 'b', description: 'B', count: '0' }
+    ];
+    expect(toSearchOptions(values)).toEqual([
+      ['A', 'a'],
+      ['B', 'b', 1]
+    ]);
+  });
+});

--- a/tests/views/searchable-filter-render.test.tsx
+++ b/tests/views/searchable-filter-render.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { CheckboxFilter } from '../../src/shared/views/components/filters/CheckboxFilter';
+import { LocalsProvider } from '../../src/shared/views/context/Locals';
+import { FilterTable, FilterValues } from '../../src/shared/dtos/filter-table';
+import { NO_JS_FILTER_CAP } from '../../src/shared/views/components/filters/searchable-filter';
+
+const flatValues = (count: number): FilterValues[] =>
+  Array.from({ length: count }, (_, i) => ({ reference: `ref-${i}`, description: `Drug ${i}` }));
+
+const render = (filter: FilterTable, values?: string[]) =>
+  renderToStaticMarkup(
+    // a no-op translator is enough — we only assert on structure, not copy
+    <LocalsProvider t={(key: string) => key} errors={[]}>
+      <CheckboxFilter filter={filter} values={values} />
+    </LocalsProvider>
+  );
+
+const countCheckboxes = (html: string) => (html.match(/type="checkbox"/g) || []).length;
+
+describe('CheckboxFilter — high-cardinality dimensions', () => {
+  test('a small flat dimension still renders one checkbox per value', () => {
+    const html = render({ columnName: 'Area', factTableColumn: 'area', values: flatValues(10) });
+    expect(html).not.toContain('data-searchable');
+    expect(countCheckboxes(html)).toBe(10);
+  });
+
+  test('a huge flat dimension renders the searchable selector, not 44k checkboxes', () => {
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) });
+
+    expect(html).toContain('data-searchable');
+    expect(html).toContain('filter-search-app');
+    // the full value list is embedded once as JSON for the client script
+    expect(html).toContain('application/json');
+    expect(html).toContain('filter-options-data');
+    // only the no-JS fallback checkboxes hit the DOM — capped, not 44k
+    expect(countCheckboxes(html)).toBeLessThanOrEqual(NO_JS_FILTER_CAP);
+  });
+
+  test('an active selection on a huge dimension is preserved in the embedded state', () => {
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) }, ['ref-5']);
+    // encoded selection echoed into the state script the client reads on load
+    expect(html).toContain('"state":"some"');
+    expect(html).toContain('ref-5');
+  });
+
+  test('embedded JSON cannot break out of the script element', () => {
+    const values: FilterValues[] = [
+      { reference: 'x', description: '</script><script>alert(1)</script>' },
+      ...flatValues(2000)
+    ];
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('\\u003c/script>');
+  });
+});

--- a/tests/views/searchable-filter-render.test.tsx
+++ b/tests/views/searchable-filter-render.test.tsx
@@ -30,19 +30,30 @@ describe('CheckboxFilter — high-cardinality dimensions', () => {
     const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) });
 
     expect(html).toContain('data-searchable');
-    expect(html).toContain('filter-search-app');
     // the full value list is embedded once as JSON for the client script
-    expect(html).toContain('application/json');
     expect(html).toContain('filter-options-data');
-    // only the no-JS fallback checkboxes hit the DOM — capped, not 44k
-    expect(countCheckboxes(html)).toBeLessThanOrEqual(NO_JS_FILTER_CAP);
+    // a search box is present to reach values beyond the rendered cap
+    expect(html).toContain('filter-search-input');
   });
 
-  test('an active selection on a huge dimension is preserved in the embedded state', () => {
-    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) }, ['ref-5']);
-    // encoded selection echoed into the state script the client reads on load
-    expect(html).toContain('"state":"some"');
-    expect(html).toContain('ref-5');
+  test('renders the first cap values as real checkboxes (the part that fixes the freeze)', () => {
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) });
+    const count = countCheckboxes(html);
+    // a usable list is shown immediately, but capped well below 44k
+    expect(count).toBe(NO_JS_FILTER_CAP);
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('carries an always-present filter_all sentinel so an untouched filter is "not filtered"', () => {
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) });
+    expect(html).toContain('name="filter_all[drug]"');
+  });
+
+  test('an active selection is rendered as checked checkboxes, selected-first', () => {
+    const html = render({ columnName: 'Drug', factTableColumn: 'drug', values: flatValues(44000) }, ['ref-9000']);
+    // the selected value is within the cap (selected-first) and checked
+    expect(html).toContain('value="ref-9000"');
+    expect(html).toContain('checked');
   });
 
   test('embedded JSON cannot break out of the script element', () => {


### PR DESCRIPTION
## Problem

A dimension with tens of thousands of values (e.g. the ~44,000-value **Drug** dimension on `cube-preview`) rendered one checkbox per value. That produced roughly 150,000 DOM nodes for a single filter, plus a `change` listener on every one of the 44k checkboxes, which froze the filter panel and the whole page. The same `CheckboxFilter` is shared by the public consumer pages, so a published dataset would have frozen end users' browsers too.

<img width="992" height="956" alt="Screenshot 2026-06-10 at 16 09 08" src="https://github.com/user-attachments/assets/f2900d31-a0f0-4b2b-b41e-ec94c5cc6923" />


## Change

Flat dimensions above **1,000** values now render a **capped checkbox list with a search box** instead of one checkbox per value. The UI is the same checkbox list used by smaller filters — only the number rendered is capped:

- The first **1,000** values (selected-first) render immediately as normal checkboxes. No empty state, no chips — it looks and behaves like a sub-1,000 filter.
- The full value list is embedded **once** as compact JSON. A search box filters the visible checkboxes and reaches values beyond the cap by injecting matching checkboxes from the embedded list (capped at 100 injected matches per search).
- Checked values stay pinned and visible at the top during search, so the current selection is never hidden by a search term.

**No-JS fallback:** the first 1,000 checkboxes render server-side and submit normally; only the search box (which reveals values beyond the cap) requires JavaScript.

**Submit semantics unchanged — no backend change.** Selection is positive: an untouched filter submits as "not filtered" via an always-present `filter_all[col]=1` sentinel, and ticked values submit as `filter[col].VALUE[]` inputs — byte-for-byte what a ticked checkbox sends. No submit-time JS required.

Because `CheckboxFilter` is shared, this fixes both the publisher `cube-preview` and the public consumer dataset pages.

## Behaviour by dimension size

| Values | Rendering |
| --- | --- |
| ≤ 1,000 | Existing checkbox list (unchanged) |
| > 1,000, flat | Capped checkbox list (first 1,000) + search box to reach the rest |
| > 1,000, hierarchical | Existing checkbox tree (flattening would lose parent/child structure) |

## Files

- `searchable-filter.ts` — threshold/cap constants + pure helpers (`isSearchableFilter`, `cappedFilterValues`, `toSearchOptions`)
- `SearchableFilter.tsx` — renders the capped checkbox list, the always-present `filter_all` sentinel, the search box, and embeds the full value list as safe JSON
- `CheckboxFilter.tsx` — delegates to `SearchableFilter` above the threshold
- `Filters.tsx` — conditionally loads `filter-search.js` when any filter is searchable
- `filter-search.js` — reveals the search box and injects out-of-cap matches; pins checked items to the top; `filters.js` skips `[data-searchable]`
- `en.json` / `cy.json` — new `filters.searchable.*` keys
- `_filters.scss` — notice + clear-control styles

## Tests

- `searchable-filter.test.ts` — unit tests for the threshold/cap/encoding helpers
- `searchable-filter-render.test.tsx` — asserts a 44k dimension renders exactly 1,000 checkboxes (not 44k, not zero), carries the `filter_all` sentinel, preserves an active selection selected-first, and that embedded JSON can't break out of the `<script>` element

`npm run check` passes (lint, 307 tests, build).

## Limitations / follow-ups

- No-JS users can only reach the first 1,000 values, and "all except a few" of 44k isn't expressible — the backend only takes positive selections. Accepted as best-effort.
- The embedded JSON is ~1–2 MB in the HTML for 44k values (gzips well; far cheaper than the ~8 MB of checkbox markup it replaces). If pages routinely carry several huge dimensions, a lazy per-dimension fetch would be the next optimisation.
- Not yet driven in a browser against the live 44k dataset (needs the backend + that dataset); verified via rendered HTML and submit format in tests.

## Thresholds

`SEARCHABLE_FILTER_THRESHOLD` (1,000) and `NO_JS_FILTER_CAP` (1,000) are named constants in `searchable-filter.ts`, easy to tune.
