### PR TITLE
SW-736 Update pagination styling for GEL

### DIFF
--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -43,7 +43,8 @@
     "next": "Nesaf",
     "update": "Diweddaru",
     "page_size": "Maint y dudalen",
-    "page_aria": "Tudalen {{page}}"
+    "page_aria": "Tudalen {{page}}",
+    "nav_aria": "Tudaleniad"
   },
   "header": {
     "product_name": "StatsCymru V3.0",

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -42,7 +42,8 @@
     "previous": "Blaenorol",
     "next": "Nesaf",
     "update": "Diweddaru",
-    "page_size": "Maint y dudalen"
+    "page_size": "Maint y dudalen",
+    "page_aria": "Tudalen {{page}}"
   },
   "header": {
     "product_name": "StatsCymru V3.0",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -44,7 +44,8 @@
     "next": "Next",
     "update": "Update",
     "page_size": "Page size",
-    "page_aria": "Page {{page}}"
+    "page_aria": "Page {{page}}",
+    "nav_aria": "Pagination"
   },
   "header": {
     "product_name": "StatsWales V3.0",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -43,7 +43,8 @@
     "previous": "Previous",
     "next": "Next",
     "update": "Update",
-    "page_size": "Page size"
+    "page_size": "Page size",
+    "page_aria": "Page {{page}}"
   },
   "header": {
     "product_name": "StatsWales V3.0",

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -902,6 +902,10 @@
     font-size: 20px;
   }
 
+  .govuk-pagination__item.govuk-pagination__inactive span {
+    display: block;
+  }
+
   .border-top {
     border-top: 8px solid colours.$lightgrey_semi;
     padding-top: 15px;
@@ -1398,7 +1402,11 @@
 
     .govuk-pagination__prev:hover,
     .govuk-pagination__next:hover {
-      background-color: colours.$midgrey;
+      background-color: colours.$black;
+
+      a {
+        color: colours.$brightred;
+      }
     }
 
     .govuk-pagination__prev::before {
@@ -1417,6 +1425,12 @@
 
     .govuk-pagination {
       flex-direction: row;
+    }
+  }
+
+  @media screen and (max-width: 480px) {
+    .govuk-pagination__summary {
+      font-family: Arial, Helvetica, 'Nimbus Sans L', sans-serif;
     }
   }
 

--- a/src/shared/public/scss/app.scss
+++ b/src/shared/public/scss/app.scss
@@ -47,10 +47,12 @@
     background-color: inherit;
   }
 
-  .govuk-pagination__item:hover,
-  .govuk-pagination__prev:hover,
-  .govuk-pagination__next:hover {
-    background-color: transparent;
+  @media screen and (min-width: 769px) {
+    .govuk-pagination__item:hover,
+    .govuk-pagination__prev:hover,
+    .govuk-pagination__next:hover {
+      background-color: transparent;
+    }
   }
 
   .govuk-pagination__item:hover .govuk-pagination__link,

--- a/src/shared/public/scss/app.scss
+++ b/src/shared/public/scss/app.scss
@@ -47,6 +47,18 @@
     background-color: inherit;
   }
 
+  .govuk-pagination__item:hover,
+  .govuk-pagination__prev:hover,
+  .govuk-pagination__next:hover {
+    background-color: transparent;
+  }
+
+  .govuk-pagination__item:hover .govuk-pagination__link,
+  .govuk-pagination__prev:hover .govuk-pagination__link,
+  .govuk-pagination__next:hover .govuk-pagination__link {
+    color: colours.$brightred;
+  }
+
   .tasklist-no-border:first-child {
     border-top: none;
   }

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -159,7 +159,7 @@ export default function Pagination({
                     { ...parsedQuery, page_number: page, page_size: page_size },
                     anchor
                   )}
-                  aria-label={`Page ${page}`}
+                  aria-label={i18n.t('pagination.page_aria', { page })}
                 >
                   {page}
                 </a>

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -110,7 +110,7 @@ export default function Pagination({
         </div>
       )}
 
-      <nav className="govuk-pagination" aria-label="Pagination">
+      <nav className="govuk-pagination" aria-label={i18n.t('pagination.nav_aria')}>
         {showPrevLink && (
           <div className={clsx('govuk-pagination__prev')}>
             <a className="govuk-link govuk-pagination__link" href={prevHref} rel="prev">

--- a/src/shared/views/components/Pagination.tsx
+++ b/src/shared/views/components/Pagination.tsx
@@ -98,93 +98,86 @@ export default function Pagination({
 
   return (
     <>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-third">
-          <div className="total-rows">
-            {!hide_pagination_hint && !inCursorMode && (
-              <div>
-                <T
-                  start={page_info.start_record?.toLocaleString()}
-                  end={page_info.end_record?.toLocaleString()}
-                  total={page_info.total_records?.toLocaleString()}
-                >
-                  publish.preview.showing_rows
-                </T>
-              </div>
-            )}
-          </div>
+      {!hide_pagination_hint && !inCursorMode && (
+        <div className="total-rows">
+          <T
+            start={page_info.start_record?.toLocaleString()}
+            end={page_info.end_record?.toLocaleString()}
+            total={page_info.total_records?.toLocaleString()}
+          >
+            publish.preview.showing_rows
+          </T>
         </div>
-        <div className="govuk-grid-column-two-thirds">
-          <nav className="govuk-pagination" aria-label="Pagination">
-            {showPrevLink && (
-              <div className={clsx('govuk-pagination__prev')}>
-                <a className="govuk-link govuk-pagination__link" href={prevHref} rel="prev">
-                  <span className="govuk-pagination__link-title">
-                    <T>pagination.previous</T>
-                  </span>
-                </a>
-              </div>
-            )}
-            <ul className="govuk-pagination__list">
-              {/* Cursor mode has no numbered jump links, but we still surface
-                  the tracked page number as the current item so it reads like
-                  the offset pagination (just without the other page links).
-                  Omitted when the counter is untrustworthy (deep cursor link
-                  with no page_hint). */}
-              {inCursorMode && cursorPage != null && (
-                <li className="govuk-pagination__item govuk-pagination__item--current govuk-pagination__inactive">
-                  <span aria-current="page">{cursorPage}</span>
-                </li>
-              )}
-              {numberedLinks.map((page, index) => {
-                if (page === '...') {
-                  return (
-                    <li key={index} className="govuk-pagination__item govuk-pagination__item--ellipses">
-                      ⋯
-                    </li>
-                  );
-                }
-                if (page === current_page) {
-                  return (
-                    <li
-                      key={index}
-                      className="govuk-pagination__item govuk-pagination__item--current govuk-pagination__inactive"
-                    >
-                      <span aria-current="page">{page}</span>
-                    </li>
-                  );
-                }
-                return (
-                  <li key={index} className="govuk-pagination__item">
-                    <a
-                      className="govuk-link govuk-pagination__link"
-                      href={buildUrl(
-                        baseUrl,
-                        i18n.language,
-                        { ...parsedQuery, page_number: page, page_size: page_size },
-                        anchor
-                      )}
-                      aria-label={`Page ${page}`}
-                    >
-                      {page}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
+      )}
 
-            {showNextLink && (
-              <div className={clsx('govuk-pagination__next')}>
-                <a className="govuk-link govuk-pagination__link" href={nextHref} rel="next">
-                  <span className="govuk-pagination__link-title">
-                    <T>pagination.next</T>
-                  </span>
+      <nav className="govuk-pagination" aria-label="Pagination">
+        {showPrevLink && (
+          <div className={clsx('govuk-pagination__prev')}>
+            <a className="govuk-link govuk-pagination__link" href={prevHref} rel="prev">
+              <span className="govuk-pagination__link-title">
+                <T>pagination.previous</T>
+              </span>
+            </a>
+          </div>
+        )}
+        <ul className="govuk-pagination__list">
+          {/* Cursor mode has no numbered jump links, but we still surface
+              the tracked page number as the current item so it reads like
+              the offset pagination (just without the other page links).
+              Omitted when the counter is untrustworthy (deep cursor link
+              with no page_hint). */}
+          {inCursorMode && cursorPage != null && (
+            <li className="govuk-pagination__item govuk-pagination__item--current govuk-pagination__inactive">
+              <span aria-current="page">{cursorPage}</span>
+            </li>
+          )}
+          {numberedLinks.map((page, index) => {
+            if (page === '...') {
+              return (
+                <li key={index} className="govuk-pagination__item govuk-pagination__item--ellipses">
+                  ⋯
+                </li>
+              );
+            }
+            if (page === current_page) {
+              return (
+                <li
+                  key={index}
+                  className="govuk-pagination__item govuk-pagination__item--current govuk-pagination__inactive"
+                >
+                  <span aria-current="page">{page}</span>
+                </li>
+              );
+            }
+            return (
+              <li key={index} className="govuk-pagination__item">
+                <a
+                  className="govuk-link govuk-pagination__link"
+                  href={buildUrl(
+                    baseUrl,
+                    i18n.language,
+                    { ...parsedQuery, page_number: page, page_size: page_size },
+                    anchor
+                  )}
+                  aria-label={`Page ${page}`}
+                >
+                  {page}
                 </a>
-              </div>
-            )}
-          </nav>
-        </div>
-      </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        {showNextLink && (
+          <div className={clsx('govuk-pagination__next')}>
+            <a className="govuk-link govuk-pagination__link" href={nextHref} rel="next">
+              <span className="govuk-pagination__link-title">
+                <T>pagination.next</T>
+              </span>
+            </a>
+          </div>
+        )}
+      </nav>
 
       <div className="govuk-pagination__summary">
         {inCursorMode ? (


### PR DESCRIPTION
**`Pagination.tsx`** — removed the inline grid layout that placed "Showing X to Y of Z rows" in a 1/3-column beside the pagination nav. The text now sits in a full-width `div.total-rows` above the `<nav>`, and the nav itself is no longer constrained to 2/3 width. This likely also resolves the publisher home last-page issue — the pagination items were previously in a `govuk-grid-column-two-thirds` inside the homepage's `govuk-grid-column-full`, which could cause flex items at the end of the row to wrap or overflow.

**`app.scss`** — added hover overrides:
- `background-color: transparent` on `.govuk-pagination__item:hover`, `__prev:hover`, `__next:hover` — removes GOV.UK's default `#f3f2f1` grey hover background
- `color: $brightred` (`#d81f1f`) on the link inside those hovered items

**`_wg.scss`** — three additions:
1. `.govuk-pagination__item.govuk-pagination__inactive span { display: block; }` — matches the `display: block` of active links so the inactive current-page number sits at the same vertical position in its cell
2. Mobile hover (≤768px): replaced `background-color: $midgrey` with `background-color: $black` (keep the button black, not grey) and `a { color: $brightred }` for the red text
3. New `@media screen and (max-width: 480px)` block setting `font-family: Arial, Helvetica, 'Nimbus Sans L', sans-serif` on `.govuk-pagination__summary` ("Page 1 of 2" text)