### PR TITLE
Update cube rebuild code to rebuild draft cubes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ WORKDIR /app
 
 COPY package*.json ./
 
-# install only production dependencies
-RUN npm ci --omit=dev
+# install only production dependencies, then remove npm — it isn't needed at
+# runtime (CMD runs node directly), and its bundled node-tar is what Trivy
+# flags for CVE-2026-59873. Deleting it drops the vulnerable copy from the image.
+RUN npm ci --omit=dev && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 RUN chown -R node:node /app
 

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -288,7 +288,7 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
       set(
         req.session,
         `dataset[${dataset.id}].buildPreviousAction`,
-        req.buildUrl(`/publish/${datasetId}/tasklist`, req.language)
+        req.buildUrl(`/publish/${dataset.id}/tasklist`, req.language)
       );
       set(
         req.session,

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -282,19 +282,20 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
     const dataset = await req.pubapi.getDataset(datasetId);
     const revId = dataset.draft_revision_id ? dataset.draft_revision_id : dataset.end_revision_id!;
     if (req.headers.referer?.includes('developer')) {
+      set(req.session, `dataset[${dataset.id}].buildPreviousAction`, req.buildUrl(`/developer`, req.language));
       set(req.session, `dataset[${dataset.id}].buildNextAction`, req.buildUrl(`/developer`, req.language));
     } else {
+      set(
+        req.session,
+        `dataset[${dataset.id}].buildNextAction`,
+        req.buildUrl(`/publish/${datasetId}/tasklist`, req.language)
+      );
       set(
         req.session,
         `dataset[${dataset.id}].buildNextAction`,
         req.buildUrl(`/publish/${datasetId}/overview`, req.language)
       );
     }
-    set(
-      req.session,
-      `dataset[${dataset.id}].buildPreviousAction`,
-      req.headers.referer ?? req.buildUrl(`/publish/${datasetId}/overview`, req.language)
-    );
     req.session.save();
     const buildId = (await req.pubapi.rebuildCube(datasetId, revId)).build_id;
     logger.debug('Redirecting to build status page');

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -287,7 +287,7 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
     } else {
       set(
         req.session,
-        `dataset[${dataset.id}].buildNextAction`,
+        `dataset[${dataset.id}].buildPreviousAction`,
         req.buildUrl(`/publish/${datasetId}/tasklist`, req.language)
       );
       set(

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -293,7 +293,7 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
       set(
         req.session,
         `dataset[${dataset.id}].buildNextAction`,
-        req.buildUrl(`/publish/${datasetId}/overview`, req.language)
+        req.buildUrl(`/publish/${dataset.id}/overview`, req.language)
       );
     }
     req.session.save();

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -281,7 +281,7 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
   try {
     const dataset = await req.pubapi.getDataset(datasetId);
     const revId = dataset.draft_revision_id ? dataset.draft_revision_id : dataset.end_revision_id!;
-    if (req.originalUrl.includes('developer')) {
+    if (req.headers.referer?.includes('developer')) {
       set(req.session, `dataset[${dataset.id}].buildNextAction`, req.buildUrl(`/developer`, req.language));
     } else {
       set(
@@ -292,7 +292,7 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
     }
     set(req.session, `dataset[${dataset.id}].buildPreviousAction`, req.originalUrl);
     req.session.save();
-    const buildId = await req.pubapi.rebuildCube(datasetId, revId);
+    const buildId = (await req.pubapi.rebuildCube(datasetId, revId)).buildId;
     logger.debug('Redirecting to build status page');
     res.redirect(req.buildUrl(`/publish/${dataset.id}/build/${buildId}`, req.language));
   } catch (_err) {

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -29,6 +29,7 @@ import { SingleLanguageDataset } from '../../shared/dtos/single-language/dataset
 import { PublishingStatus } from '../../shared/enums/publishing-status';
 import { processFileList, getDatasetJson } from '../utils/dev';
 import { DatasetDTO } from '../../shared/dtos/dataset';
+import { set } from 'lodash';
 
 export const listAllDatasets = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -279,8 +280,21 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
 
   try {
     const dataset = await req.pubapi.getDataset(datasetId);
-    await req.pubapi.rebuildCube(datasetId, dataset.end_revision_id!);
-    res.redirect(req.buildUrl(`/publish/${datasetId}/overview`, req.language));
+    const revId = dataset.draft_revision_id ? dataset.draft_revision_id : dataset.end_revision_id!;
+    if (req.originalUrl.includes('developer')) {
+      set(req.session, `dataset[${dataset.id}].buildNextAction`, req.buildUrl(`/developer`, req.language));
+    } else {
+      set(
+        req.session,
+        `dataset[${dataset.id}].buildNextAction`,
+        req.buildUrl(`/publish/${datasetId}/overview`, req.language)
+      );
+    }
+    set(req.session, `dataset[${dataset.id}].buildPreviousAction`, req.originalUrl);
+    req.session.save();
+    const buildId = await req.pubapi.rebuildCube(datasetId, revId);
+    logger.debug('Redirecting to build status page');
+    res.redirect(req.buildUrl(`/publish/${dataset.id}/build/${buildId}`, req.language));
   } catch (_err) {
     logger.error(_err, 'Error rebuilding the cube');
     next(new NotFoundException('errors.import_missing'));

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -280,7 +280,11 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
 
   try {
     const dataset = await req.pubapi.getDataset(datasetId);
-    const revId = dataset.draft_revision_id ? dataset.draft_revision_id : dataset.end_revision_id!;
+    const revId = dataset.draft_revision_id || dataset.end_revision_id;
+    if (!revId) {
+      next(new NotFoundException('errors.import_missing'));
+      return;
+    }
     if (req.headers.referer?.includes('developer')) {
       set(req.session, `dataset[${dataset.id}].buildPreviousAction`, req.buildUrl(`/developer`, req.language));
       set(req.session, `dataset[${dataset.id}].buildNextAction`, req.buildUrl(`/developer`, req.language));

--- a/src/publisher/controllers/developer.ts
+++ b/src/publisher/controllers/developer.ts
@@ -290,9 +290,13 @@ export const rebuildCube = async (req: Request, res: Response, next: NextFunctio
         req.buildUrl(`/publish/${datasetId}/overview`, req.language)
       );
     }
-    set(req.session, `dataset[${dataset.id}].buildPreviousAction`, req.originalUrl);
+    set(
+      req.session,
+      `dataset[${dataset.id}].buildPreviousAction`,
+      req.headers.referer ?? req.buildUrl(`/publish/${datasetId}/overview`, req.language)
+    );
     req.session.save();
-    const buildId = (await req.pubapi.rebuildCube(datasetId, revId)).buildId;
+    const buildId = (await req.pubapi.rebuildCube(datasetId, revId)).build_id;
     logger.debug('Redirecting to build status page');
     res.redirect(req.buildUrl(`/publish/${dataset.id}/build/${buildId}`, req.language));
   } catch (_err) {

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -354,12 +354,12 @@ export class PublisherApi {
     return this.fetch({ url, lang: language }).then((response) => response.body as ReadableStream);
   }
 
-  public async rebuildCube(datasetId: string, revisionId: string): Promise<string> {
+  public async rebuildCube(datasetId: string, revisionId: string): Promise<{ buildId: string }> {
     logger.debug(`Rebuilding cube for revision: ${revisionId}...`);
     return this.fetch({
       url: `dataset/${datasetId}/revision/by-id/${revisionId}/`,
       method: HttpMethod.Post
-    }).then((response) => (response.json() as unknown as { buildId: string }).buildId);
+    }).then((response) => response.json() as unknown as { buildId: string });
   }
 
   public async getSourcesForDataset(datasetId: string): Promise<FactTableColumnDto[]> {

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -354,12 +354,12 @@ export class PublisherApi {
     return this.fetch({ url, lang: language }).then((response) => response.body as ReadableStream);
   }
 
-  public async rebuildCube(datasetId: string, revisionId: string): Promise<{ buildId: string }> {
+  public async rebuildCube(datasetId: string, revisionId: string): Promise<{ build_id: string }> {
     logger.debug(`Rebuilding cube for revision: ${revisionId}...`);
     return this.fetch({
       url: `dataset/${datasetId}/revision/by-id/${revisionId}/`,
       method: HttpMethod.Post
-    }).then((response) => response.json() as unknown as { buildId: string });
+    }).then((response) => response.json() as unknown as { build_id: string });
   }
 
   public async getSourcesForDataset(datasetId: string): Promise<FactTableColumnDto[]> {

--- a/src/publisher/services/publisher-api.ts
+++ b/src/publisher/services/publisher-api.ts
@@ -354,12 +354,12 @@ export class PublisherApi {
     return this.fetch({ url, lang: language }).then((response) => response.body as ReadableStream);
   }
 
-  public async rebuildCube(datasetId: string, revisionId: string) {
+  public async rebuildCube(datasetId: string, revisionId: string): Promise<string> {
     logger.debug(`Rebuilding cube for revision: ${revisionId}...`);
     return this.fetch({
       url: `dataset/${datasetId}/revision/by-id/${revisionId}/`,
       method: HttpMethod.Post
-    });
+    }).then((response) => (response.json() as unknown as { buildId: string }).buildId);
   }
 
   public async getSourcesForDataset(datasetId: string): Promise<FactTableColumnDto[]> {

--- a/tests/developer-rebuild.test.ts
+++ b/tests/developer-rebuild.test.ts
@@ -1,0 +1,168 @@
+import request from 'supertest';
+import JWT from 'jsonwebtoken';
+import { http, HttpResponse } from 'msw';
+
+import app from '../src/publisher/app';
+import { config } from '../src/shared/config';
+import { GlobalRole } from '../src/shared/enums/global-role';
+import { UserStatus } from '../src/shared/enums/user-status';
+import { CubeBuildStatus } from '../src/shared/enums/cube-build-status';
+import { mockBackend } from './mocks/backend';
+import { completedDataset } from './mocks/fixtures';
+
+const testUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+  provider: 'test',
+  global_roles: [GlobalRole.Developer] as GlobalRole[],
+  groups: [],
+  status: UserStatus.Active,
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z'
+};
+
+describe('Rebuild cube', () => {
+  const jwt = JWT.sign({ user: testUser }, config.auth.jwt.secret);
+  const datasetId = completedDataset.id;
+  const buildId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  beforeAll(() => {
+    mockBackend.listen({
+      onUnhandledRequest: ({ url }, print) => {
+        if (!url.includes(config.backend.url)) return;
+        print.error();
+      }
+    });
+  });
+
+  afterEach(() => mockBackend.resetHandlers());
+  afterAll(() => mockBackend.close());
+
+  const makeAgent = () => {
+    const agent = request.agent(app);
+    agent.set('Cookie', `jwt=${jwt}`);
+    return agent;
+  };
+
+  // Captures the revision id the rebuild request was made against, and responds with buildId.
+  const mockRebuild = () => {
+    let requestedRevisionId: string | undefined;
+    mockBackend.use(
+      http.post(`${config.backend.url}/dataset/${datasetId}/revision/by-id/:revisionId/`, ({ params }) => {
+        requestedRevisionId = params.revisionId as string;
+        return HttpResponse.json({ build_id: buildId });
+      })
+    );
+    return () => requestedRevisionId;
+  };
+
+  const mockBuildLogEntry = (status: CubeBuildStatus) => {
+    mockBackend.use(
+      http.get(`${config.backend.url}/build/${buildId}`, () => {
+        return HttpResponse.json({
+          id: buildId,
+          status,
+          type: 'rebuild',
+          startedAt: '2024-01-01T00:00:00.000Z',
+          performanceStart: 0
+        });
+      })
+    );
+  };
+
+  test('rebuilds using the draft revision when one exists, and redirects to the build status page', async () => {
+    const draftRevisionId = 'draft-revision-id';
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return HttpResponse.json({
+          ...completedDataset,
+          draft_revision_id: draftRevisionId,
+          end_revision_id: 'end-revision-id'
+        });
+      })
+    );
+    const getRequestedRevisionId = mockRebuild();
+
+    const res = await makeAgent().get(`/en-GB/developer/${datasetId}/rebuild/`);
+
+    expect(getRequestedRevisionId()).toBe(draftRevisionId);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/en-GB/publish/${datasetId}/build/${buildId}`);
+  });
+
+  test('falls back to the end revision when there is no draft revision', async () => {
+    const endRevisionId = 'end-revision-id';
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return HttpResponse.json({ ...completedDataset, draft_revision_id: undefined, end_revision_id: endRevisionId });
+      })
+    );
+    const getRequestedRevisionId = mockRebuild();
+
+    const res = await makeAgent().get(`/en-GB/developer/${datasetId}/rebuild/`);
+
+    expect(getRequestedRevisionId()).toBe(endRevisionId);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/en-GB/publish/${datasetId}/build/${buildId}`);
+  });
+
+  test('sends the developer back to the developer page after rebuilding from the developer preview', async () => {
+    const endRevisionId = 'end-revision-id';
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return HttpResponse.json({ ...completedDataset, draft_revision_id: undefined, end_revision_id: endRevisionId });
+      })
+    );
+    mockRebuild();
+
+    const agent = makeAgent();
+    await agent
+      .get(`/en-GB/developer/${datasetId}/rebuild/`)
+      .set('Referer', `http://localhost/en-GB/developer/${datasetId}`);
+
+    mockBuildLogEntry(CubeBuildStatus.Completed);
+    const refreshRes = await agent.get(`/en-GB/publish/${datasetId}/build/${buildId}/refresh`);
+
+    expect(refreshRes.status).toBe(200);
+    expect(refreshRes.text).toContain(`href="/en-GB/developer" class="govuk-button" id="action-button"`);
+  });
+
+  test('sends a publisher on to the overview page, or back to the tasklist on failure, when not rebuilding from developer', async () => {
+    const endRevisionId = 'end-revision-id';
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return HttpResponse.json({ ...completedDataset, draft_revision_id: undefined, end_revision_id: endRevisionId });
+      })
+    );
+    mockRebuild();
+
+    const agent = makeAgent();
+    await agent
+      .get(`/en-GB/developer/${datasetId}/rebuild/`)
+      .set('Referer', `http://localhost/en-GB/publish/${datasetId}/tasklist`);
+
+    mockBuildLogEntry(CubeBuildStatus.Completed);
+    const completedRes = await agent.get(`/en-GB/publish/${datasetId}/build/${buildId}/refresh`);
+    expect(completedRes.text).toContain(
+      `href="/en-GB/publish/${datasetId}/overview" class="govuk-button" id="action-button"`
+    );
+
+    mockBuildLogEntry(CubeBuildStatus.Failed);
+    const failedRes = await agent.get(`/en-GB/publish/${datasetId}/build/${buildId}/refresh`);
+    expect(failedRes.text).toContain(
+      `href="/en-GB/publish/${datasetId}/tasklist" class="govuk-button" id="action-button"`
+    );
+  });
+
+  test('returns a not found error when the dataset cannot be loaded', async () => {
+    mockBackend.use(
+      http.get(`${config.backend.url}/dataset/${datasetId}`, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
+
+    const res = await makeAgent().get(`/en-GB/developer/${datasetId}/rebuild/`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/publisher-api.test.ts
+++ b/tests/publisher-api.test.ts
@@ -432,6 +432,27 @@ describe('PublisherApi', () => {
     });
   });
 
+  describe('rebuildCube', () => {
+    it('should POST to the revision endpoint and return the build_id', async () => {
+      const datasetId = randomUUID();
+      const revisionId = randomUUID();
+      const buildId = randomUUID();
+
+      mockResponse = Promise.resolve(new Response(JSON.stringify({ build_id: buildId })));
+
+      const result = await statsWalesApi.rebuildCube(datasetId, revisionId);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${baseUrl}/dataset/${datasetId}/revision/by-id/${revisionId}/?lang=en`,
+        expect.objectContaining({
+          method: HttpMethod.Post,
+          headers: expect.objectContaining(headers)
+        })
+      );
+      expect(result).toEqual({ build_id: buildId });
+    });
+  });
+
   describe('getDatasetTasks', () => {
     it('should return an array of TaskDTO without open parameter', async () => {
       const datasetId = randomUUID();


### PR DESCRIPTION
The rebuild function was only rebuilding the currently published cube unless the dataset was new with no published cubes.  This updates the code to rebuild the inprogress draft cube.  Additionally the code now uses the build id and the cube build page for longer cube builds rather than always assuming the cube rebuild was successful.