### PR TITLE
SW-726 Fix navigation bar issues [GEL QA]

### DIFF
--- a/src/publisher/views/components/Layout.tsx
+++ b/src/publisher/views/components/Layout.tsx
@@ -210,10 +210,21 @@ const Layout = ({ title, children, backLink, returnLink, formPage }: PropsWithCh
                 {t('header.navigation.logout')}
               </a>
             )}
+            <button
+              type="button"
+              className="toggle__button js-nav-toggle"
+              aria-expanded={false}
+              aria-controls="primary-nav-content"
+            >
+              <span aria-hidden="true"></span>
+              <span aria-hidden="true"></span>
+              <span aria-hidden="true"></span>
+              {t('header.navigation.menu')}
+            </button>
           </div>
-          <div className="nav__content">
+          <div className="nav__content" id="primary-nav-content">
             <div className="govuk-width-container">
-              <ul aria-hidden="true">
+              <ul>
                 <li>
                   <a
                     href={buildUrl('/', i18n.language)}
@@ -280,6 +291,7 @@ const Layout = ({ title, children, backLink, returnLink, formPage }: PropsWithCh
             </div>
           </div>
         </nav>
+        <script type="module" src="/assets/js/nav-toggle.js" />
 
         {backLink && (
           <div className="top-links">

--- a/src/shared/public/assets/js/nav-toggle.js
+++ b/src/shared/public/assets/js/nav-toggle.js
@@ -1,0 +1,13 @@
+(() => {
+  const nav = document.querySelector('.js-primary-nav');
+  if (!nav) return;
+
+  const toggle = nav.querySelector('.js-nav-toggle');
+  const content = nav.querySelector('.nav__content');
+  if (!toggle || !content) return;
+
+  toggle.addEventListener('click', () => {
+    const isOpen = nav.classList.toggle('nav--is-open');
+    toggle.setAttribute('aria-expanded', String(isOpen));
+  });
+})();

--- a/src/shared/public/assets/js/nav-toggle.js
+++ b/src/shared/public/assets/js/nav-toggle.js
@@ -3,8 +3,7 @@
   if (!nav) return;
 
   const toggle = nav.querySelector('.js-nav-toggle');
-  const content = nav.querySelector('.nav__content');
-  if (!toggle || !content) return;
+  if (!toggle || !nav.querySelector('.nav__content')) return;
 
   toggle.addEventListener('click', () => {
     const isOpen = nav.classList.toggle('nav--is-open');

--- a/src/shared/public/scss/_wg.scss
+++ b/src/shared/public/scss/_wg.scss
@@ -2561,6 +2561,7 @@
     position: relative;
     color: colours.$blue;
     border: 1px solid colours.$blue;
+    display: none;
   }
 
   nav.primary .nav__toggle .toggle__button span {
@@ -2587,10 +2588,27 @@
     opacity: 1;
   }
 
+  // The hamburger toggle and the collapsed nav state are both JS-dependent, so
+  // they only engage once .govuk-frontend-supported is present - without JS the
+  // nav stays permanently expanded/reachable (progressive enhancement).
+  .govuk-frontend-supported nav.primary .nav__toggle .toggle__button {
+    display: inline-block;
+  }
+
+  .govuk-frontend-supported nav.primary .nav__content {
+    display: none;
+  }
+
+  .govuk-frontend-supported nav.primary.nav--is-open .nav__content {
+    display: block;
+  }
+
+  .govuk-frontend-supported nav.primary .nav__content:focus-within {
+    display: block;
+  }
+
   nav.primary .nav__content {
-    height: 0;
-    overflow: hidden;
-    padding: 0;
+    display: block;
   }
 
   nav.primary .nav__content ul {
@@ -2672,14 +2690,6 @@
     transform: rotate(-45deg);
   }
 
-  nav.primary.nav--is-open .nav__content {
-    height: auto;
-  }
-
-  nav.primary .nav__content:focus-within {
-    height: auto;
-  }
-
   nav.primary + h1 {
     padding: 20px 0 0;
   }
@@ -2698,30 +2708,41 @@
     margin: 20px 0 0 0;
   }
 
-  nav.primary .nav__content {
-    height: auto;
-    padding: 0 20px;
-    background-color: colours.$lightgrey_mid;
-  }
+  // Screens 960px and above (GEL 13.1): nav is a single inline bar, hamburger
+  // toggle never shows. Note: no padding is added here on top of the nested
+  // .govuk-width-container's own gutter - that double-indent was the bug that
+  // pushed the first link out of alignment with the logo row above it.
+  @media (min-width: 960px) {
+    nav.primary .nav__toggle .toggle__button,
+    .govuk-frontend-supported nav.primary .nav__toggle .toggle__button {
+      display: none;
+    }
 
-  nav.primary .nav__content ul li {
-    border: 0;
-    float: left;
-    margin: 0;
-    text-align: center;
-  }
+    nav.primary .nav__content,
+    .govuk-frontend-supported nav.primary .nav__content {
+      display: block;
+      background-color: colours.$lightgrey_mid;
+    }
 
-  nav.primary .nav__content ul li:last-of-type {
-    margin: 0;
-  }
+    nav.primary .nav__content ul li {
+      border: 0;
+      float: left;
+      margin: 0;
+      text-align: center;
+    }
 
-  nav.primary .nav__content ul li a {
-    font-size: 18px;
-    padding: 8px 10px;
-  }
+    nav.primary .nav__content ul li:last-of-type {
+      margin: 0;
+    }
 
-  nav.primary .nav__content .is-helper {
-    display: none;
+    nav.primary .nav__content ul li a {
+      font-size: 18px;
+      padding: 8px 10px;
+    }
+
+    nav.primary .nav__content .is-helper {
+      display: none;
+    }
   }
 
   .statsWales-logo {

--- a/tests-e2e/publish/navigation.spec.ts
+++ b/tests-e2e/publish/navigation.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures/test';
+
+test.describe('Primary navigation', () => {
+  test.use({ role: 'publisher' });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/en-GB');
+  });
+
+  test('nav links show inline and the menu toggle is hidden at desktop widths', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await expect(page.getByRole('button', { name: 'Menu' })).toBeHidden();
+    await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  });
+
+  test('collapses into a hamburger menu below 960px and toggles on click', async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 800 });
+
+    const toggle = page.getByRole('button', { name: 'Menu' });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    const homeLink = page.getByRole('link', { name: 'Home' });
+    await expect(homeLink).toBeHidden();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(homeLink).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(homeLink).toBeHidden();
+  });
+
+  test('first nav link aligns with the header logo at desktop widths (no double indent)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    const logoBox = await page.locator('.statsWales-logo').boundingBox();
+    const homeLinkBox = await page.getByRole('link', { name: 'Home' }).boundingBox();
+
+    expect(Math.abs((logoBox?.x ?? 0) - (homeLinkBox?.x ?? 0))).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests-e2e/publish/navigation.spec.ts
+++ b/tests-e2e/publish/navigation.spec.ts
@@ -36,9 +36,12 @@ test.describe('Primary navigation', () => {
   test('first nav link aligns with the header logo at desktop widths (no double indent)', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
 
-    const logoBox = await page.locator('.statsWales-logo').boundingBox();
-    const homeLinkBox = await page.getByRole('link', { name: 'Home' }).boundingBox();
-
-    expect(Math.abs((logoBox?.x ?? 0) - (homeLinkBox?.x ?? 0))).toBeLessThanOrEqual(2);
+    const logo = page.locator('.statsWales-logo');
+    const homeLink = page.getByRole('link', { name: 'Home' });
+    const logoBox = await logo.boundingBox();
+    const homeLinkBox = await homeLink.boundingBox();
+    expect(logoBox).not.toBeNull();
+    expect(homeLinkBox).not.toBeNull();
+    expect(Math.abs(logoBox!.x - homeLinkBox!.x)).toBeLessThanOrEqual(2);
   });
 });


### PR DESCRIPTION
Wire up the hamburger toggle button and gate the nav bar's mobile/desktop CSS behind a 960px breakpoint - the desktop-shaped styles were unguarded so they always won, meaning the nav never collapsed below 960px despite the toggle button CSS already existing in _wg.scss. Add the missing button, a small nav-toggle.js to drive it, and a 960px media query so mobile stays vertical/collapsible and desktop stays a single inline bar.

Drop the desktop nav__content's redundant padding, which stacked on top of its own nested govuk-width-container's gutter and pushed the first link ~20px further right than the logo row above it.

Also remove the hardcoded aria-hidden on the nav link list, which made every nav link permanently unreachable to screen readers - the collapsed state is now hidden via display:none instead, which is excluded from the accessibility tree without needing separate ARIA bookkeeping.