### PR TITLE
Fix open redirect via protocol-relative/backslash URLs (SW-1320)

### DIFF
--- a/src/publisher/routes/publish.ts
+++ b/src/publisher/routes/publish.ts
@@ -55,6 +55,7 @@ import {
 import { DatasetInclude as Include } from '../../shared/enums/dataset-include';
 import { flashMessages, flashErrors } from '../../shared/middleware/flash';
 import { noCache } from '../../shared/middleware/no-cache';
+import { isRelativeUrl } from '../../shared/middleware/history';
 import { redirectIfOpenPublishRequest } from '../middleware/redirect-if-open-publish-request';
 
 export const publish = Router();
@@ -69,8 +70,7 @@ const uploadNoneOrFieldError =
     upload.none()(req, res, (err: unknown) => {
       if (err instanceof multer.MulterError && err.code === 'LIMIT_FIELD_VALUE') {
         req.session.errors = [{ field, message: { key: errorKey } }];
-        const redirectTarget =
-          req.originalUrl.startsWith('/') && !req.originalUrl.startsWith('//') ? req.originalUrl : '/';
+        const redirectTarget = isRelativeUrl(req.originalUrl) ? req.originalUrl : '/';
         req.session.save((saveErr) => {
           if (saveErr) {
             next(saveErr);

--- a/src/shared/middleware/history.ts
+++ b/src/shared/middleware/history.ts
@@ -1,10 +1,22 @@
 import { Request, Response, NextFunction } from 'express';
 import { RequestHistory } from '../interfaces/request-history';
 
+const isSafeRelativePath = (url: string): boolean => /^\/(?!\/|\\)/.test(url);
+
 // rejects protocol-relative ("//evil.com") and backslash-obfuscated ("/\evil.com") forms, both of which
-// browsers will treat as absolute URLs pointing off-site even though they pass a naive "starts with /" check
+// browsers will treat as absolute URLs pointing off-site even though they pass a naive "starts with /" check.
+// Also checks the percent-decoded form, since some proxies/user agents normalise "/%2F%2Fevil.com" or
+// "/%5Cevil.com" into the same dangerous forms before they'd be resolved as a redirect target.
 export const isRelativeUrl = (url: string): boolean => {
-  return /^\/(?!\/|\\)/.test(url);
+  if (!isSafeRelativePath(url)) {
+    return false;
+  }
+
+  try {
+    return isSafeRelativePath(decodeURIComponent(url));
+  } catch {
+    return false;
+  }
 };
 
 // records the last 10 URLs visited by the user

--- a/src/shared/middleware/history.ts
+++ b/src/shared/middleware/history.ts
@@ -1,8 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { RequestHistory } from '../interfaces/request-history';
 
-const isRelativeUrl = (url: string): boolean => {
-  return url.startsWith('/') && !url.includes('://');
+// rejects protocol-relative ("//evil.com") and backslash-obfuscated ("/\evil.com") forms, both of which
+// browsers will treat as absolute URLs pointing off-site even though they pass a naive "starts with /" check
+export const isRelativeUrl = (url: string): boolean => {
+  return /^\/(?!\/|\\)/.test(url);
 };
 
 // records the last 10 URLs visited by the user

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -32,8 +32,10 @@ const docsPath = path.join(__dirname, '..', '..', '..', 'docs', 'static-pages');
 const isSupportedLocaleUrl = (url: string): boolean =>
   url === `/${Locale.EnglishGb}` ||
   url.startsWith(`/${Locale.EnglishGb}/`) ||
+  url.startsWith(`/${Locale.EnglishGb}?`) ||
   url === `/${Locale.WelshGb}` ||
-  url.startsWith(`/${Locale.WelshGb}/`);
+  url.startsWith(`/${Locale.WelshGb}/`) ||
+  url.startsWith(`/${Locale.WelshGb}?`);
 
 const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
   const defaultPref: CookiePreferences = { acceptAll: false, measuring: false, showBanner: true };

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -14,6 +14,7 @@ import { CookiePreferences } from '../interfaces/cookie-preferences';
 import { config } from '../config';
 import { flashMessages } from '../middleware/flash';
 import { RequestHistory } from '../interfaces/request-history';
+import { Locale } from '../enums/locale';
 
 export const cookies = Router();
 
@@ -21,6 +22,15 @@ cookies.use(flashMessages);
 
 const bodyParser = express.urlencoded({ extended: true });
 const docsPath = path.join(__dirname, '..', '..', '..', 'docs', 'static-pages');
+
+// path-based i18n only ever uses en-GB/cy-GB prefixes (see language-switcher.ts) - only ever redirect back
+// into the app under one of those, since the referrer is sourced from stored request history and a crafted
+// //evil.com or /\evil.com history entry must never be redirected to
+const SUPPORTED_LOCALE_PATH_PREFIXES: string[] = [Locale.EnglishGb, Locale.WelshGb];
+
+const isSupportedLocaleUrl = (url: string): boolean => {
+  return SUPPORTED_LOCALE_PATH_PREFIXES.some((locale) => url === `/${locale}` || url.startsWith(`/${locale}/`));
+};
 
 const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
   const defaultPref: CookiePreferences = { acceptAll: false, measuring: false, showBanner: true };
@@ -51,7 +61,9 @@ const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
 
     req.session.flash = [`cookies.settings.saved.heading`];
     req.session.save();
-    res.redirect(acceptAll === 'true' ? referrer : req.buildUrl('/cookies', req.language));
+    res.redirect(
+      acceptAll === 'true' && isSupportedLocaleUrl(referrer) ? referrer : req.buildUrl('/cookies', req.language)
+    );
     return;
   }
 

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -25,12 +25,15 @@ const docsPath = path.join(__dirname, '..', '..', '..', 'docs', 'static-pages');
 
 // path-based i18n only ever uses en-GB/cy-GB prefixes (see language-switcher.ts) - only ever redirect back
 // into the app under one of those, since the referrer is sourced from stored request history and a crafted
-// //evil.com or /\evil.com history entry must never be redirected to
-const SUPPORTED_LOCALE_PATH_PREFIXES: string[] = [Locale.EnglishGb, Locale.WelshGb];
-
-const isSupportedLocaleUrl = (url: string): boolean => {
-  return SUPPORTED_LOCALE_PATH_PREFIXES.some((locale) => url === `/${locale}` || url.startsWith(`/${locale}/`));
-};
+// //evil.com or /\evil.com history entry must never be redirected to.
+// Written as direct startsWith/equality checks on `url` (rather than iterating an array of prefixes) so
+// static analysis can see `url` is checked against a fixed prefix right at the guard, not just inside an
+// array-method callback - CodeQL's untrusted-redirect check couldn't otherwise trace it as a sanitizer.
+const isSupportedLocaleUrl = (url: string): boolean =>
+  url === `/${Locale.EnglishGb}` ||
+  url.startsWith(`/${Locale.EnglishGb}/`) ||
+  url === `/${Locale.WelshGb}` ||
+  url.startsWith(`/${Locale.WelshGb}/`);
 
 const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
   const defaultPref: CookiePreferences = { acceptAll: false, measuring: false, showBanner: true };

--- a/src/shared/routes/cookies.ts
+++ b/src/shared/routes/cookies.ts
@@ -35,7 +35,12 @@ const isSupportedLocaleUrl = (url: string): boolean => {
 const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
   const defaultPref: CookiePreferences = { acceptAll: false, measuring: false, showBanner: true };
   const cookiePreferences = req.cookies['cookiePref'] || defaultPref;
-  const referrer = res.locals.history?.find((h: RequestHistory) => h.url !== req.originalUrl)?.url || req.originalUrl;
+  const rawReferrer =
+    res.locals.history?.find((h: RequestHistory) => h.url !== req.originalUrl)?.url || req.originalUrl;
+  // normalise before use in either the redirect or the rendered page - referrer is sourced from stored
+  // request history, and a crafted //evil.com or /\evil.com history entry must never end up as a redirect
+  // target or as the href of the "saved" banner link on the page itself
+  const referrer = isSupportedLocaleUrl(rawReferrer) ? rawReferrer : req.buildUrl('/cookies', req.language);
   const saved = res.locals.flash || false;
 
   if (req.method === 'POST') {
@@ -61,9 +66,7 @@ const cookiePage = async (req: Request, res: Response, next: NextFunction) => {
 
     req.session.flash = [`cookies.settings.saved.heading`];
     req.session.save();
-    res.redirect(
-      acceptAll === 'true' && isSupportedLocaleUrl(referrer) ? referrer : req.buildUrl('/cookies', req.language)
-    );
+    res.redirect(acceptAll === 'true' ? referrer : req.buildUrl('/cookies', req.language));
     return;
   }
 

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -72,6 +72,15 @@ describe('POST /cookies (accept all)', () => {
     expect(res.status).toBe(302);
     expect(res.header.location).toBe('/en-GB/cookies');
   });
+
+  test('redirects back to a locale-root referrer with a query string', async () => {
+    const app = buildHarness([entry('/en-GB?feature=x')]);
+
+    const res = await request(app).post('/en-GB/cookies').type('form').send({ acceptAll: 'true' });
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe('/en-GB?feature=x');
+  });
 });
 
 describe('GET /cookies', () => {

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -25,6 +25,11 @@ const buildHarness = (seedHistory: RequestHistory[]) => {
     res.locals.history = seedHistory;
     next();
   });
+  // stub out the view engine - we only need to see what locals the route would have rendered with
+  app.use((_req: Request, res: Response, next: NextFunction) => {
+    res.render = ((view: string, locals?: object) => res.json({ view, locals })) as Response['render'];
+    next();
+  });
   app.use('/en-GB/cookies', cookies);
   return app;
 };
@@ -66,5 +71,31 @@ describe('POST /cookies (accept all)', () => {
 
     expect(res.status).toBe(302);
     expect(res.header.location).toBe('/en-GB/cookies');
+  });
+});
+
+describe('GET /cookies', () => {
+  test('passes a normal /en-GB/... referrer through to the rendered page', async () => {
+    const app = buildHarness([entry('/en-GB/some-page')]);
+
+    const res = await request(app).get('/en-GB/cookies');
+
+    expect(res.body.locals.referrer).toBe('/en-GB/some-page');
+  });
+
+  test('does not pass a protocol-relative referrer to the rendered page, falls back to /cookies', async () => {
+    const app = buildHarness([entry('//evil.com/x')]);
+
+    const res = await request(app).get('/en-GB/cookies');
+
+    expect(res.body.locals.referrer).toBe('/en-GB/cookies');
+  });
+
+  test('does not pass a backslash-obfuscated referrer to the rendered page, falls back to /cookies', async () => {
+    const app = buildHarness([entry('/\\evil.com')]);
+
+    const res = await request(app).get('/en-GB/cookies');
+
+    expect(res.body.locals.referrer).toBe('/en-GB/cookies');
   });
 });

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -1,0 +1,70 @@
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+
+import { cookies } from '../src/shared/routes/cookies';
+import sessionMiddleware from '../src/shared/middleware/session';
+import { localeUrl } from '../src/shared/middleware/language-switcher';
+import { Locale } from '../src/shared/enums/locale';
+import { RequestHistory } from '../src/shared/interfaces/request-history';
+
+// mounts only the pieces the cookies router needs, with res.locals.history seeded directly - this
+// simulates a malicious entry having ended up in session history by any means (a live exploit, a bug
+// elsewhere, or a session created before this fix shipped) so we can prove the redirect sink itself is
+// safe regardless of how the history got there
+const buildHarness = (seedHistory: RequestHistory[]) => {
+  const app = express();
+  app.use(cookieParser());
+  app.use(sessionMiddleware);
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    req.language = Locale.EnglishGb;
+    req.buildUrl = localeUrl;
+    next();
+  });
+  app.use((_req: Request, res: Response, next: NextFunction) => {
+    res.locals.history = seedHistory;
+    next();
+  });
+  app.use('/en-GB/cookies', cookies);
+  return app;
+};
+
+const entry = (url: string): RequestHistory => ({ url, timestamp: new Date().toISOString(), method: 'GET' });
+
+describe('POST /cookies (accept all)', () => {
+  test('redirects back to a normal /en-GB/... referrer', async () => {
+    const app = buildHarness([entry('/en-GB/some-page')]);
+
+    const res = await request(app).post('/en-GB/cookies').type('form').send({ acceptAll: 'true' });
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe('/en-GB/some-page');
+  });
+
+  test('does not redirect to a protocol-relative referrer, falls back to /cookies', async () => {
+    const app = buildHarness([entry('//evil.com/x')]);
+
+    const res = await request(app).post('/en-GB/cookies').type('form').send({ acceptAll: 'true' });
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe('/en-GB/cookies');
+  });
+
+  test('does not redirect to a backslash-obfuscated referrer, falls back to /cookies', async () => {
+    const app = buildHarness([entry('/\\evil.com')]);
+
+    const res = await request(app).post('/en-GB/cookies').type('form').send({ acceptAll: 'true' });
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe('/en-GB/cookies');
+  });
+
+  test('falls back to /cookies when there is no history at all', async () => {
+    const app = buildHarness([]);
+
+    const res = await request(app).post('/en-GB/cookies').type('form').send({ acceptAll: 'true' });
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe('/en-GB/cookies');
+  });
+});

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -11,6 +11,11 @@ describe('isRelativeUrl', () => {
     ['/\\\\evil.com', false],
     ['https://evil.com', false],
     ['http://evil.com/x', false],
+    ['/%2F%2Fevil.com', false],
+    ['/%2f%2fevil.com', false],
+    ['/%5Cevil.com', false],
+    ['/%5cevil.com', false],
+    ['/%', false],
     ['/en-GB/some-page', true],
     ['/cy-GB/rhyw-dudalen', true],
     ['/', true]

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import request from 'supertest';
+
+import { history, isRelativeUrl } from '../src/shared/middleware/history';
+import sessionMiddleware from '../src/shared/middleware/session';
+
+describe('isRelativeUrl', () => {
+  test.each([
+    ['//evil.com/x', false],
+    ['/\\evil.com', false],
+    ['/\\\\evil.com', false],
+    ['https://evil.com', false],
+    ['http://evil.com/x', false],
+    ['/en-GB/some-page', true],
+    ['/cy-GB/rhyw-dudalen', true],
+    ['/', true]
+  ])('isRelativeUrl(%s) returns %s', (url, expected) => {
+    expect(isRelativeUrl(url)).toBe(expected);
+  });
+});
+
+describe('history middleware', () => {
+  const buildHarness = () => {
+    const app = express();
+    app.use(sessionMiddleware);
+    app.use(history);
+    app.get('/{*splat}', (req, res) => res.json({ history: req.session.history }));
+    return app;
+  };
+
+  test('does not record a protocol-relative URL in session history', async () => {
+    const agent = request.agent(buildHarness());
+    const res = await agent.get('//evil.com/x');
+    expect(res.body.history).toEqual([]);
+  });
+
+  test('does not record a backslash-obfuscated URL in session history', async () => {
+    const agent = request.agent(buildHarness());
+    const res = await agent.get('/\\evil.com');
+    expect(res.body.history).toEqual([]);
+  });
+
+  test('records a normal relative URL in session history', async () => {
+    const agent = request.agent(buildHarness());
+    const res = await agent.get('/en-GB/some-page');
+    expect(res.body.history).toEqual([expect.objectContaining({ url: '/en-GB/some-page', method: 'GET' })]);
+  });
+});


### PR DESCRIPTION
isRelativeUrl only checked for a leading '/' and no '://', so '//evil.com' and '/\evil.com' passed as "relative" and were stored in history and later redirected to verbatim on the cookies page. Tighten the check to /^\/(?!\/|\\)/ and additionally constrain the cookies redirect sink to only honor referrers under a supported locale prefix (en-GB/cy-GB), falling back to the cookies page otherwise.