### PR TITLE
SW-935 Fix consumer home and topic screen styling [GEL QA]

### DIFF
--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -140,9 +140,9 @@ export default function TopicList(props) {
       {!props.selectedTopic && (
         <Hero>
           <div className="govuk-width-container">
-            <div className="govuk-grid-row govuk-!-margin-bottom-6">
+            <div className="govuk-grid-row govuk-!-padding-bottom-6">
               <div className="govuk-grid-column-two-thirds">
-                <h1 className="govuk-heading-xl govuk-!-margin-top-6">{title}</h1>
+                <h1 className="govuk-heading-xl govuk-!-padding-top-6">{title}</h1>
               </div>
             </div>
           </div>
@@ -167,9 +167,9 @@ export default function TopicList(props) {
           {props.selectedTopic && (
             <>
               <ParentTopicBreadcrumbs {...props} />
-              <h2 className="topic-subhead">
+              <span className="topic-subhead">
                 <T>{props.parentTopics.length > 0 ? 'consumer.topic_list.sub_topic' : 'consumer.topic_list.topic'}</T>
-              </h2>
+              </span>
               <h1 className="govuk-heading-xl">{title}</h1>
             </>
           )}

--- a/src/consumer/views/topic-list.jsx
+++ b/src/consumer/views/topic-list.jsx
@@ -167,9 +167,9 @@ export default function TopicList(props) {
           {props.selectedTopic && (
             <>
               <ParentTopicBreadcrumbs {...props} />
-              <span className="topic-subhead">
-                <T>{props.parentTopics.length > 0 ? 'consumer.topic_list.sub_topic' : 'consumer.topic_list.topic'}</T>
-              </span>
+              <T className="topic-subhead">
+                {props.parentTopics.length > 0 ? 'consumer.topic_list.sub_topic' : 'consumer.topic_list.topic'}
+              </T>
               <h1 className="govuk-heading-xl">{title}</h1>
             </>
           )}


### PR DESCRIPTION
Use padding instead of margin for the hero band's top/bottom spacing so it can't collapse through unstyled ancestor divs and escape the blue background - this was leaving the required 20px+ gap outside the hero rather than around the text on screens below 640px.

Change the topic-subhead label from an h2 to a span so it no longer introduces a heading level before the page's h1, and tightens up against the title to match other eyebrow-label usage in the app.