### PR TITLE
Fix stored XSS in dimension/measure match-failure views and CSV trans…

### DIFF
--- a/src/publisher/views/components/NonMatchingValue.tsx
+++ b/src/publisher/views/components/NonMatchingValue.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from '../../../shared/views/components/T';
 
 export type NonMatchingValueProps = {
   value: unknown;
@@ -21,7 +22,7 @@ export default function NonMatchingValue({ value }: NonMatchingValueProps) {
           {part}
           {index < parts.length - 1 && (
             <>
-              <span className="govuk-visually-hidden">space</span>
+              <T className="govuk-visually-hidden">publish.non_matching_value.space</T>
               <span aria-hidden="true" className="mid-dot">
                 &middot;
               </span>

--- a/src/publisher/views/components/NonMatchingValue.tsx
+++ b/src/publisher/views/components/NonMatchingValue.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export type NonMatchingValueProps = {
+  value: unknown;
+};
+
+// Renders an uploaded, non-matching cell value inside a quoted string, visually
+// marking spaces so editors can spot leading/trailing/duplicate whitespace.
+// The value comes straight from the publisher-uploaded CSV/lookup table, so it
+// must only ever be rendered as text (React's default escaping) — never fed to
+// dangerouslySetInnerHTML.
+export default function NonMatchingValue({ value }: NonMatchingValueProps) {
+  const text = value === null || value === undefined ? '' : value.toString();
+  const parts = text.split(' ');
+
+  return (
+    <>
+      &quot;
+      {parts.map((part, index) => (
+        <React.Fragment key={index}>
+          {part}
+          {index < parts.length - 1 && (
+            <>
+              <span className="govuk-visually-hidden">space</span>
+              <span aria-hidden="true" className="mid-dot">
+                &middot;
+              </span>
+            </>
+          )}
+        </React.Fragment>
+      ))}
+      &quot;
+    </>
+  );
+}

--- a/src/publisher/views/publish/dimension-match-failure.jsx
+++ b/src/publisher/views/publish/dimension-match-failure.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Layout from '../components/Layout';
+import NonMatchingValue from '../components/NonMatchingValue';
 
 export default function DimensionMatchFailure(props) {
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
@@ -54,23 +55,9 @@ export default function DimensionMatchFailure(props) {
               <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.no_matches')}</li>
             ) : (
               props.extension.nonMatchingDataTableValues.map((value, index) => (
-                <li
-                  key={index}
-                  className="govuk-list--bullet"
-                  dangerouslySetInnerHTML={{
-                    __html: `
-                          "${value.toString().replace(
-                            ' ',
-                            <>
-                              <span className="govuk-visually-hidden">space</span>
-                              <span aria-hidden="true" className="mid-dot">
-                                &middot;
-                              </span>
-                            </>
-                          )}"
-                          `
-                  }}
-                />
+                <li key={index} className="govuk-list--bullet">
+                  <NonMatchingValue value={value} />
+                </li>
               ))
             )}
           </ul>
@@ -86,21 +73,9 @@ export default function DimensionMatchFailure(props) {
               <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.no_matches')}</li>
             ) : (
               props.extension.nonMatchedLookupValues.map((value, index) => (
-                <li
-                  key={index}
-                  className="govuk-list--bullet"
-                  dangerouslySetInnerHTML={{
-                    __html: `"${value.toString().replace(
-                      ' ',
-                      <>
-                        <span className="govuk-visually-hidden">space</span>
-                        <span aria-hidden="true" className="mid-dot">
-                          &middot;
-                        </span>
-                      </>
-                    )}"`
-                  }}
-                />
+                <li key={index} className="govuk-list--bullet">
+                  <NonMatchingValue value={value} />
+                </li>
               ))
             )}
           </ul>

--- a/src/publisher/views/publish/measure-match-failure.jsx
+++ b/src/publisher/views/publish/measure-match-failure.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Layout from '../components/Layout';
+import NonMatchingValue from '../components/NonMatchingValue';
 
 export default function MeasureMatchFailure(props) {
   const returnLink = props.buildUrl(`/publish/${props.datasetId}/tasklist`, props.i18n.language);
@@ -28,23 +29,9 @@ export default function MeasureMatchFailure(props) {
               <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.no_matches')}</li>
             ) : (
               props.extension.nonMatchingDataTableValues.map((value, index) => (
-                <li
-                  key={index}
-                  className="govuk-list--bullet"
-                  dangerouslySetInnerHTML={{
-                    __html: `
-                          "${value.toString().replace(
-                            ' ',
-                            <>
-                              <span className="govuk-visually-hidden">space</span>
-                              <span aria-hidden="true" className="mid-dot">
-                                &middot;
-                              </span>
-                            </>
-                          )}"
-                          `
-                  }}
-                />
+                <li key={index} className="govuk-list--bullet">
+                  <NonMatchingValue value={value} />
+                </li>
               ))
             )}
           </ul>
@@ -60,21 +47,9 @@ export default function MeasureMatchFailure(props) {
               <li className="govuk-list--bullet">{props.t('publish.dimension_match_failure.no_matches')}</li>
             ) : (
               props.extension.nonMatchingLookupValues.map((value, idx) => (
-                <li
-                  key={idx}
-                  className="govuk-list--bullet"
-                  dangerouslySetInnerHTML={{
-                    __html: `"${value.toString().replace(
-                      ' ',
-                      <>
-                        <span className="govuk-visually-hidden">space</span>
-                        <span aria-hidden="true" className="mid-dot">
-                          &middot;
-                        </span>
-                      </>
-                    )}"`
-                  }}
-                />
+                <li key={idx} className="govuk-list--bullet">
+                  <NonMatchingValue value={value} />
+                </li>
               ))
             )}
           </ul>

--- a/src/shared/i18n/cy.json
+++ b/src/shared/i18n/cy.json
@@ -577,6 +577,9 @@
       "missing_data_table_values": "Codau cyfeirio yn y tabl data na ellir eu cyfateb",
       "missing_lookup_table_values": "Codau cyfeirio yn y tabl am-edrych na ellir eu cyfateb"
     },
+    "non_matching_value": {
+      "space": "bwlch"
+    },
     "period_match_failure": {
       "heading": "Ni ellir cyfateb fformat y dyddiad gyda’r dimensiwn",
       "information": "{{failureCount, number}} achos o godau dyddiadau yn y dimensiwn heb fod yn cyfateb â’r fformat dyddiadau a nodwyd gennych. Dylech wirio:",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -606,6 +606,9 @@
       "missing_data_table_values": "Reference codes in the data table that cannot be matched",
       "missing_lookup_table_values": "Reference codes in the lookup table that cannot be matched"
     },
+    "non_matching_value": {
+      "space": "space"
+    },
     "period_match_failure": {
       "heading": "Date formatting cannot be matched to the dimension",
       "information": "{{failureCount, number}} instances of date codes in the dimension do not match the date formatting you have indicated. You should check:",

--- a/src/shared/utils/translations.ts
+++ b/src/shared/utils/translations.ts
@@ -53,10 +53,10 @@ export const parseUploadedTranslations = async (fileBuffer: Buffer): Promise<Tra
 export const markdownToHtml = async (translations: TranslationDTO[]): Promise<TranslationDTO[]> => {
   return Promise.all(
     translations.map(async (translation: TranslationDTO) => {
-      if (translation.type === 'metadata') {
-        translation.english = await markdownToSafeHTML(translation.english);
-        translation.cymraeg = await markdownToSafeHTML(translation.cymraeg);
-      }
+      // Sanitize every row regardless of `type` — that field comes straight from the
+      // uploaded CSV, so it must never gate whether a row gets sanitized (CWE-79).
+      translation.english = await markdownToSafeHTML(translation.english);
+      translation.cymraeg = await markdownToSafeHTML(translation.cymraeg);
       return translation;
     })
   );

--- a/src/shared/utils/translations.ts
+++ b/src/shared/utils/translations.ts
@@ -51,13 +51,14 @@ export const parseUploadedTranslations = async (fileBuffer: Buffer): Promise<Tra
 };
 
 export const markdownToHtml = async (translations: TranslationDTO[]): Promise<TranslationDTO[]> => {
-  return Promise.all(
-    translations.map(async (translation: TranslationDTO) => {
-      // Sanitize every row regardless of `type` — that field comes straight from the
-      // uploaded CSV, so it must never gate whether a row gets sanitized (CWE-79).
-      translation.english = await markdownToSafeHTML(translation.english);
-      translation.cymraeg = await markdownToSafeHTML(translation.cymraeg);
-      return translation;
-    })
-  );
+  // Sanitize every row regardless of `type` — that field comes straight from the
+  // uploaded CSV, so it must never gate whether a row gets sanitized (CWE-79).
+  // Processed sequentially: markdownToSafeHTML spins up a JSDOM/DOMPurify instance per
+  // call, so running them all concurrently via Promise.all could spike CPU/memory on
+  // large uploads.
+  for (const translation of translations) {
+    translation.english = await markdownToSafeHTML(translation.english);
+    translation.cymraeg = await markdownToSafeHTML(translation.cymraeg);
+  }
+  return translations;
 };

--- a/tests/utils/translations.test.ts
+++ b/tests/utils/translations.test.ts
@@ -1,0 +1,52 @@
+import { markdownToHtml } from '../../src/shared/utils/translations';
+import { TranslationDTO } from '../../src/shared/dtos/translations';
+
+const XSS_PAYLOAD = '<img src=x onerror=alert(1)>';
+
+describe('markdownToHtml', () => {
+  it('sanitizes metadata rows (existing behaviour)', async () => {
+    const rows: TranslationDTO[] = [{ type: 'metadata', key: 'description', english: XSS_PAYLOAD, cymraeg: 'ok' }];
+
+    const [result] = await markdownToHtml(rows);
+
+    // DOMPurify keeps the harmless <img> tag but strips the dangerous event handler
+    expect(result.english).not.toContain('onerror');
+  });
+
+  it.each(['dimension', 'measure', 'link', 'anything-attacker-controlled'])(
+    'sanitizes rows of type "%s" too, since `type` comes straight from the uploaded CSV',
+    async (type) => {
+      const rows: TranslationDTO[] = [{ type, key: 'name', english: XSS_PAYLOAD, cymraeg: XSS_PAYLOAD }];
+
+      const [result] = await markdownToHtml(rows);
+
+      expect(result.english).not.toContain('onerror');
+      expect(result.cymraeg).not.toContain('onerror');
+    }
+  );
+
+  it('neutralizes a <script> payload regardless of row type', async () => {
+    const rows: TranslationDTO[] = [
+      { type: 'link', key: 'related', english: '<script>alert(document.cookie)</script>', cymraeg: 'ok' }
+    ];
+
+    const [result] = await markdownToHtml(rows);
+
+    expect(result.english).not.toContain('<script>');
+  });
+
+  it('still returns plain text content untouched for benign values', async () => {
+    const rows: TranslationDTO[] = [{ type: 'dimension', key: 'name', english: 'Area', cymraeg: 'Ardal' }];
+
+    const [result] = await markdownToHtml(rows);
+
+    expect(result.english).toContain('Area');
+    expect(result.cymraeg).toContain('Ardal');
+  });
+
+  it('handles missing english/cymraeg values without throwing', async () => {
+    const rows: TranslationDTO[] = [{ type: 'metadata', key: 'description' }];
+
+    await expect(markdownToHtml(rows)).resolves.toBeDefined();
+  });
+});

--- a/tests/views/match-failure-render.test.tsx
+++ b/tests/views/match-failure-render.test.tsx
@@ -37,7 +37,7 @@ describe('DimensionMatchFailure — uploaded lookup/fact-table values that faile
       />
     );
 
-  it('renders a fact-table value containing a script payload inert', () => {
+  it('renders a fact-table value containing an img onerror payload inert', () => {
     const html = render([XSS_PAYLOAD]);
     // React's default escaping neutralizes the tag; "onerror" survives only as inert escaped text
     expect(html).not.toContain('<img');
@@ -72,7 +72,7 @@ describe('MeasureMatchFailure — uploaded measure lookup values that failed to 
       />
     );
 
-  it('renders a fact-table value containing a script payload inert', () => {
+  it('renders a fact-table value containing an img onerror payload inert', () => {
     const html = render([XSS_PAYLOAD]);
     expect(html).not.toContain('<img');
     expect(html).toContain('&lt;img');

--- a/tests/views/match-failure-render.test.tsx
+++ b/tests/views/match-failure-render.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import DimensionMatchFailure from '../../src/publisher/views/publish/dimension-match-failure.jsx';
+import MeasureMatchFailure from '../../src/publisher/views/publish/measure-match-failure.jsx';
+
+const XSS_PAYLOAD = '<img src=x onerror=alert(1)>';
+
+const baseProps = {
+  t: (key: string) => key,
+  buildUrl: (path: string) => path,
+  url: '/back',
+  i18n: { language: 'en-GB' },
+  isAuthenticated: true,
+  activePage: 'publish',
+  isAdmin: false,
+  isDeveloper: false,
+  appEnv: 'local',
+  hostname: 'localhost',
+  datasetId: 'dataset-1',
+  dataset: { id: 'dataset-1' }
+};
+
+describe('DimensionMatchFailure — uploaded lookup/fact-table values that failed to match', () => {
+  const render = (nonMatchingDataTableValues: unknown[], nonMatchedLookupValues: unknown[] = []) =>
+    renderToStaticMarkup(
+      <DimensionMatchFailure
+        {...baseProps}
+        patchRequest={{ dimension_type: 'lookup_table' }}
+        dimension={{ id: 'dim-1', metadata: { name: 'Area' } }}
+        dimensionPatch={{}}
+        extension={{
+          totalNonMatching: nonMatchingDataTableValues.length,
+          nonMatchingDataTableValues,
+          nonMatchedLookupValues
+        }}
+      />
+    );
+
+  it('renders a fact-table value containing a script payload inert', () => {
+    const html = render([XSS_PAYLOAD]);
+    // React's default escaping neutralizes the tag; "onerror" survives only as inert escaped text
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('renders a lookup-table value containing a script payload inert', () => {
+    const html = render([], ['<script>alert(1)</script>']);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('still shows the benign value, quoted, with no leftover [object Object] from the old String.replace bug', () => {
+    const html = render(['North Wales']);
+    expect(html).toContain('North');
+    expect(html).toContain('Wales');
+    expect(html).not.toContain('[object Object]');
+  });
+});
+
+describe('MeasureMatchFailure — uploaded measure lookup values that failed to match', () => {
+  const render = (nonMatchingDataTableValues: unknown[], nonMatchingLookupValues: unknown[] = []) =>
+    renderToStaticMarkup(
+      <MeasureMatchFailure
+        {...baseProps}
+        measure={{ id: 'measure-1', metadata: { name: 'Count' } }}
+        extension={{
+          totalNonMatching: nonMatchingDataTableValues.length,
+          nonMatchingDataTableValues,
+          nonMatchingLookupValues
+        }}
+      />
+    );
+
+  it('renders a fact-table value containing a script payload inert', () => {
+    const html = render([XSS_PAYLOAD]);
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('renders a measure-lookup value containing a script payload inert', () => {
+    const html = render([], ['<script>alert(1)</script>']);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/tests/views/translations-preview-table-render.test.tsx
+++ b/tests/views/translations-preview-table-render.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import TranslationsPreviewTable from '../../src/publisher/views/components/TranslationsPreviewTable';
+import { LocalsProvider } from '../../src/shared/views/context/Locals';
+import { TranslationDTO } from '../../src/shared/dtos/translations';
+import { markdownToHtml } from '../../src/shared/utils/translations';
+
+const XSS_PAYLOAD = '<img src=x onerror=alert(1)>';
+
+const render = (translations: TranslationDTO[], isImport = true) =>
+  renderToStaticMarkup(
+    <LocalsProvider t={(key: string) => key} i18n={{ language: 'en-GB' }} url="/" errors={[]}>
+      <TranslationsPreviewTable translations={translations} isImport={isImport} />
+    </LocalsProvider>
+  );
+
+describe('TranslationsPreviewTable — uploaded translation import preview', () => {
+  it('renders a payload from a non-metadata row inert (this is the worst-case row: only metadata used to be sanitized)', async () => {
+    const rows: TranslationDTO[] = [{ type: 'dimension', key: 'name', english: XSS_PAYLOAD, cymraeg: 'Ardal' }];
+
+    // Mirrors the real controller flow: parseUploadedTranslations -> markdownToHtml -> render
+    const sanitized = await markdownToHtml(rows);
+    const html = render(sanitized);
+
+    // DOMPurify keeps the harmless <img> tag but strips the dangerous event handler
+    expect(html).not.toContain('onerror');
+  });
+
+  it('renders a <script> payload from a metadata row inert', async () => {
+    const rows: TranslationDTO[] = [
+      { type: 'metadata', key: 'description', english: '<script>alert(1)</script>', cymraeg: 'ok' }
+    ];
+
+    const sanitized = await markdownToHtml(rows);
+    const html = render(sanitized);
+
+    expect(html).not.toContain('<script>');
+  });
+
+  it('still shows benign uploaded content', async () => {
+    const rows: TranslationDTO[] = [{ type: 'dimension', key: 'name', english: 'Area', cymraeg: 'Ardal' }];
+
+    const sanitized = await markdownToHtml(rows);
+    const html = render(sanitized);
+
+    expect(html).toContain('Area');
+  });
+});


### PR DESCRIPTION
…lation import

- Replace dangerouslySetInnerHTML rendering of uploaded non-matching values in dimension-match-failure.jsx and measure-match-failure.jsx with a new NonMatchingValue component that relies on React's default text escaping.
- Sanitize every row in markdownToHtml regardless of `type`, since `type` is attacker-controlled CSV input and must not gate whether sanitization runs (CWE-79).