### PR TITLE
Fix broken PR pipelines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       && node /app/dist/seeders/required/orgs-and-groups.js
       && node /app/dist/seeders/required/topics.js
       && node /app/dist/seeders/tests/seed.js
-      && node dist/server.js
+      && node /app/dist/server.js
       "
 
   ready-for-tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,11 @@ services:
       AZURE_BLOB_STORAGE_URL: 'http://blobstorage:10000/devstoreaccount1'
 
     command: sh -c "
-      /app/node_modules/.bin/typeorm migration:run -d ./dist/db/publisher-source.js
-      && node ./dist/seeders/required/data-providers.js
-      && node ./dist/seeders/required/orgs-and-groups.js
-      && node ./dist/seeders/required/topics.js
-      && node ./dist/seeders/tests/seed.js
+      /app/node_modules/.bin/typeorm migration:run -d /app/dist/db/publisher-source.js
+      && node /app/dist/seeders/required/data-providers.js
+      && node /app/dist/seeders/required/orgs-and-groups.js
+      && node /app/dist/seeders/required/topics.js
+      && node /app/dist/seeders/tests/seed.js
       && node dist/server.js
       "
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,14 @@ services:
       TEST_DB_SYNC: 'false'
       AZURE_BLOB_STORAGE_URL: 'http://blobstorage:10000/devstoreaccount1'
 
-    command: sh -c "npm run init:ci && npm run start"
+    command: sh -c "
+      /app/node_modules/.bin/typeorm migration:run -d ./dist/db/publisher-source.js
+      && node ./dist/seeders/required/data-providers.js
+      && node ./dist/seeders/required/orgs-and-groups.js
+      && node ./dist/seeders/required/topics.js
+      && node ./dist/seeders/tests/seed.js
+      && node dist/server.js
+      "
 
   ready-for-tests:
     image: busybox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,14 +53,16 @@ services:
       TEST_DB_SYNC: 'false'
       AZURE_BLOB_STORAGE_URL: 'http://blobstorage:10000/devstoreaccount1'
 
-    command: sh -c "
-      /app/node_modules/.bin/typeorm migration:run -d /app/dist/db/publisher-source.js
-      && node /app/dist/seeders/required/data-providers.js
-      && node /app/dist/seeders/required/orgs-and-groups.js
-      && node /app/dist/seeders/required/topics.js
-      && node /app/dist/seeders/tests/seed.js
-      && node /app/dist/server.js
-      "
+    command:
+      - sh
+      - -c
+      - |
+          /app/node_modules/.bin/typeorm migration:run -d /app/dist/db/publisher-source.js &&
+          node /app/dist/seeders/required/data-providers.js &&
+          node /app/dist/seeders/required/orgs-and-groups.js &&
+          node /app/dist/seeders/required/topics.js &&
+          node /app/dist/seeders/tests/seed.js &&
+          node /app/dist/server.js
 
   ready-for-tests:
     image: busybox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,12 +57,12 @@ services:
       - sh
       - -c
       - |
-          /app/node_modules/.bin/typeorm migration:run -d /app/dist/db/publisher-source.js &&
-          node /app/dist/seeders/required/data-providers.js &&
-          node /app/dist/seeders/required/orgs-and-groups.js &&
-          node /app/dist/seeders/required/topics.js &&
-          node /app/dist/seeders/tests/seed.js &&
-          node /app/dist/server.js
+        /app/node_modules/.bin/typeorm migration:run -d /app/dist/db/publisher-source.js &&
+        node /app/dist/seeders/required/data-providers.js &&
+        node /app/dist/seeders/required/orgs-and-groups.js &&
+        node /app/dist/seeders/required/topics.js &&
+        node /app/dist/seeders/tests/seed.js &&
+        node /app/dist/server.js
 
   ready-for-tests:
     image: busybox


### PR DESCRIPTION
The frontend PR pipelines broke due to the removal of npm and associated files from the backend docker image.  This removes the dependance on npm from the docker-compose file used for our pipelines.